### PR TITLE
[global] 잘못된 `@NotBlank` Validation 사용 변경

### DIFF
--- a/src/main/kotlin/team/themoment/datagsm/domain/club/dto/request/ClubReqDto.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/club/dto/request/ClubReqDto.kt
@@ -2,7 +2,6 @@ package team.themoment.datagsm.domain.club.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import team.themoment.datagsm.domain.club.entity.constant.ClubType
 
@@ -11,7 +10,6 @@ data class ClubReqDto(
     @field:Size(max = 30)
     @param:Schema(description = "동아리 이름", example = "SW개발동아리", maxLength = 30)
     val name: String,
-    @field:NotNull
     @param:Schema(description = "동아리 종류", example = "MAJOR_CLUB")
     val type: ClubType,
 )

--- a/src/main/kotlin/team/themoment/datagsm/domain/project/dto/request/ProjectReqDto.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/project/dto/request/ProjectReqDto.kt
@@ -2,7 +2,6 @@ package team.themoment.datagsm.domain.project.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 
 data class ProjectReqDto(
@@ -14,7 +13,6 @@ data class ProjectReqDto(
     @field:Size(max = 500)
     @param:Schema(description = "프로젝트 설명", example = "학교 데이터를 제공하는 API 서비스", maxLength = 500)
     val description: String,
-    @field:NotNull
     @param:Schema(description = "프로젝트 소유 동아리 ID", example = "1")
     val clubId: Long,
 )

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/dto/internal/ExcelColumnDto.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/dto/internal/ExcelColumnDto.kt
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import team.themoment.datagsm.domain.student.entity.constant.Major
 import team.themoment.datagsm.domain.student.entity.constant.Sex
@@ -25,7 +24,6 @@ data class ExcelColumnDto(
     @field:Email
     @param:Schema(description = "이메일", example = "student@gsm.hs.kr", maxLength = 50)
     val email: String,
-    @field:NotNull
     @param:Schema(description = "학과", example = "SW개발과")
     val major: Major,
     @field:Size(max = 50)
@@ -41,12 +39,10 @@ data class ExcelColumnDto(
     @field:Max(518)
     @param:Schema(description = "기숙사 번호", example = "201", minimum = "201", maximum = "518")
     val dormitoryRoomNumber: Int?,
-    @field:NotNull
     @param:Schema(description = "소속", example = "학생회")
     val role: StudentRole,
     @param:Schema(description = "자퇴 여부", example = "true")
     val isLeaveSchool: Boolean,
-    @field:NotNull
     @param:Schema(description = "성별", example = "남")
     val sex: Sex,
 )

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/dto/request/CreateStudentReqDto.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/dto/request/CreateStudentReqDto.kt
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import team.themoment.datagsm.domain.student.entity.constant.Sex
 import team.themoment.datagsm.domain.student.entity.constant.StudentRole
@@ -15,7 +14,6 @@ data class CreateStudentReqDto(
     @field:NotBlank
     @param:Schema(description = "이름", example = "홍길동", maxLength = 30)
     val name: String,
-    @field:NotNull
     @param:Schema(description = "성별", example = "WOMAN")
     val sex: Sex,
     @param:Size(max = 50)
@@ -25,17 +23,14 @@ data class CreateStudentReqDto(
     val email: String,
     @field:Min(value = 1)
     @field:Max(value = 3)
-    @field:NotNull
     @param:Schema(description = "학년 (1-3)", example = "1", minimum = "1", maximum = "3")
     val grade: Int,
     @field:Min(value = 1)
     @field:Max(value = 4)
-    @field:NotNull
     @param:Schema(description = "반 (1-4)", example = "1", minimum = "1", maximum = "4")
     val classNum: Int,
     @field:Min(value = 1)
     @field:Max(value = 18)
-    @field:NotNull
     @param:Schema(description = "번호 (1-18)", example = "1", minimum = "1", maximum = "18")
     val number: Int,
     @param:Schema(description = "역할", example = "GENERAL_STUDENT")

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/dto/request/UpdateStudentReqDto.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/dto/request/UpdateStudentReqDto.kt
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import team.themoment.datagsm.domain.student.entity.constant.Sex
 import team.themoment.datagsm.domain.student.entity.constant.StudentRole
@@ -15,7 +14,6 @@ data class UpdateStudentReqDto(
     @field:NotBlank
     @param:Schema(description = "이름", example = "홍길동", maxLength = 30)
     val name: String,
-    @field:NotNull
     @param:Schema(description = "성별", example = "WOMAN")
     val sex: Sex,
     @field:Size(max = 50)
@@ -25,20 +23,16 @@ data class UpdateStudentReqDto(
     val email: String,
     @field:Min(value = 1)
     @field:Max(value = 3)
-    @field:NotNull
     @param:Schema(description = "학년 (1-3)", example = "1", minimum = "1", maximum = "3")
     val grade: Int,
     @field:Min(value = 1)
     @field:Max(value = 4)
-    @field:NotNull
     @param:Schema(description = "반 (1-4)", example = "1", minimum = "1", maximum = "4")
     val classNum: Int,
     @field:Min(value = 1)
     @field:Max(value = 18)
-    @field:NotNull
     @param:Schema(description = "번호 (1-18)", example = "1", minimum = "1", maximum = "18")
     val number: Int,
-    @field:NotNull
     @param:Schema(description = "역할", example = "GENERAL_STUDENT")
     val role: StudentRole,
     @field:Min(value = 201)


### PR DESCRIPTION
## 개요

@NotBlank는 String에만 사용이 가능하지만, Enum, Int 등 다른 타입에도 사용되던 문제를 해결했습니다.

