### PR TITLE
[student] 학생 정보 추가 API에서 올바르지 않은 예외 처리 문서화 수정

### DIFF
--- a/src/main/kotlin/team/themoment/datagsm/domain/student/controller/StudentController.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/controller/StudentController.kt
@@ -87,7 +87,7 @@ class StudentController(
         value = [
             ApiResponse(responseCode = "200", description = "생성 성공"),
             ApiResponse(responseCode = "400", description = "잘못된 요청 (검증 실패)", content = [Content()]),
-            ApiResponse(responseCode = "404", description = "계정을 찾을 수 없음", content = [Content()]),
+            ApiResponse(responseCode = "404", description = "동아리를 찾을 수 없음", content = [Content()]),
             ApiResponse(responseCode = "409", description = "이미 존재하는 학생", content = [Content()]),
         ],
     )


### PR DESCRIPTION
## 개요

학생 정보 추가 API에서 올바르지 않은 예외 처리 문서화를 수정하였습니다.

## 본문

학생 정보 추가 API(`POST /v1/student`)에서 `404 NOT FOUND`를 반환하는 예외 시나리오가 올바르지 않게 되어있던 것을 수정하였습니다
- `계정을 찾을 수 없음` -> `동아리를 찾을 수 없음`
