### PR TITLE
[global] Apache POI 의존성 버전 분리

### DIFF
--- a/buildSrc/src/main/kotlin/dependency/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependency/Dependencies.kt
@@ -11,7 +11,6 @@ import dependency.DependencyVersions.QUERY_DSL_VERSION
 import dependency.DependencyVersions.SPRING_CLOUD_VERSION
 import dependency.DependencyVersions.SWAGGER_VERSION
 import dependency.DependencyVersions.POI_VERSION
-import dependency.DependencyVersions.POI_OOXML_VERSION
 
 object Dependencies {
     // Spring Starters
@@ -62,7 +61,7 @@ object Dependencies {
 
     // Excel
     const val POI = "org.apache.poi:poi:${POI_VERSION}"
-    const val POI_OOXML = "org.apache.poi:poi-ooxml:${POI_OOXML_VERSION}"
+    const val POI_OOXML = "org.apache.poi:poi-ooxml:${POI_VERSION}"
 
     // Testing
     const val SPRING_TEST = "org.springframework.boot:spring-boot-starter-test"

--- a/buildSrc/src/main/kotlin/dependency/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/dependency/DependencyVersions.kt
@@ -20,5 +20,4 @@ object DependencyVersions {
     const val KOTLIN_COROUTINES_VERSION = "1.10.2"
 
     const val POI_VERSION = "5.5.1"
-    const val POI_OOXML_VERSION = "5.5.1"
 }


### PR DESCRIPTION
## 개요

엑셀 관련 의존성의 버전을 `DependencyVersions`에 지정하여 사용하도록 변경하였습니다.