### PR TITLE
[student] 학생 정보 검색 API에서 재학 여부 파라미터 기본값 설정 제거

### DIFF
--- a/src/main/kotlin/team/themoment/datagsm/domain/student/controller/StudentController.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/controller/StudentController.kt
@@ -63,7 +63,7 @@ class StudentController(
         @Parameter(description = "성별") @RequestParam(required = false) sex: Sex?,
         @Parameter(description = "역할") @RequestParam(required = false) role: StudentRole?,
         @Parameter(description = "기숙사 호실") @RequestParam(required = false) dormitoryRoom: Int?,
-        @Parameter(description = "자퇴 여부") @RequestParam(required = false, defaultValue = "false") isLeaveSchool: Boolean,
+        @Parameter(description = "자퇴 여부") @RequestParam(required = false) isLeaveSchool: Boolean?,
         @Parameter(description = "페이지 번호") @RequestParam(required = false, defaultValue = "0") page: Int,
         @Parameter(description = "페이지 크기") @RequestParam(required = false, defaultValue = "300") size: Int,
     ): StudentListResDto =

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/repository/custom/StudentJpaCustomRepository.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/repository/custom/StudentJpaCustomRepository.kt
@@ -17,7 +17,7 @@ interface StudentJpaCustomRepository {
         sex: Sex?,
         role: StudentRole?,
         dormitoryRoom: Int?,
-        isLeaveSchool: Boolean,
+        isLeaveSchool: Boolean?,
         pageable: Pageable,
     ): Page<StudentJpaEntity>
 

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
@@ -25,7 +25,7 @@ class StudentJpaCustomRepositoryImpl(
         sex: Sex?,
         role: StudentRole?,
         dormitoryRoom: Int?,
-        isLeaveSchool: Boolean,
+        isLeaveSchool: Boolean?,
         pageable: Pageable,
     ): Page<StudentJpaEntity> {
         val content =
@@ -41,7 +41,7 @@ class StudentJpaCustomRepositoryImpl(
                     sex?.let { studentJpaEntity.sex.eq(it) },
                     role?.let { studentJpaEntity.role.eq(it) },
                     dormitoryRoom?.let { studentJpaEntity.dormitoryRoomNumber.dormitoryRoomNumber.eq(it) },
-                    studentJpaEntity.isLeaveSchool.eq(isLeaveSchool),
+                    isLeaveSchool?.let { studentJpaEntity.isLeaveSchool.eq(it) },
                 ).offset(pageable.offset)
                 .limit(pageable.pageSize.toLong())
                 .fetch()
@@ -60,7 +60,7 @@ class StudentJpaCustomRepositoryImpl(
                     sex?.let { studentJpaEntity.sex.eq(it) },
                     role?.let { studentJpaEntity.role.eq(it) },
                     dormitoryRoom?.let { studentJpaEntity.dormitoryRoomNumber.dormitoryRoomNumber.eq(it) },
-                    studentJpaEntity.isLeaveSchool.eq(isLeaveSchool),
+                    isLeaveSchool?.let { studentJpaEntity.isLeaveSchool.eq(it) },
                 )
 
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/QueryStudentService.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/QueryStudentService.kt
@@ -15,7 +15,7 @@ interface QueryStudentService {
         sex: Sex?,
         role: StudentRole?,
         dormitoryRoom: Int?,
-        isLeaveSchool: Boolean,
+        isLeaveSchool: Boolean?,
         page: Int,
         size: Int,
     ): StudentListResDto

--- a/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/QueryStudentServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/student/service/impl/QueryStudentServiceImpl.kt
@@ -26,7 +26,7 @@ class QueryStudentServiceImpl(
         sex: Sex?,
         role: StudentRole?,
         dormitoryRoom: Int?,
-        isLeaveSchool: Boolean,
+        isLeaveSchool: Boolean?,
         page: Int,
         size: Int,
     ): StudentListResDto {


### PR DESCRIPTION
## 개요

학생 정보 검색 API에서 재학 여부 파라미터의 기본값을 제거하였습니다.

## 본문

웹 클라이언트 팀원들이 재학 여부에 따라 검색하는 기능을 구현하였는데 해당 조건을 비활성화하고 재학 중,재학 중 아님 상태에 구애받지 않는 검색결과를 원하여서 해당 작업을 진행하였습니다.
학생 정보 검색 API에서 재학 여부 파라미터의 기본값이 `false`로 되어 있었는데 해당 설정을 제거하였습니다.
