### PR TITLE
[global] SpEL 표현식 문자열 파싱 문제 수정

### DIFF
--- a/src/main/kotlin/team/themoment/datagsm/global/security/annotation/RequireScope.kt
+++ b/src/main/kotlin/team/themoment/datagsm/global/security/annotation/RequireScope.kt
@@ -4,7 +4,7 @@ import org.springframework.security.access.prepost.PreAuthorize
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-@PreAuthorize("@scopeChecker.hasScope(authentication, {scope})")
+@PreAuthorize("@scopeChecker.hasScope(authentication, '{scope}')")
 annotation class RequireScope(
     val scope: String,
 )


### PR DESCRIPTION
## 개요

  @RequireScope 어노테이션의 SpEL 표현식에서 scope 파라미터를 문자열 리터럴로 감싸 파싱 오류를 해결했습니다.

  ## 본문

  ### 문제
  - `student:read`, `club:write` 등 콜론(:)을 포함한 scope 값 사용 시 `SpelParseException` 발생
  - 에러 메시지: `EL1043E: Unexpected token. Expected 'rparen())' but was 'colon(:)'`
  - SpEL 표현식 `{scope}`가 문자열 리터럴이 아닌 표현식으로 파싱되어 콜론을 예상치 못한 토큰으로 인식

  ### 해결
  - `@PreAuthorize("@scopeChecker.hasScope(authentication, {scope})")`
    → `@PreAuthorize("@scopeChecker.hasScope(authentication, '{scope})')")`
  - scope 파라미터를 작은따옴표로 감싸 문자열 리터럴로 명시
