### PR TITLE
[neis] 시각 관련 필드에 불필요해진 어노테이션 적용 제거

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/neis/dto/meal/response/MealResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/neis/dto/meal/response/MealResDto.kt
@@ -1,6 +1,5 @@
 package team.themoment.datagsm.common.domain.neis.dto.meal.response
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import team.themoment.datagsm.common.domain.neis.meal.entity.constant.MealType
 import java.time.LocalDate
@@ -18,7 +17,6 @@ data class MealResDto(
     @param:Schema(description = "시도교육청명", example = "광주광역시교육청")
     val officeName: String,
     @param:Schema(description = "급식 날짜", example = "2025-12-15")
-    @param:JsonFormat(pattern = "yyyy-MM-dd")
     val mealDate: LocalDate,
     @param:Schema(description = "급식 타입 (BREAKFAST, LUNCH, DINNER)", example = "LUNCH")
     val mealType: MealType,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/neis/dto/schedule/response/ScheduleResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/neis/dto/schedule/response/ScheduleResDto.kt
@@ -1,6 +1,5 @@
 package team.themoment.datagsm.common.domain.neis.dto.schedule.response
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
@@ -17,7 +16,6 @@ data class ScheduleResDto(
     @param:Schema(description = "시도교육청명", example = "광주광역시교육청")
     val officeName: String,
     @param:Schema(description = "학사일정 날짜", example = "2025-12-15")
-    @param:JsonFormat(pattern = "yyyy-MM-dd")
     val scheduleDate: LocalDate,
     @param:Schema(description = "학년도", example = "2025")
     val academicYear: String,


### PR DESCRIPTION
## 개요

NEIS 관련 데이터 응답 시 시각 관련 필드의 정규화를 위해 사용하였던 어노테이션을 제거하였습니다.
## 본문

#81 에서 Spring Boot의 버전을 4.0.0으로 변경하였습니다. 그에 따라 Jackson의 기본 동작이 변경되어 이제 추가 설정 없이 기본적으로 ISO 8601 형식으로 포맷팅 되어 직렬화 됩니다.이에 따라 불필요한 중복 설정이라 판단하여 기존 어노테이션을 제거하였습니다.

<img width="705" height="476" alt="image" src="https://github.com/user-attachments/assets/702345fc-e7ad-4d14-9695-b92dfcf2d8d9" />


- #55 
