### PR TITLE
[ci/cd] Github Action 버전 변경 및 Gradle 명령어 수정

### DIFF
--- a/.github/workflows/datagsm-prod-cd.yaml
+++ b/.github/workflows/datagsm-prod-cd.yaml
@@ -12,7 +12,7 @@ jobs:
     environment: prod
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup JDK 24
         uses: actions/setup-java@v5
@@ -30,7 +30,7 @@ jobs:
         shell: bash
 
       - name: Build with Gradle
-        run : ./gradlew clean build
+        run : ./gradlew clean build -x test
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5

--- a/.github/workflows/datagsm-prod-ci.yaml
+++ b/.github/workflows/datagsm-prod-ci.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup JDK 24
         uses: actions/setup-java@v5
@@ -27,7 +27,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
 
       - name: Test with Gradle
-        run: ./gradlew test
+        run: ./gradlew clean build
 
       - name: CI Success Notification
         uses: sarisia/actions-status-discord@v1

--- a/.github/workflows/datagsm-stage-cd.yaml
+++ b/.github/workflows/datagsm-stage-cd.yaml
@@ -12,7 +12,7 @@ jobs:
     environment: stage
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup JDK 24
         uses: actions/setup-java@v5
@@ -30,7 +30,7 @@ jobs:
         shell: bash
 
       - name: Build with Gradle
-        run : ./gradlew clean build
+        run : ./gradlew clean build -x test
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5

--- a/.github/workflows/datagsm-stage-ci.yaml
+++ b/.github/workflows/datagsm-stage-ci.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup JDK 24
         uses: actions/setup-java@v5
@@ -27,7 +27,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
 
       - name: Test with Gradle
-        run: ./gradlew test
+        run: ./gradlew clean build
 
       - name: CI Success Notification
         uses: sarisia/actions-status-discord@v1


### PR DESCRIPTION
## 개요

Github Action 버전을 더 최신버전으로 교체하고 Gradle 명령어를 수정하였습니다.

## 본문

`actions/checkout` 버전을 `v5`에서 `v6`로 교체하였으며 Gradle 빌드 명령어를 `./gradlew test`에서 `./gradlew clean build`로 교체하여 CI 스크립트에서 린트 체크까지 수행하도록 하였습니다.