### PR TITLE
[global] 공통 모듈의 Feign Client 인식 실패 문제 수정

### DIFF
--- a/datagsm-authorization/src/main/kotlin/team/themoment/datagsm/authorization/global/thirdparty/feign/config/FeignConfig.kt
+++ b/datagsm-authorization/src/main/kotlin/team/themoment/datagsm/authorization/global/thirdparty/feign/config/FeignConfig.kt
@@ -4,12 +4,12 @@ import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import team.themoment.datagsm.authorization.global.thirdparty.feign.error.FeignErrorDecoder
+import team.themoment.datagsm.common.global.thirdparty.feign.discord.DiscordWebhookClient
 
 @Configuration
 @EnableFeignClients(
-    basePackages = [
-        "team.themoment.datagsm.authorization.global.thirdparty.feign",
-        "team.themoment.datagsm.common.global.thirdparty.feign",
+    basePackageClasses = [
+        DiscordWebhookClient::class,
     ],
 )
 class FeignConfig {

--- a/datagsm-resource/src/main/kotlin/team/themoment/datagsm/resource/global/thirdparty/feign/config/FeignConfig.kt
+++ b/datagsm-resource/src/main/kotlin/team/themoment/datagsm/resource/global/thirdparty/feign/config/FeignConfig.kt
@@ -3,13 +3,15 @@ package team.themoment.datagsm.resource.global.thirdparty.feign.config
 import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import team.themoment.datagsm.common.global.thirdparty.feign.discord.DiscordWebhookClient
 import team.themoment.datagsm.resource.global.thirdparty.feign.error.FeignErrorDecoder
+import team.themoment.datagsm.resource.global.thirdparty.feign.neis.NeisApiClient
 
 @Configuration
 @EnableFeignClients(
-    basePackages = [
-        "team.themoment.datagsm.resource.global.thirdparty.feign",
-        "team.themoment.datagsm.common.global.thirdparty.feign",
+    basePackageClasses = [
+        NeisApiClient::class,
+        DiscordWebhookClient::class,
     ],
 )
 class FeignConfig {

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/global/thirdparty/feign/config/FeignConfig.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/global/thirdparty/feign/config/FeignConfig.kt
@@ -3,13 +3,13 @@ package team.themoment.datagsm.web.global.thirdparty.feign.config
 import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import team.themoment.datagsm.common.global.thirdparty.feign.discord.DiscordWebhookClient
 import team.themoment.datagsm.web.global.thirdparty.feign.error.FeignErrorDecoder
 
 @Configuration
 @EnableFeignClients(
-    basePackages = [
-        "team.themoment.datagsm.web.global.thirdparty.feign",
-        "team.themoment.datagsm.common.global.thirdparty.feign",
+    basePackageClasses = [
+        DiscordWebhookClient::class,
     ],
 )
 class FeignConfig {


### PR DESCRIPTION
## 개요

  `common` 모듈의 Feign Client가 스캔되지 않아 발생하는 애플리케이션 구동 오류를 해결했습니다. 각 모듈의 Feign 설정에 `common` 모듈 패키지를 추가하여 빈이 정상적으로 등록되도록
  수정했습니다.

  ## 본문

  애플리케이션 시작 시 `DiscordWebhookClient` 빈을 찾을 수 없어 다음과 같은 오류가 발생했습니다.
```
    1 ***************************
    2 APPLICATION FAILED TO START
    3 ***************************
    4 
    5 Description:
    6 
    7 Parameter 0 of constructor in team.themoment.datagsm.common.global.common.discord.error.DiscordErrorNotificationService required a bean of type
      'team.themoment.datagsm.common.global.thirdparty.feign.discord.DiscordWebhookClient' that could not be found.
    8 
    9 
   10 Action:
   11 
   12 Consider defining a bean of type 'team.themoment.datagsm.common.global.thirdparty.feign.discord.DiscordWebhookClient' in your configuration.
```
  `DiscordWebhookClient`는 `datagsm-common` 모듈에 정의되어 있으나, 각 서비스(`authorization`, `resource`, `web`)의 `@EnableFeignClients` 설정이 해당 서비스의 패키지만 스캔하도록 제한되어 있어 빈으로
  등록되지 않았습니다.

  이를 해결하기 위해 모든 서비스의 FeignConfig 파일에서 basePackages 설정에 `team.themoment.datagsm.common.global.thirdparty.feign` 경로를 추가했습니다.
