### PR TITLE
[global] 엔드포인트별 접근권한 설정 추가

### DIFF
--- a/src/main/kotlin/team/themoment/datagsm/global/config/DomainAuthorizationConfig.kt
+++ b/src/main/kotlin/team/themoment/datagsm/global/config/DomainAuthorizationConfig.kt
@@ -14,9 +14,9 @@ class DomainAuthorizationConfig {
             .requestMatchers("/v1/auth/google", "/v1/auth/refresh")
             .permitAll()
             .requestMatchers("/v1/auth/api-key/**")
-            .hasAnyAuthority(AccountRole.USER.authority, AccountRole.ADMIN.authority, AccountRole.ROOT.authority)
+            .hasAnyAuthority(AccountRole.ROOT.authority, AccountRole.ADMIN.authority, AccountRole.USER.authority)
             .requestMatchers("/v1/club/**", "/v1/project/**", "/v1/students/**")
-            .hasAnyAuthority(AccountRole.ADMIN.authority, AccountRole.ROOT.authority, AccountRole.API_KEY_USER.authority)
+            .hasAnyAuthority(AccountRole.ROOT.authority, AccountRole.ADMIN.authority, AccountRole.API_KEY_USER.authority)
             .anyRequest()
             .authenticated()
     }


### PR DESCRIPTION
## 개요

엔드포인트 별 접근 권한 설정을 추가하였습니다.

## 본문

### 변경 사항

  1. **API Key 관리 엔드포인트 권한 강화**
     - `/v1/auth/api-key/**`: `authenticated()` → USER, ADMIN, ROOT만 접근 가능
     - 일반 사용자가 자신의 API 키를 발급/갱신/조회/삭제할 수 있도록 허용

  2. **데이터 API 접근 권한 추가**
     - `/v1/club/**`, `/v1/project/**`, `/v1/students/**`: ADMIN, ROOT, API_KEY_USER만 접근 가능
     - 일반 JWT 사용자는 접근 불가 (외부 API 키 또는 관리자 전용)

  ### 권한 구조

  | 엔드포인트 | ROOT | ADMIN | USER | API_KEY_USER |
  |-----------|------|-------|------|--------------|
  | `/v1/auth/api-key/**` | ✅ | ✅ | ✅ | ❌ |
  | `/v1/club/**`, `/v1/project/**`, `/v1/students/**` | ✅ | ✅ | ❌ | ✅ |
  | 기타 | ✅ | ✅ | ✅ | ✅ |


