### PR TITLE
[auth] API 키 설명 수정 시 완전히 재발급 되도록 로직 수정

### DIFF
--- a/src/main/kotlin/team/themoment/datagsm/domain/auth/service/impl/ModifyCurrentAccountApiKeyServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/datagsm/domain/auth/service/impl/ModifyCurrentAccountApiKeyServiceImpl.kt
@@ -66,17 +66,21 @@ class ModifyCurrentAccountApiKeyServiceImpl(
         val expirationDays = if (isAdmin) apiKeyEnvironment.adminExpirationDays else apiKeyEnvironment.expirationDays
         val expiresAt = now.plusDays(expirationDays)
         val isScopeChanged = apiKey.scopes != reqDto.scopes
+        val isDescriptionChanged = apiKey.description != reqDto.description
         val oldValue = apiKey.value
         apiKey.apply {
             updatedAt = now
             this.expiresAt = expiresAt
             this.description = reqDto.description
-            if (isScopeChanged) {
+            if (isScopeChanged || isDescriptionChanged) {
                 value = UUID.randomUUID()
-                updateScopes(reqDto.scopes)
+                if (isScopeChanged) {
+                    updateScopes(reqDto.scopes)
+                }
                 logger().info(
-                    "API Key reissued due to scope change: accountId=${account.id}, " +
-                        "oldKey=${oldValue.toString().take(8)}****, newKey=${value.toString().take(8)}****",
+                    "API Key reissued: accountId=${account.id}, " +
+                        "oldKey=${oldValue.toString().take(8)}****, newKey=${value.toString().take(8)}****, " +
+                        "scopeChanged=$isScopeChanged, descriptionChanged=$isDescriptionChanged",
                 )
             } else {
                 logger().info(


### PR DESCRIPTION
## 개요

API키의 설명이 수정될 때 해당 키가 완전히 재발급되도록 수정하였습니다.
## 본문

#67 이슈를 해결하기 위하여 작업하였습니다.
API키의 설명(`description`) 필드 값이 변경되었을 때 키를 완전히 재발급 받도록 하였습니다.
