### PR TITLE
[student] 학생 정보 검색/추가/수정 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,9 @@ dependencies {
     // Testing
     testImplementation(dependency.Dependencies.SPRING_TEST)
     testImplementation(dependency.Dependencies.KOTLIN_JUNIT5)
-    testImplementation(dependency.Dependencies.KOTEST)
+    testImplementation(dependency.Dependencies.KOTEST_ASSERTIONS)
+    testImplementation(dependency.Dependencies.KOTEST_RUNNER)
+    testImplementation(dependency.Dependencies.KOTEST_FRAMEWORK)
     testImplementation(dependency.Dependencies.SPRING_SECURITY_TEST)
     testRuntimeOnly(dependency.Dependencies.JUNIT_PLATFORM_LAUNCHER)
     testImplementation(dependency.Dependencies.MOCKK)

--- a/buildSrc/src/main/kotlin/dependency/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependency/Dependencies.kt
@@ -41,7 +41,9 @@ object Dependencies {
     /* Testing */
     const val SPRING_TEST = "org.springframework.boot:spring-boot-starter-test"
     const val KOTLIN_JUNIT5 = "org.jetbrains.kotlin:kotlin-test-junit5"
-    const val KOTEST = "io.kotest:kotest-assertions-core:${DependencyVersions.KOTEST_VERSION}"
+    const val KOTEST_ASSERTIONS = "io.kotest:kotest-assertions-core:${DependencyVersions.KOTEST_VERSION}"
+    const val KOTEST_RUNNER = "io.kotest:kotest-runner-junit5:${DependencyVersions.KOTEST_VERSION}"
+    const val KOTEST_FRAMEWORK = "io.kotest:kotest-framework-engine:${DependencyVersions.KOTEST_VERSION}"
     const val SPRING_SECURITY_TEST = "org.springframework.security:spring-security-test"
     const val JUNIT_PLATFORM_LAUNCHER = "org.junit.platform:junit-platform-launcher"
     const val MOCKK = "io.mockk:mockk:${DependencyVersions.MOCKK_VERSION}"

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/controller/StudentController.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/controller/StudentController.kt
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.themoment.datagsm.domain.auth.entity.constant.Role
-import team.themoment.datagsm.domain.student.dto.request.StudentReqDto
+import team.themoment.datagsm.domain.student.dto.request.StudentCreateReqDto
 import team.themoment.datagsm.domain.student.dto.request.StudentUpdateReqDto
 import team.themoment.datagsm.domain.student.dto.response.StudentResDto
 import team.themoment.datagsm.domain.student.entity.constant.Sex
@@ -57,7 +57,7 @@ class StudentController(
 
     @PostMapping
     fun createStudent(
-        @RequestBody @Valid reqDto: StudentReqDto,
+        @RequestBody @Valid reqDto: StudentCreateReqDto,
     ): StudentResDto = createStudentService.createStudent(reqDto)
 
     @PatchMapping("/{studentId}")

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/controller/StudentController.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/controller/StudentController.kt
@@ -1,6 +1,9 @@
 package team.themoment.datagsm.domain.student.controller
 
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -8,16 +11,19 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.themoment.datagsm.domain.auth.entity.constant.Role
 import team.themoment.datagsm.domain.student.dto.request.StudentReqDto
+import team.themoment.datagsm.domain.student.dto.request.StudentUpdateReqDto
 import team.themoment.datagsm.domain.student.dto.response.StudentResDto
 import team.themoment.datagsm.domain.student.entity.constant.Sex
 import team.themoment.datagsm.domain.student.service.CreateStudentService
+import team.themoment.datagsm.domain.student.service.ModifyStudentService
 import team.themoment.datagsm.domain.student.service.QueryStudentService
 
 @RestController
 @RequestMapping("/v1/students")
 class StudentController(
-    private val queryStudentService: QueryStudentService,
-    private val createStudentService: CreateStudentService,
+    private final val queryStudentService: QueryStudentService,
+    private final val createStudentService: CreateStudentService,
+    private final val modifyStudentService: ModifyStudentService,
 ) {
     @GetMapping
     fun getStudentInfo(
@@ -51,6 +57,12 @@ class StudentController(
 
     @PostMapping
     fun createStudent(
-        @RequestBody reqDto: StudentReqDto,
+        @RequestBody @Valid reqDto: StudentReqDto,
     ): StudentResDto = createStudentService.createStudent(reqDto)
+
+    @PatchMapping("/{studentId}")
+    fun updateStudent(
+        @PathVariable studentId: Long,
+        @RequestBody @Valid reqDto: StudentUpdateReqDto,
+    ): StudentResDto = modifyStudentService.execute(studentId, reqDto)
 }

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/controller/StudentController.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/controller/StudentController.kt
@@ -1,18 +1,23 @@
 package team.themoment.datagsm.domain.student.controller
 
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.themoment.datagsm.domain.auth.entity.constant.Role
-import team.themoment.datagsm.domain.student.dto.response.StudentReqDto
+import team.themoment.datagsm.domain.student.dto.request.StudentReqDto
+import team.themoment.datagsm.domain.student.dto.response.StudentResDto
 import team.themoment.datagsm.domain.student.entity.constant.Sex
+import team.themoment.datagsm.domain.student.service.CreateStudentService
 import team.themoment.datagsm.domain.student.service.QueryStudentService
 
 @RestController
 @RequestMapping("/v1/students")
 class StudentController(
     private val queryStudentService: QueryStudentService,
+    private val createStudentService: CreateStudentService,
 ) {
     @GetMapping
     fun getStudentInfo(
@@ -28,7 +33,7 @@ class StudentController(
         @RequestParam(required = false, defaultValue = "false") isLeaveSchool: Boolean,
         @RequestParam(required = false, defaultValue = "0") page: Int,
         @RequestParam(required = false, defaultValue = "300") size: Int,
-    ): StudentReqDto =
+    ): StudentResDto =
         queryStudentService.execute(
             studentId,
             name,
@@ -43,4 +48,9 @@ class StudentController(
             page,
             size,
         )
+
+    @PostMapping
+    fun createStudent(
+        @RequestBody reqDto: StudentReqDto,
+    ): StudentResDto = createStudentService.createStudent(reqDto)
 }

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/dto/internal/StudentDto.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/dto/internal/StudentDto.kt
@@ -12,7 +12,7 @@ data class StudentDto(
     val grade: Int,
     val classNum: Int,
     val number: Int,
-    val studnetNumber: Int,
+    val studentNumber: Int,
     val major: Major,
     val role: Role,
     val dormitoryFloor: Int,

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/dto/request/StudentCreateReqDto.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/dto/request/StudentCreateReqDto.kt
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.Size
 import team.themoment.datagsm.domain.auth.entity.constant.Role
 import team.themoment.datagsm.domain.student.entity.constant.Sex
 
-data class StudentReqDto(
+data class StudentCreateReqDto(
     @param:Size(max = 30)
     @param:NotBlank
     val name: String,

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/dto/request/StudentReqDto.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/dto/request/StudentReqDto.kt
@@ -1,0 +1,37 @@
+package team.themoment.datagsm.domain.student.dto.request
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import team.themoment.datagsm.domain.auth.entity.constant.Role
+import team.themoment.datagsm.domain.student.entity.constant.Sex
+
+data class StudentReqDto(
+    @param:Size(max = 30)
+    @param:NotBlank
+    val name: String,
+    @param:NotBlank
+    val sex: Sex,
+    @param:Size(max = 50)
+    @param:Email
+    @param:NotBlank
+    val email: String,
+    @param:Min(value = 1)
+    @param:Max(value = 3)
+    @param:NotBlank
+    val grade: Int,
+    @param:Min(value = 1)
+    @param:Max(value = 4)
+    @param:NotBlank
+    val classNum: Int,
+    @param:Min(value = 1)
+    @param:Max(value = 18)
+    @param:NotBlank
+    val number: Int,
+    val role: Role = Role.GENERAL_STUDENT,
+    @param:Min(value = 201)
+    @param:Max(value = 518)
+    val dormitoryRoomNumber: Int,
+)

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/dto/request/StudentUpdateReqDto.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/dto/request/StudentUpdateReqDto.kt
@@ -1,0 +1,30 @@
+package team.themoment.datagsm.domain.student.dto.request
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Size
+import team.themoment.datagsm.domain.auth.entity.constant.Role
+import team.themoment.datagsm.domain.student.entity.constant.Sex
+
+data class StudentUpdateReqDto(
+    @param:Size(max = 30)
+    val name: String?,
+    val sex: Sex?,
+    @param:Size(max = 50)
+    @param:Email
+    val email: String?,
+    @param:Min(value = 1)
+    @param:Max(value = 3)
+    val grade: Int?,
+    @param:Min(value = 1)
+    @param:Max(value = 4)
+    val classNum: Int?,
+    @param:Min(value = 1)
+    @param:Max(value = 18)
+    val number: Int?,
+    val role: Role?,
+    @param:Min(value = 201)
+    @param:Max(value = 518)
+    val dormitoryRoomNumber: Int?,
+)

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/dto/response/StudentResDto.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/dto/response/StudentResDto.kt
@@ -2,7 +2,7 @@ package team.themoment.datagsm.domain.student.dto.response
 
 import team.themoment.datagsm.domain.student.dto.internal.StudentDto
 
-data class StudentReqDto(
+data class StudentResDto(
     val totalPages: Int,
     val totalElements: Long,
     val students: List<StudentDto>,

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/entity/constant/Major.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/entity/constant/Major.kt
@@ -4,4 +4,15 @@ enum class Major {
     SW_DEVELOPMENT,
     SMART_IOT,
     AI,
+    ;
+
+    companion object {
+        fun fromGrade(grade: Int): Major? =
+            when (grade) {
+                1, 2 -> SW_DEVELOPMENT
+                3 -> SMART_IOT
+                4 -> AI
+                else -> null
+            }
+    }
 }

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/repository/custom/StudentJpaCustomRepository.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/repository/custom/StudentJpaCustomRepository.kt
@@ -20,4 +20,24 @@ interface StudentJpaCustomRepository {
         isLeaveSchool: Boolean,
         pageable: Pageable,
     ): Page<StudentJpaEntity>
+
+    fun existsByStudentEmail(email: String): Boolean
+
+    fun existsByStudentNumber(
+        grade: Int,
+        classNum: Int,
+        number: Int,
+    ): Boolean
+
+    fun existsByStudentEmailAndNotStudentId(
+        email: String,
+        studentId: Long,
+    ): Boolean
+
+    fun existsByStudentNumberAndNotStudentId(
+        grade: Int,
+        classNum: Int,
+        number: Int,
+        studentId: Long,
+    ): Boolean
 }

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
@@ -65,4 +65,56 @@ class StudentJpaCustomRepositoryImpl(
 
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
     }
+
+    override fun existsByStudentEmail(email: String): Boolean =
+        jpaQueryFactory
+            .selectOne()
+            .from(studentJpaEntity)
+            .where(studentJpaEntity.studentEmail.eq(email))
+            .fetchFirst() != null
+
+    override fun existsByStudentNumber(
+        grade: Int,
+        classNum: Int,
+        number: Int,
+    ): Boolean =
+        jpaQueryFactory
+            .selectOne()
+            .from(studentJpaEntity)
+            .where(
+                studentJpaEntity.studentNumber.studentGrade
+                    .eq(grade)
+                    .and(studentJpaEntity.studentNumber.studentClass.eq(classNum))
+                    .and(studentJpaEntity.studentNumber.studentNumber.eq(number)),
+            ).fetchFirst() != null
+
+    override fun existsByStudentEmailAndNotStudentId(
+        email: String,
+        studentId: Long,
+    ): Boolean =
+        jpaQueryFactory
+            .selectOne()
+            .from(studentJpaEntity)
+            .where(
+                studentJpaEntity.studentEmail
+                    .eq(email)
+                    .and(studentJpaEntity.studentId.ne(studentId)),
+            ).fetchFirst() != null
+
+    override fun existsByStudentNumberAndNotStudentId(
+        grade: Int,
+        classNum: Int,
+        number: Int,
+        studentId: Long,
+    ): Boolean =
+        jpaQueryFactory
+            .selectOne()
+            .from(studentJpaEntity)
+            .where(
+                studentJpaEntity.studentNumber.studentGrade
+                    .eq(grade)
+                    .and(studentJpaEntity.studentNumber.studentClass.eq(classNum))
+                    .and(studentJpaEntity.studentNumber.studentNumber.eq(number))
+                    .and(studentJpaEntity.studentId.ne(studentId)),
+            ).fetchFirst() != null
 }

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/CreateStudentService.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/CreateStudentService.kt
@@ -1,8 +1,8 @@
 package team.themoment.datagsm.domain.student.service
 
-import team.themoment.datagsm.domain.student.dto.request.StudentReqDto
+import team.themoment.datagsm.domain.student.dto.request.StudentCreateReqDto
 import team.themoment.datagsm.domain.student.dto.response.StudentResDto
 
 interface CreateStudentService {
-    fun createStudent(reqDto: StudentReqDto): StudentResDto
+    fun createStudent(reqDto: StudentCreateReqDto): StudentResDto
 }

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/CreateStudentService.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/CreateStudentService.kt
@@ -1,0 +1,8 @@
+package team.themoment.datagsm.domain.student.service
+
+import team.themoment.datagsm.domain.student.dto.request.StudentReqDto
+import team.themoment.datagsm.domain.student.dto.response.StudentResDto
+
+interface CreateStudentService {
+    fun createStudent(reqDto: StudentReqDto): StudentResDto
+}

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/ModifyStudentService.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/ModifyStudentService.kt
@@ -1,0 +1,11 @@
+package team.themoment.datagsm.domain.student.service
+
+import team.themoment.datagsm.domain.student.dto.request.StudentUpdateReqDto
+import team.themoment.datagsm.domain.student.dto.response.StudentResDto
+
+interface ModifyStudentService {
+    fun execute(
+        studentId: Long,
+        reqDto: StudentUpdateReqDto,
+    ): StudentResDto
+}

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/QueryStudentService.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/QueryStudentService.kt
@@ -1,7 +1,7 @@
 package team.themoment.datagsm.domain.student.service
 
 import team.themoment.datagsm.domain.auth.entity.constant.Role
-import team.themoment.datagsm.domain.student.dto.response.StudentReqDto
+import team.themoment.datagsm.domain.student.dto.response.StudentResDto
 import team.themoment.datagsm.domain.student.entity.constant.Sex
 
 interface QueryStudentService {
@@ -18,5 +18,5 @@ interface QueryStudentService {
         isLeaveSchool: Boolean,
         page: Int,
         size: Int,
-    ): StudentReqDto
+    ): StudentResDto
 }

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/CreateStudentServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/CreateStudentServiceImpl.kt
@@ -3,7 +3,7 @@ package team.themoment.datagsm.domain.student.service.impl
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.domain.student.dto.internal.StudentDto
-import team.themoment.datagsm.domain.student.dto.request.StudentReqDto
+import team.themoment.datagsm.domain.student.dto.request.StudentCreateReqDto
 import team.themoment.datagsm.domain.student.dto.response.StudentResDto
 import team.themoment.datagsm.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.domain.student.entity.constant.DormitoryRoomNumber
@@ -17,7 +17,7 @@ import team.themoment.datagsm.domain.student.service.CreateStudentService
 class CreateStudentServiceImpl(
     private final val studentJpaRepository: StudentJpaRepository,
 ) : CreateStudentService {
-    override fun createStudent(reqDto: StudentReqDto): StudentResDto {
+    override fun createStudent(reqDto: StudentCreateReqDto): StudentResDto {
         if (studentJpaRepository.existsByStudentEmail(reqDto.email)) {
             throw IllegalArgumentException("이미 존재하는 이메일입니다: ${reqDto.email}")
         }

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/CreateStudentServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/CreateStudentServiceImpl.kt
@@ -32,8 +32,8 @@ class CreateStudentServiceImpl(
                 studentSex = reqDto.sex
                 studentEmail = reqDto.email
                 studentNumber = StudentNumber(reqDto.grade, reqDto.classNum, reqDto.number)
-                studentMajor = Major.fromGrade(reqDto.grade)
-                    ?: throw IllegalArgumentException("유효하지 않은 학년입니다: ${reqDto.grade}")
+                studentMajor = Major.fromGrade(reqDto.classNum)
+                    ?: throw IllegalArgumentException("유효하지 않은 학급입니다: ${reqDto.classNum}")
                 studentRole = reqDto.role
                 studentDormitoryRoomNumber = DormitoryRoomNumber(reqDto.dormitoryRoomNumber)
             }

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/CreateStudentServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/CreateStudentServiceImpl.kt
@@ -1,0 +1,55 @@
+package team.themoment.datagsm.domain.student.service.impl
+
+import org.springframework.stereotype.Service
+import team.themoment.datagsm.domain.student.dto.internal.StudentDto
+import team.themoment.datagsm.domain.student.dto.request.StudentReqDto
+import team.themoment.datagsm.domain.student.dto.response.StudentResDto
+import team.themoment.datagsm.domain.student.entity.StudentJpaEntity
+import team.themoment.datagsm.domain.student.entity.constant.DormitoryRoomNumber
+import team.themoment.datagsm.domain.student.entity.constant.Major
+import team.themoment.datagsm.domain.student.entity.constant.StudentNumber
+import team.themoment.datagsm.domain.student.repository.StudentJpaRepository
+import team.themoment.datagsm.domain.student.service.CreateStudentService
+
+@Service
+class CreateStudentServiceImpl(
+    val studentJpaRepository: StudentJpaRepository,
+) : CreateStudentService {
+    override fun createStudent(reqDto: StudentReqDto): StudentResDto {
+        val studentEntity =
+            StudentJpaEntity().apply {
+                studentName = reqDto.name
+                studentSex = reqDto.sex
+                studentEmail = reqDto.email
+                studentNumber = StudentNumber(reqDto.grade, reqDto.classNum, reqDto.number)
+                studentMajor = Major.fromGrade(reqDto.grade)!!
+                studentRole = reqDto.role
+                studentDormitoryRoomNumber = DormitoryRoomNumber(reqDto.dormitoryRoomNumber)
+            }
+
+        val savedStudent = studentJpaRepository.save(studentEntity)
+
+        val studentDto =
+            StudentDto(
+                studentId = savedStudent.studentId!!,
+                name = savedStudent.studentName,
+                sex = savedStudent.studentSex,
+                email = savedStudent.studentEmail,
+                grade = savedStudent.studentNumber.studentGrade,
+                classNum = savedStudent.studentNumber.studentClass,
+                number = savedStudent.studentNumber.studentNumber,
+                studentNumber = savedStudent.studentNumber.fullStudentNumber,
+                major = savedStudent.studentMajor,
+                role = savedStudent.studentRole,
+                dormitoryFloor = savedStudent.studentDormitoryRoomNumber.dormitoryRoomFloor,
+                dormitoryRoom = savedStudent.studentDormitoryRoomNumber.dormitoryRoomNumber,
+                isLeaveSchool = savedStudent.studentIsLeaveSchool,
+            )
+
+        return StudentResDto(
+            totalPages = 1,
+            totalElements = 1L,
+            students = listOf(studentDto),
+        )
+    }
+}

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/ModifyStudentServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/ModifyStudentServiceImpl.kt
@@ -1,0 +1,88 @@
+package team.themoment.datagsm.domain.student.service.impl
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.domain.student.dto.internal.StudentDto
+import team.themoment.datagsm.domain.student.dto.request.StudentUpdateReqDto
+import team.themoment.datagsm.domain.student.dto.response.StudentResDto
+import team.themoment.datagsm.domain.student.entity.constant.DormitoryRoomNumber
+import team.themoment.datagsm.domain.student.entity.constant.Major
+import team.themoment.datagsm.domain.student.entity.constant.StudentNumber
+import team.themoment.datagsm.domain.student.repository.StudentJpaRepository
+import team.themoment.datagsm.domain.student.service.ModifyStudentService
+
+@Service
+@Transactional
+class ModifyStudentServiceImpl(
+    private final val studentJpaRepository: StudentJpaRepository,
+) : ModifyStudentService {
+    override fun execute(
+        studentId: Long,
+        reqDto: StudentUpdateReqDto,
+    ): StudentResDto {
+        val student =
+            studentJpaRepository
+                .findById(studentId)
+                .orElseThrow { IllegalArgumentException("학생을 찾을 수 없습니다. studentId: $studentId") }
+        reqDto.email?.let { email ->
+            if (studentJpaRepository.existsByStudentEmailAndNotStudentId(email, studentId)) {
+                throw IllegalArgumentException("이미 존재하는 이메일입니다: $email")
+            }
+            student.studentEmail = email
+        }
+        if (reqDto.grade != null || reqDto.classNum != null || reqDto.number != null) {
+            val newGrade = reqDto.grade ?: student.studentNumber.studentGrade
+            val newClassNum = reqDto.classNum ?: student.studentNumber.studentClass
+            val newNumber = reqDto.number ?: student.studentNumber.studentNumber
+
+            if (studentJpaRepository.existsByStudentNumberAndNotStudentId(
+                    newGrade,
+                    newClassNum,
+                    newNumber,
+                    studentId,
+                )
+            ) {
+                throw IllegalArgumentException("이미 존재하는 학번입니다: ${newGrade}학년 ${newClassNum}반 ${newNumber}번")
+            }
+
+            student.studentNumber = StudentNumber(newGrade, newClassNum, newNumber)
+
+            if (reqDto.grade != null) {
+                student.studentMajor = Major.fromGrade(newGrade)
+                    ?: throw IllegalArgumentException("유효하지 않은 학년입니다: $newGrade")
+            }
+        }
+
+        reqDto.name?.let { student.studentName = it }
+        reqDto.sex?.let { student.studentSex = it }
+        reqDto.role?.let { student.studentRole = it }
+        reqDto.dormitoryRoomNumber?.let {
+            student.studentDormitoryRoomNumber = DormitoryRoomNumber(it)
+        }
+
+        val savedStudent = studentJpaRepository.save(student)
+
+        val studentDto =
+            StudentDto(
+                studentId = savedStudent.studentId!!,
+                name = savedStudent.studentName,
+                sex = savedStudent.studentSex,
+                email = savedStudent.studentEmail,
+                grade = savedStudent.studentNumber.studentGrade,
+                classNum = savedStudent.studentNumber.studentClass,
+                number = savedStudent.studentNumber.studentNumber,
+                studentNumber = savedStudent.studentNumber.fullStudentNumber,
+                major = savedStudent.studentMajor,
+                role = savedStudent.studentRole,
+                dormitoryFloor = savedStudent.studentDormitoryRoomNumber.dormitoryRoomFloor,
+                dormitoryRoom = savedStudent.studentDormitoryRoomNumber.dormitoryRoomNumber,
+                isLeaveSchool = savedStudent.studentIsLeaveSchool,
+            )
+
+        return StudentResDto(
+            totalPages = 1,
+            totalElements = 1L,
+            students = listOf(studentDto),
+        )
+    }
+}

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/ModifyStudentServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/ModifyStudentServiceImpl.kt
@@ -47,9 +47,9 @@ class ModifyStudentServiceImpl(
 
             student.studentNumber = StudentNumber(newGrade, newClassNum, newNumber)
 
-            if (reqDto.grade != null) {
-                student.studentMajor = Major.fromGrade(newGrade)
-                    ?: throw IllegalArgumentException("유효하지 않은 학년입니다: $newGrade")
+            if (reqDto.classNum != null) {
+                student.studentMajor = Major.fromGrade(newClassNum)
+                    ?: throw IllegalArgumentException("유효하지 않은 학급입니다: $newClassNum")
             }
         }
 

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/QueryStudentServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/QueryStudentServiceImpl.kt
@@ -55,7 +55,7 @@ class QueryStudentServiceImpl(
                         grade = entity.studentNumber.studentGrade,
                         classNum = entity.studentNumber.studentClass,
                         number = entity.studentNumber.studentNumber,
-                        studnetNumber = entity.studentNumber.fullStudentNumber,
+                        studentNumber = entity.studentNumber.fullStudentNumber,
                         major = entity.studentMajor,
                         role = entity.studentRole,
                         dormitoryFloor = entity.studentDormitoryRoomNumber.dormitoryRoomFloor,

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/QueryStudentServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/QueryStudentServiceImpl.kt
@@ -11,7 +11,7 @@ import team.themoment.datagsm.domain.student.service.QueryStudentService
 
 @Service
 class QueryStudentServiceImpl(
-    val studentJpaRepository: StudentJpaRepository,
+    private final val studentJpaRepository: StudentJpaRepository,
 ) : QueryStudentService {
     override fun execute(
         studentId: Long?,

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/QueryStudentServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/QueryStudentServiceImpl.kt
@@ -4,7 +4,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import team.themoment.datagsm.domain.auth.entity.constant.Role
 import team.themoment.datagsm.domain.student.dto.internal.StudentDto
-import team.themoment.datagsm.domain.student.dto.response.StudentReqDto
+import team.themoment.datagsm.domain.student.dto.response.StudentResDto
 import team.themoment.datagsm.domain.student.entity.constant.Sex
 import team.themoment.datagsm.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.domain.student.service.QueryStudentService
@@ -26,7 +26,7 @@ class QueryStudentServiceImpl(
         isLeaveSchool: Boolean,
         page: Int,
         size: Int,
-    ): StudentReqDto {
+    ): StudentResDto {
         val studentPage =
             studentJpaRepository.searchStudentsWithPaging(
                 studentId = studentId,
@@ -42,7 +42,7 @@ class QueryStudentServiceImpl(
                 pageable = PageRequest.of(page, size),
             )
 
-        return StudentReqDto(
+        return StudentResDto(
             totalElements = studentPage.totalElements,
             totalPages = studentPage.totalPages,
             students =

--- a/src/test/kotlin/team/themoment/datagsm/domain/student/service/CreateStudentServiceTest.kt
+++ b/src/test/kotlin/team/themoment/datagsm/domain/student/service/CreateStudentServiceTest.kt
@@ -1,0 +1,390 @@
+package team.themoment.datagsm.domain.student.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import team.themoment.datagsm.domain.auth.entity.constant.Role
+import team.themoment.datagsm.domain.student.dto.request.StudentCreateReqDto
+import team.themoment.datagsm.domain.student.entity.StudentJpaEntity
+import team.themoment.datagsm.domain.student.entity.constant.DormitoryRoomNumber
+import team.themoment.datagsm.domain.student.entity.constant.Major
+import team.themoment.datagsm.domain.student.entity.constant.Sex
+import team.themoment.datagsm.domain.student.entity.constant.StudentNumber
+import team.themoment.datagsm.domain.student.repository.StudentJpaRepository
+import team.themoment.datagsm.domain.student.service.impl.CreateStudentServiceImpl
+
+class CreateStudentServiceTest : DescribeSpec({
+
+    val mockStudentRepository = mockk<StudentJpaRepository>()
+
+    val createStudentService = CreateStudentServiceImpl(mockStudentRepository)
+
+    afterEach {
+        clearAllMocks()
+    }
+
+    describe("CreateStudentService 클래스의") {
+        describe("createStudent 메서드는") {
+
+            context("유효한 1반 학생 정보로 생성 요청할 때") {
+                val createRequest = StudentCreateReqDto(
+                    name = "김학생",
+                    sex = Sex.WOMAN,
+                    email = "kim@gsm.hs.kr",
+                    grade = 2,
+                    classNum = 1,
+                    number = 15,
+                    role = Role.GENERAL_STUDENT,
+                    dormitoryRoomNumber = 205
+                )
+
+                val savedStudent = StudentJpaEntity().apply {
+                    studentId = 1L
+                    studentName = createRequest.name
+                    studentSex = createRequest.sex
+                    studentEmail = createRequest.email
+                    studentNumber = StudentNumber(createRequest.grade, createRequest.classNum, createRequest.number)
+                    studentMajor = Major.SW_DEVELOPMENT
+                    studentRole = createRequest.role
+                    studentDormitoryRoomNumber = DormitoryRoomNumber(createRequest.dormitoryRoomNumber)
+                    studentIsLeaveSchool = false
+                }
+
+                beforeEach {
+                    every { mockStudentRepository.existsByStudentEmail(createRequest.email) } returns false
+                    every {
+                        mockStudentRepository.existsByStudentNumber(
+                            createRequest.grade,
+                            createRequest.classNum,
+                            createRequest.number
+                        )
+                    } returns false
+                    every { mockStudentRepository.save(any()) } returns savedStudent
+                }
+
+                it("새로운 학생을 생성하고 저장 후 결과를 반환한다") {
+                    val result = createStudentService.createStudent(createRequest)
+
+                    result.totalElements shouldBe 1L
+                    result.totalPages shouldBe 1
+                    result.students.size shouldBe 1
+
+                    val student = result.students[0]
+                    student.name shouldBe "김학생"
+                    student.sex shouldBe Sex.WOMAN
+                    student.email shouldBe "kim@gsm.hs.kr"
+                    student.grade shouldBe 2
+                    student.classNum shouldBe 1
+                    student.number shouldBe 15
+                    student.studentNumber shouldBe 2115
+                    student.major shouldBe Major.SW_DEVELOPMENT
+                    student.role shouldBe Role.GENERAL_STUDENT
+                    student.dormitoryFloor shouldBe 2
+                    student.dormitoryRoom shouldBe 205
+                    student.isLeaveSchool shouldBe false
+
+                    verify(exactly = 1) { mockStudentRepository.existsByStudentEmail(createRequest.email) }
+                    verify(exactly = 1) {
+                        mockStudentRepository.existsByStudentNumber(
+                            createRequest.grade,
+                            createRequest.classNum,
+                            createRequest.number
+                        )
+                    }
+                    verify(exactly = 1) { mockStudentRepository.save(any()) }
+                }
+            }
+
+            context("유효한 3반 학생 정보로 생성 요청할 때") {
+                val createRequest = StudentCreateReqDto(
+                    name = "이학생",
+                    sex = Sex.MAN,
+                    email = "lee@gsm.hs.kr",
+                    grade = 1,
+                    classNum = 3,
+                    number = 5,
+                    role = Role.GENERAL_STUDENT,
+                    dormitoryRoomNumber = 301
+                )
+
+                val savedStudent = StudentJpaEntity().apply {
+                    studentId = 2L
+                    studentName = createRequest.name
+                    studentSex = createRequest.sex
+                    studentEmail = createRequest.email
+                    studentNumber = StudentNumber(createRequest.grade, createRequest.classNum, createRequest.number)
+                    studentMajor = Major.SMART_IOT
+                    studentRole = createRequest.role
+                    studentDormitoryRoomNumber = DormitoryRoomNumber(createRequest.dormitoryRoomNumber)
+                    studentIsLeaveSchool = false
+                }
+
+                beforeEach {
+                    every { mockStudentRepository.existsByStudentEmail(createRequest.email) } returns false
+                    every {
+                        mockStudentRepository.existsByStudentNumber(
+                            createRequest.grade,
+                            createRequest.classNum,
+                            createRequest.number
+                        )
+                    } returns false
+                    every { mockStudentRepository.save(any()) } returns savedStudent
+                }
+
+                it("3반 학생이 SMART_IOT 전공으로 생성되어야 한다") {
+                    val result = createStudentService.createStudent(createRequest)
+
+                    val student = result.students[0]
+                    student.major shouldBe Major.SMART_IOT
+                    student.classNum shouldBe 3
+                    student.studentNumber shouldBe 1305
+                    student.dormitoryFloor shouldBe 3
+                }
+            }
+
+            context("이미 존재하는 이메일로 생성 요청할 때") {
+                val createRequest = StudentCreateReqDto(
+                    name = "중복학생",
+                    sex = Sex.WOMAN,
+                    email = "duplicate@gsm.hs.kr",
+                    grade = 1,
+                    classNum = 1,
+                    number = 1,
+                    role = Role.GENERAL_STUDENT,
+                    dormitoryRoomNumber = 201
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.existsByStudentEmail(createRequest.email) } returns true
+                }
+
+                it("IllegalArgumentException이 발생해야 한다") {
+                    val exception = shouldThrow<IllegalArgumentException> {
+                        createStudentService.createStudent(createRequest)
+                    }
+
+                    exception.message shouldBe "이미 존재하는 이메일입니다: ${createRequest.email}"
+
+                    verify(exactly = 1) { mockStudentRepository.existsByStudentEmail(createRequest.email) }
+                    verify(exactly = 0) { mockStudentRepository.save(any()) }
+                }
+            }
+
+            context("이미 존재하는 학번으로 생성 요청할 때") {
+                val createRequest = StudentCreateReqDto(
+                    name = "학번중복",
+                    sex = Sex.MAN,
+                    email = "unique@gsm.hs.kr",
+                    grade = 2,
+                    classNum = 2,
+                    number = 10,
+                    role = Role.GENERAL_STUDENT,
+                    dormitoryRoomNumber = 410
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.existsByStudentEmail(createRequest.email) } returns false
+                    every {
+                        mockStudentRepository.existsByStudentNumber(
+                            createRequest.grade,
+                            createRequest.classNum,
+                            createRequest.number
+                        )
+                    } returns true
+                }
+
+                it("IllegalArgumentException이 발생해야 한다") {
+                    val exception = shouldThrow<IllegalArgumentException> {
+                        createStudentService.createStudent(createRequest)
+                    }
+
+                    exception.message shouldBe "이미 존재하는 학번입니다: ${createRequest.grade}학년 ${createRequest.classNum}반 ${createRequest.number}번"
+
+                    verify(exactly = 1) { mockStudentRepository.existsByStudentEmail(createRequest.email) }
+                    verify(exactly = 1) {
+                        mockStudentRepository.existsByStudentNumber(
+                            createRequest.grade,
+                            createRequest.classNum,
+                            createRequest.number
+                        )
+                    }
+                    verify(exactly = 0) { mockStudentRepository.save(any()) }
+                }
+            }
+
+            context("유효하지 않은 학급으로 생성 요청할 때") {
+                val createRequest = StudentCreateReqDto(
+                    name = "무효학급",
+                    sex = Sex.WOMAN,
+                    email = "invalid@gsm.hs.kr",
+                    grade = 1,
+                    classNum = 5,
+                    number = 1,
+                    role = Role.GENERAL_STUDENT,
+                    dormitoryRoomNumber = 201
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.existsByStudentEmail(createRequest.email) } returns false
+                    every {
+                        mockStudentRepository.existsByStudentNumber(
+                            createRequest.grade,
+                            createRequest.classNum,
+                            createRequest.number
+                        )
+                    } returns false
+                }
+
+                it("IllegalArgumentException이 발생해야 한다") {
+                    val exception = shouldThrow<IllegalArgumentException> {
+                        createStudentService.createStudent(createRequest)
+                    }
+
+                    exception.message shouldBe "유효하지 않은 학급입니다: ${createRequest.classNum}"
+                }
+            }
+
+            context("1반 학생 생성 시 SW_DEVELOPMENT 전공이 할당될 때") {
+                val createRequest = StudentCreateReqDto(
+                    name = "1반학생",
+                    sex = Sex.WOMAN,
+                    email = "class1@gsm.hs.kr",
+                    grade = 3,
+                    classNum = 1,
+                    number = 1,
+                    role = Role.GENERAL_STUDENT,
+                    dormitoryRoomNumber = 211
+                )
+
+                val savedStudent = StudentJpaEntity().apply {
+                    studentId = 1L
+                    studentName = createRequest.name
+                    studentSex = createRequest.sex
+                    studentEmail = createRequest.email
+                    studentNumber = StudentNumber(createRequest.grade, createRequest.classNum, createRequest.number)
+                    studentMajor = Major.SW_DEVELOPMENT
+                    studentRole = createRequest.role
+                    studentDormitoryRoomNumber = DormitoryRoomNumber(createRequest.dormitoryRoomNumber)
+                    studentIsLeaveSchool = false
+                }
+
+                beforeEach {
+                    every { mockStudentRepository.existsByStudentEmail(createRequest.email) } returns false
+                    every {
+                        mockStudentRepository.existsByStudentNumber(
+                            createRequest.grade,
+                            createRequest.classNum,
+                            createRequest.number
+                        )
+                    } returns false
+                    every { mockStudentRepository.save(any()) } returns savedStudent
+                }
+
+                it("1반 학생이 SW_DEVELOPMENT 전공으로 생성되어야 한다") {
+                    val result = createStudentService.createStudent(createRequest)
+
+                    val student = result.students[0]
+                    student.major shouldBe Major.SW_DEVELOPMENT
+                    student.classNum shouldBe 1
+                    student.name shouldBe "1반학생"
+                }
+            }
+
+            context("2반 학생 생성 시 SW_DEVELOPMENT 전공이 할당될 때") {
+                val createRequest = StudentCreateReqDto(
+                    name = "2반학생",
+                    sex = Sex.MAN,
+                    email = "class2@gsm.hs.kr",
+                    grade = 2,
+                    classNum = 2,
+                    number = 2,
+                    role = Role.GENERAL_STUDENT,
+                    dormitoryRoomNumber = 222
+                )
+
+                val savedStudent = StudentJpaEntity().apply {
+                    studentId = 2L
+                    studentName = createRequest.name
+                    studentSex = createRequest.sex
+                    studentEmail = createRequest.email
+                    studentNumber = StudentNumber(createRequest.grade, createRequest.classNum, createRequest.number)
+                    studentMajor = Major.SW_DEVELOPMENT
+                    studentRole = createRequest.role
+                    studentDormitoryRoomNumber = DormitoryRoomNumber(createRequest.dormitoryRoomNumber)
+                    studentIsLeaveSchool = false
+                }
+
+                beforeEach {
+                    every { mockStudentRepository.existsByStudentEmail(createRequest.email) } returns false
+                    every {
+                        mockStudentRepository.existsByStudentNumber(
+                            createRequest.grade,
+                            createRequest.classNum,
+                            createRequest.number
+                        )
+                    } returns false
+                    every { mockStudentRepository.save(any()) } returns savedStudent
+                }
+
+                it("2반 학생이 SW_DEVELOPMENT 전공으로 생성되어야 한다") {
+                    val result = createStudentService.createStudent(createRequest)
+
+                    val student = result.students[0]
+                    student.major shouldBe Major.SW_DEVELOPMENT
+                    student.classNum shouldBe 2
+                    student.name shouldBe "2반학생"
+                }
+            }
+
+            context("4반 학생 생성 시 AI 전공이 할당될 때") {
+                val createRequest = StudentCreateReqDto(
+                    name = "4반학생",
+                    sex = Sex.MAN,
+                    email = "class4@gsm.hs.kr",
+                    grade = 1,
+                    classNum = 4,
+                    number = 4,
+                    role = Role.GENERAL_STUDENT,
+                    dormitoryRoomNumber = 241
+                )
+
+                val savedStudent = StudentJpaEntity().apply {
+                    studentId = 4L
+                    studentName = createRequest.name
+                    studentSex = createRequest.sex
+                    studentEmail = createRequest.email
+                    studentNumber = StudentNumber(createRequest.grade, createRequest.classNum, createRequest.number)
+                    studentMajor = Major.AI
+                    studentRole = createRequest.role
+                    studentDormitoryRoomNumber = DormitoryRoomNumber(createRequest.dormitoryRoomNumber)
+                    studentIsLeaveSchool = false
+                }
+
+                beforeEach {
+                    every { mockStudentRepository.existsByStudentEmail(createRequest.email) } returns false
+                    every {
+                        mockStudentRepository.existsByStudentNumber(
+                            createRequest.grade,
+                            createRequest.classNum,
+                            createRequest.number
+                        )
+                    } returns false
+                    every { mockStudentRepository.save(any()) } returns savedStudent
+                }
+
+                it("4반 학생이 AI 전공으로 생성되어야 한다") {
+                    val result = createStudentService.createStudent(createRequest)
+
+                    val student = result.students[0]
+                    student.major shouldBe Major.AI
+                    student.classNum shouldBe 4
+                    student.name shouldBe "4반학생"
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/team/themoment/datagsm/domain/student/service/ModifyStudentServiceTest.kt
+++ b/src/test/kotlin/team/themoment/datagsm/domain/student/service/ModifyStudentServiceTest.kt
@@ -1,0 +1,489 @@
+package team.themoment.datagsm.domain.student.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import team.themoment.datagsm.domain.auth.entity.constant.Role
+import team.themoment.datagsm.domain.student.dto.request.StudentUpdateReqDto
+import team.themoment.datagsm.domain.student.entity.StudentJpaEntity
+import team.themoment.datagsm.domain.student.entity.constant.DormitoryRoomNumber
+import team.themoment.datagsm.domain.student.entity.constant.Major
+import team.themoment.datagsm.domain.student.entity.constant.Sex
+import team.themoment.datagsm.domain.student.entity.constant.StudentNumber
+import team.themoment.datagsm.domain.student.repository.StudentJpaRepository
+import team.themoment.datagsm.domain.student.service.impl.ModifyStudentServiceImpl
+import java.util.*
+
+class ModifyStudentServiceTest : DescribeSpec({
+
+    val mockStudentRepository = mockk<StudentJpaRepository>()
+
+    val modifyStudentService = ModifyStudentServiceImpl(mockStudentRepository)
+
+    afterEach {
+        clearAllMocks()
+    }
+
+    describe("ModifyStudentService 클래스의") {
+        describe("execute 메서드는") {
+
+            val studentId = 1L
+            val existingStudent = StudentJpaEntity().apply {
+                this.studentId = studentId
+                studentName = "기존학생"
+                studentSex = Sex.MAN
+                studentEmail = "existing@gsm.hs.kr"
+                studentNumber = StudentNumber(2, 1, 5)
+                studentMajor = Major.SW_DEVELOPMENT
+                studentRole = Role.GENERAL_STUDENT
+                studentDormitoryRoomNumber = DormitoryRoomNumber(201)
+                studentIsLeaveSchool = false
+            }
+
+            context("존재하는 학생의 이름을 수정할 때") {
+                val updateRequest = StudentUpdateReqDto(
+                    name = "수정된이름",
+                    sex = null,
+                    email = null,
+                    grade = null,
+                    classNum = null,
+                    number = null,
+                    role = null,
+                    dormitoryRoomNumber = null
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.findById(studentId) } returns Optional.of(existingStudent)
+                    every { mockStudentRepository.save(any()) } returns existingStudent.apply {
+                        studentName = updateRequest.name!!
+                    }
+                }
+
+                it("학생 이름이 성공적으로 업데이트되어야 한다") {
+                    val result = modifyStudentService.execute(studentId, updateRequest)
+
+                    result.students.size shouldBe 1
+                    result.students[0].studentId shouldBe studentId
+                    result.students[0].name shouldBe "수정된이름"
+
+                    verify(exactly = 1) { mockStudentRepository.findById(studentId) }
+                    verify(exactly = 1) { mockStudentRepository.save(any()) }
+                }
+            }
+
+            context("학생의 학년만 변경할 때 (반은 변경하지 않음)") {
+                val updateRequest = StudentUpdateReqDto(
+                    name = null,
+                    sex = null,
+                    email = null,
+                    grade = 3,
+                    classNum = null,
+                    number = null,
+                    role = null,
+                    dormitoryRoomNumber = null
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.findById(studentId) } returns Optional.of(existingStudent)
+                    every {
+                        mockStudentRepository.existsByStudentNumberAndNotStudentId(
+                            3,
+                            1,
+                            5,
+                            studentId
+                        )
+                    } returns false
+                    every { mockStudentRepository.save(any()) } returns existingStudent.apply {
+                        studentNumber = StudentNumber(3, 1, 5)
+                    }
+                }
+
+                it("학년만 변경하고 반이 변경되지 않으면 전공은 유지되어야 한다") {
+                    val result = modifyStudentService.execute(studentId, updateRequest)
+
+                    val student = result.students[0]
+                    student.grade shouldBe 3
+                    student.classNum shouldBe 1
+                    student.major shouldBe Major.SW_DEVELOPMENT
+                    student.studentNumber shouldBe 3105
+
+                    verify(exactly = 1) {
+                        mockStudentRepository.existsByStudentNumberAndNotStudentId(
+                            3,
+                            1,
+                            5,
+                            studentId
+                        )
+                    }
+                }
+            }
+
+            context("학생의 반만 변경할 때") {
+                val updateRequest = StudentUpdateReqDto(
+                    name = null,
+                    sex = null,
+                    email = null,
+                    grade = null,
+                    classNum = 3,
+                    number = null,
+                    role = null,
+                    dormitoryRoomNumber = null
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.findById(studentId) } returns Optional.of(existingStudent)
+                    every {
+                        mockStudentRepository.existsByStudentNumberAndNotStudentId(
+                            2,
+                            3,
+                            5,
+                            studentId
+                        )
+                    } returns false
+                    every { mockStudentRepository.save(any()) } returns existingStudent.apply {
+                        studentNumber = StudentNumber(2, 3, 5)
+                        studentMajor = Major.SMART_IOT
+                    }
+                }
+
+                it("반 변경 시 새로운 반에 따라 전공이 변경되어야 한다") {
+                    val result = modifyStudentService.execute(studentId, updateRequest)
+
+                    val student = result.students[0]
+                    student.grade shouldBe 2
+                    student.classNum shouldBe 3
+                    student.major shouldBe Major.SMART_IOT
+                    student.studentNumber shouldBe 2305
+                }
+            }
+
+            context("학생의 학년과 반을 동시에 변경할 때") {
+                val updateRequest = StudentUpdateReqDto(
+                    name = null,
+                    sex = null,
+                    email = null,
+                    grade = 1,
+                    classNum = 4,
+                    number = null,
+                    role = null,
+                    dormitoryRoomNumber = null
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.findById(studentId) } returns Optional.of(existingStudent)
+                    every {
+                        mockStudentRepository.existsByStudentNumberAndNotStudentId(
+                            1,
+                            4,
+                            5,
+                            studentId
+                        )
+                    } returns false
+                    every { mockStudentRepository.save(any()) } returns existingStudent.apply {
+                        studentNumber = StudentNumber(1, 4, 5)
+                        studentMajor = Major.AI
+                    }
+                }
+
+                it("반 변경 시 새로운 반에 따라 전공이 변경되어야 한다") {
+                    val result = modifyStudentService.execute(studentId, updateRequest)
+
+                    val student = result.students[0]
+                    student.grade shouldBe 1
+                    student.classNum shouldBe 4
+                    student.major shouldBe Major.AI
+                    student.studentNumber shouldBe 1405
+                }
+            }
+
+            context("이미 존재하는 이메일로 변경을 시도할 때") {
+                val updateRequest = StudentUpdateReqDto(
+                    name = null,
+                    sex = null,
+                    email = "duplicate@gsm.hs.kr",
+                    grade = null,
+                    classNum = null,
+                    number = null,
+                    role = null,
+                    dormitoryRoomNumber = null
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.findById(studentId) } returns Optional.of(existingStudent)
+                    every {
+                        mockStudentRepository.existsByStudentEmailAndNotStudentId(
+                            updateRequest.email!!,
+                            studentId
+                        )
+                    } returns true
+                }
+
+                it("IllegalArgumentException이 발생해야 한다") {
+                    val exception = shouldThrow<IllegalArgumentException> {
+                        modifyStudentService.execute(studentId, updateRequest)
+                    }
+
+                    exception.message shouldBe "이미 존재하는 이메일입니다: ${updateRequest.email}"
+
+                    verify(exactly = 1) { mockStudentRepository.findById(studentId) }
+                    verify(exactly = 1) {
+                        mockStudentRepository.existsByStudentEmailAndNotStudentId(
+                            updateRequest.email!!,
+                            studentId
+                        )
+                    }
+                    verify(exactly = 0) { mockStudentRepository.save(any()) }
+                }
+            }
+
+            context("이미 존재하는 학번으로 변경을 시도할 때") {
+                val updateRequest = StudentUpdateReqDto(
+                    name = null,
+                    sex = null,
+                    email = null,
+                    grade = 2,
+                    classNum = 2,
+                    number = 10,
+                    role = null,
+                    dormitoryRoomNumber = null
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.findById(studentId) } returns Optional.of(existingStudent)
+                    every {
+                        mockStudentRepository.existsByStudentNumberAndNotStudentId(
+                            2,
+                            2,
+                            10,
+                            studentId
+                        )
+                    } returns true
+                }
+
+                it("IllegalArgumentException이 발생해야 한다") {
+                    val exception = shouldThrow<IllegalArgumentException> {
+                        modifyStudentService.execute(studentId, updateRequest)
+                    }
+
+                    exception.message shouldBe "이미 존재하는 학번입니다: 2학년 2반 10번"
+
+                    verify(exactly = 1) {
+                        mockStudentRepository.existsByStudentNumberAndNotStudentId(
+                            2,
+                            2,
+                            10,
+                            studentId
+                        )
+                    }
+                    verify(exactly = 0) { mockStudentRepository.save(any()) }
+                }
+            }
+
+            context("존재하지 않는 학생 ID로 수정을 시도할 때") {
+                val updateRequest = StudentUpdateReqDto(
+                    name = "수정이름",
+                    sex = null,
+                    email = null,
+                    grade = null,
+                    classNum = null,
+                    number = null,
+                    role = null,
+                    dormitoryRoomNumber = null
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.findById(studentId) } returns Optional.empty()
+                }
+
+                it("IllegalArgumentException이 발생해야 한다") {
+                    val exception = shouldThrow<IllegalArgumentException> {
+                        modifyStudentService.execute(studentId, updateRequest)
+                    }
+
+                    exception.message shouldBe "학생을 찾을 수 없습니다. studentId: $studentId"
+
+                    verify(exactly = 1) { mockStudentRepository.findById(studentId) }
+                    verify(exactly = 0) { mockStudentRepository.save(any()) }
+                }
+            }
+
+            context("유효하지 않은 학급으로 반을 변경할 때") {
+                val updateRequest = StudentUpdateReqDto(
+                    name = null,
+                    sex = null,
+                    email = null,
+                    grade = null,
+                    classNum = 5,
+                    number = null,
+                    role = null,
+                    dormitoryRoomNumber = null
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.findById(studentId) } returns Optional.of(existingStudent)
+                    every {
+                        mockStudentRepository.existsByStudentNumberAndNotStudentId(
+                            2,
+                            5,
+                            5,
+                            studentId
+                        )
+                    } returns false
+                }
+
+                it("IllegalArgumentException이 발생해야 한다") {
+                    val exception = shouldThrow<IllegalArgumentException> {
+                        modifyStudentService.execute(studentId, updateRequest)
+                    }
+
+                    exception.message shouldBe "유효하지 않은 학급입니다: 5"
+
+                    verify(exactly = 1) { mockStudentRepository.findById(studentId) }
+                    verify(exactly = 0) { mockStudentRepository.save(any()) }
+                }
+            }
+
+            context("기숙사 방 번호를 변경할 때") {
+                val updateRequest = StudentUpdateReqDto(
+                    name = null,
+                    sex = null,
+                    email = null,
+                    grade = null,
+                    classNum = null,
+                    number = null,
+                    role = null,
+                    dormitoryRoomNumber = 305
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.findById(studentId) } returns Optional.of(existingStudent)
+                    every { mockStudentRepository.save(any()) } returns existingStudent.apply {
+                        studentDormitoryRoomNumber = DormitoryRoomNumber(updateRequest.dormitoryRoomNumber!!)
+                    }
+                }
+
+                it("기숙사 방 번호가 성공적으로 변경되어야 한다") {
+                    val result = modifyStudentService.execute(studentId, updateRequest)
+
+                    val student = result.students[0]
+                    student.dormitoryRoom shouldBe 305
+                    student.dormitoryFloor shouldBe 3
+
+                    verify(exactly = 1) { mockStudentRepository.findById(studentId) }
+                    verify(exactly = 1) { mockStudentRepository.save(any()) }
+                }
+            }
+
+            context("학생의 성별과 역할을 동시에 변경할 때") {
+                val updateRequest = StudentUpdateReqDto(
+                    name = null,
+                    sex = Sex.WOMAN,
+                    email = null,
+                    grade = null,
+                    classNum = null,
+                    number = null,
+                    role = Role.STUDENT_COUNCIL,
+                    dormitoryRoomNumber = null
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.findById(studentId) } returns Optional.of(existingStudent)
+                    every { mockStudentRepository.save(any()) } returns existingStudent.apply {
+                        studentSex = updateRequest.sex!!
+                        studentRole = updateRequest.role!!
+                    }
+                }
+
+                it("성별과 역할이 성공적으로 변경되어야 한다") {
+                    val result = modifyStudentService.execute(studentId, updateRequest)
+
+                    val student = result.students[0]
+                    student.sex shouldBe Sex.WOMAN
+                    student.role shouldBe Role.STUDENT_COUNCIL
+
+                    verify(exactly = 1) { mockStudentRepository.findById(studentId) }
+                    verify(exactly = 1) { mockStudentRepository.save(any()) }
+                }
+            }
+
+            context("모든 필드를 한번에 수정할 때") {
+                val updateRequest = StudentUpdateReqDto(
+                    name = "완전수정학생",
+                    sex = Sex.WOMAN,
+                    email = "updated@gsm.hs.kr",
+                    grade = 4,
+                    classNum = 2,
+                    number = 8,
+                    role = Role.DORMITORY_MANAGER,
+                    dormitoryRoomNumber = 418
+                )
+
+                beforeEach {
+                    every { mockStudentRepository.findById(studentId) } returns Optional.of(existingStudent)
+                    every {
+                        mockStudentRepository.existsByStudentEmailAndNotStudentId(
+                            updateRequest.email!!,
+                            studentId
+                        )
+                    } returns false
+                    every {
+                        mockStudentRepository.existsByStudentNumberAndNotStudentId(
+                            4,
+                            2,
+                            8,
+                            studentId
+                        )
+                    } returns false
+                    every { mockStudentRepository.save(any()) } returns existingStudent.apply {
+                        studentName = updateRequest.name!!
+                        studentSex = updateRequest.sex!!
+                        studentEmail = updateRequest.email!!
+                        studentNumber =
+                            StudentNumber(updateRequest.grade!!, updateRequest.classNum!!, updateRequest.number!!)
+                        studentMajor = Major.SW_DEVELOPMENT
+                        studentRole = updateRequest.role!!
+                        studentDormitoryRoomNumber = DormitoryRoomNumber(updateRequest.dormitoryRoomNumber!!)
+                    }
+                }
+
+                it("모든 필드가 성공적으로 업데이트되어야 한다") {
+                    val result = modifyStudentService.execute(studentId, updateRequest)
+
+                    val student = result.students[0]
+                    student.name shouldBe "완전수정학생"
+                    student.sex shouldBe Sex.WOMAN
+                    student.email shouldBe "updated@gsm.hs.kr"
+                    student.grade shouldBe 4
+                    student.classNum shouldBe 2
+                    student.number shouldBe 8
+                    student.studentNumber shouldBe 4208
+                    student.major shouldBe Major.SW_DEVELOPMENT
+                    student.role shouldBe Role.DORMITORY_MANAGER
+                    student.dormitoryRoom shouldBe 418
+                    student.dormitoryFloor shouldBe 4
+
+                    verify(exactly = 1) { mockStudentRepository.findById(studentId) }
+                    verify(exactly = 1) {
+                        mockStudentRepository.existsByStudentEmailAndNotStudentId(
+                            updateRequest.email!!,
+                            studentId
+                        )
+                    }
+                    verify(exactly = 1) {
+                        mockStudentRepository.existsByStudentNumberAndNotStudentId(
+                            4,
+                            2,
+                            8,
+                            studentId
+                        )
+                    }
+                    verify(exactly = 1) { mockStudentRepository.save(any()) }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/team/themoment/datagsm/domain/student/service/QueryStudentServiceTest.kt
+++ b/src/test/kotlin/team/themoment/datagsm/domain/student/service/QueryStudentServiceTest.kt
@@ -1,0 +1,258 @@
+package team.themoment.datagsm.domain.student.service
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import team.themoment.datagsm.domain.auth.entity.constant.Role
+import team.themoment.datagsm.domain.student.entity.StudentJpaEntity
+import team.themoment.datagsm.domain.student.entity.constant.DormitoryRoomNumber
+import team.themoment.datagsm.domain.student.entity.constant.Major
+import team.themoment.datagsm.domain.student.entity.constant.Sex
+import team.themoment.datagsm.domain.student.entity.constant.StudentNumber
+import team.themoment.datagsm.domain.student.repository.StudentJpaRepository
+import team.themoment.datagsm.domain.student.service.impl.QueryStudentServiceImpl
+
+class QueryStudentServiceTest : DescribeSpec({
+
+    val mockStudentRepository = mockk<StudentJpaRepository>()
+
+    val queryStudentService = QueryStudentServiceImpl(mockStudentRepository)
+
+    afterEach {
+        clearAllMocks()
+    }
+
+    describe("QueryStudentService 클래스의") {
+        describe("execute 메서드는") {
+
+            val testStudent = StudentJpaEntity().apply {
+                studentId = 1L
+                studentName = "홍길동"
+                studentSex = Sex.MAN
+                studentEmail = "hong@gsm.hs.kr"
+                studentNumber = StudentNumber(1, 1, 1)
+                studentMajor = Major.SW_DEVELOPMENT
+                studentRole = Role.GENERAL_STUDENT
+                studentDormitoryRoomNumber = DormitoryRoomNumber(101)
+                studentIsLeaveSchool = false
+            }
+
+            context("존재하는 학생 ID로 검색할 때") {
+                beforeEach {
+                    every {
+                        mockStudentRepository.searchStudentsWithPaging(
+                            studentId = 1L,
+                            name = null,
+                            email = null,
+                            grade = null,
+                            classNum = null,
+                            number = null,
+                            sex = null,
+                            role = null,
+                            dormitoryRoom = null,
+                            isLeaveSchool = false,
+                            pageable = PageRequest.of(0, 20)
+                        )
+                    } returns PageImpl(listOf(testStudent), PageRequest.of(0, 20), 1L)
+                }
+
+                it("해당 학생 정보가 반환되어야 한다") {
+                    val result = queryStudentService.execute(
+                        studentId = 1L,
+                        name = null,
+                        email = null,
+                        grade = null,
+                        classNum = null,
+                        number = null,
+                        sex = null,
+                        role = null,
+                        dormitoryRoom = null,
+                        isLeaveSchool = false,
+                        page = 0,
+                        size = 20
+                    )
+
+                    result.totalElements shouldBe 1L
+                    result.totalPages shouldBe 1
+                    result.students.size shouldBe 1
+
+                    val student = result.students[0]
+                    student.studentId shouldBe 1L
+                    student.name shouldBe "홍길동"
+                    student.sex shouldBe Sex.MAN
+                    student.email shouldBe "hong@gsm.hs.kr"
+                    student.grade shouldBe 1
+                    student.classNum shouldBe 1
+                    student.number shouldBe 1
+                    student.studentNumber shouldBe 1101
+                    student.major shouldBe Major.SW_DEVELOPMENT
+                    student.role shouldBe Role.GENERAL_STUDENT
+                    student.dormitoryRoom shouldBe 101
+                    student.dormitoryFloor shouldBe 1
+                    student.isLeaveSchool shouldBe false
+
+                    verify(exactly = 1) {
+                        mockStudentRepository.searchStudentsWithPaging(
+                            studentId = 1L,
+                            name = null,
+                            email = null,
+                            grade = null,
+                            classNum = null,
+                            number = null,
+                            sex = null,
+                            role = null,
+                            dormitoryRoom = null,
+                            isLeaveSchool = false,
+                            pageable = PageRequest.of(0, 20)
+                        )
+                    }
+                }
+            }
+
+            context("이름과 성별로 다중 조건 검색할 때") {
+                beforeEach {
+                    every {
+                        mockStudentRepository.searchStudentsWithPaging(
+                            studentId = null,
+                            name = "홍길동",
+                            email = null,
+                            grade = null,
+                            classNum = null,
+                            number = null,
+                            sex = Sex.MAN,
+                            role = null,
+                            dormitoryRoom = null,
+                            isLeaveSchool = false,
+                            pageable = PageRequest.of(0, 20)
+                        )
+                    } returns PageImpl(listOf(testStudent), PageRequest.of(0, 20), 1L)
+                }
+
+                it("조건에 맞는 학생 목록이 반환되어야 한다") {
+                    val result = queryStudentService.execute(
+                        studentId = null,
+                        name = "홍길동",
+                        email = null,
+                        grade = null,
+                        classNum = null,
+                        number = null,
+                        sex = Sex.MAN,
+                        role = null,
+                        dormitoryRoom = null,
+                        isLeaveSchool = false,
+                        page = 0,
+                        size = 20
+                    )
+
+                    result.totalElements shouldBe 1L
+                    result.students[0].name shouldBe "홍길동"
+                    result.students[0].sex shouldBe Sex.MAN
+                }
+            }
+
+            context("존재하지 않는 조건으로 검색할 때") {
+                beforeEach {
+                    every {
+                        mockStudentRepository.searchStudentsWithPaging(
+                            studentId = 999L,
+                            name = null,
+                            email = null,
+                            grade = null,
+                            classNum = null,
+                            number = null,
+                            sex = null,
+                            role = null,
+                            dormitoryRoom = null,
+                            isLeaveSchool = false,
+                            pageable = PageRequest.of(0, 20)
+                        )
+                    } returns PageImpl(emptyList(), PageRequest.of(0, 20), 0L)
+                }
+
+                it("빈 결과가 반환되어야 한다") {
+                    val result = queryStudentService.execute(
+                        studentId = 999L,
+                        name = null,
+                        email = null,
+                        grade = null,
+                        classNum = null,
+                        number = null,
+                        sex = null,
+                        role = null,
+                        dormitoryRoom = null,
+                        isLeaveSchool = false,
+                        page = 0,
+                        size = 20
+                    )
+
+                    result.totalElements shouldBe 0L
+                    result.totalPages shouldBe 0
+                    result.students.size shouldBe 0
+                }
+            }
+
+            context("페이지네이션으로 여러 학생을 조회할 때") {
+                val students = (1..50).map { index ->
+                    StudentJpaEntity().apply {
+                        studentId = index.toLong()
+                        studentName = "학생$index"
+                        studentSex = if (index % 2 == 0) Sex.WOMAN else Sex.MAN
+                        studentEmail = "student$index@gsm.hs.kr"
+                        studentNumber = StudentNumber(1, 1, index)
+                        studentMajor = Major.SW_DEVELOPMENT
+                        studentRole = Role.GENERAL_STUDENT
+                        studentDormitoryRoomNumber = DormitoryRoomNumber(100 + index)
+                        studentIsLeaveSchool = false
+                    }
+                }
+
+                beforeEach {
+                    val firstPageStudents = students.take(20)
+                    every {
+                        mockStudentRepository.searchStudentsWithPaging(
+                            studentId = null,
+                            name = null,
+                            email = null,
+                            grade = null,
+                            classNum = null,
+                            number = null,
+                            sex = null,
+                            role = null,
+                            dormitoryRoom = null,
+                            isLeaveSchool = false,
+                            pageable = PageRequest.of(0, 20)
+                        )
+                    } returns PageImpl(firstPageStudents, PageRequest.of(0, 20), 50L)
+                }
+
+                it("첫 번째 페이지 결과가 반환되어야 한다") {
+                    val result = queryStudentService.execute(
+                        studentId = null,
+                        name = null,
+                        email = null,
+                        grade = null,
+                        classNum = null,
+                        number = null,
+                        sex = null,
+                        role = null,
+                        dormitoryRoom = null,
+                        isLeaveSchool = false,
+                        page = 0,
+                        size = 20
+                    )
+
+                    result.totalElements shouldBe 50L
+                    result.totalPages shouldBe 3
+                    result.students.size shouldBe 20
+                    result.students[0].name shouldBe "학생1"
+                    result.students[19].name shouldBe "학생20"
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 요약
학생 정보의 검색, 추가, 부분 수정 기능을 제공하는 API를 구현했습니다.

## 본문
총 3개의 API 엔드포인트를 구현했습니다:
- `GET /v1/students/` - 학생 정보 조회
- `POST /v1/students/` - 새로운 학생 정보 추가  
- `PATCH /v1/students/{studentId}` - 기존 학생 정보 수정

**조회 API**
`studentId`, `name`, `email`, `grade`, `classNum`, `number`, `sex`, `role`, `domitoryRoom`, `isLeaveSchool` 등의 파라미터를 활용하여 학생 정보를 검색할 수 있습니다. 대용량 데이터 처리를 위한 페이징 기능도 지원합니다.

**추가 API**  
새로운 학생 정보를 등록할 수 있으며, 데이터베이스에 동일한 이메일이나 학번이 이미 존재할 경우 중복 오류를 반환하여 데이터 무결성을 보장합니다.

**수정 API**
`studentId`로 특정 학생을 식별한 후, 원하는 필드만 선택적으로 수정할 수 있습니다. 전체 정보를 다시 보낼 필요 없이 변경하고자 하는 필드만 요청에 포함하면 됩니다.