### PR TITLE
[global] 더 이상 사용되지 않는 ConfigurationPropertiesScan 삭제

### DIFF
--- a/datagsm-authorization/src/main/kotlin/team/themoment/datagsm/authorization/global/config/PropertiesScanConfig.kt
+++ b/datagsm-authorization/src/main/kotlin/team/themoment/datagsm/authorization/global/config/PropertiesScanConfig.kt
@@ -1,6 +1,5 @@
 package team.themoment.datagsm.authorization.global.config
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import team.themoment.datagsm.common.global.data.ApiKeyEnvironment
@@ -10,11 +9,6 @@ import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.common.global.data.OauthJwtEnvironment
 
 @Configuration
-@ConfigurationPropertiesScan(
-    basePackages = [
-        "team.themoment.datagsm.authorization.global.security.data",
-    ],
-)
 @EnableConfigurationProperties(
     ApiKeyEnvironment::class,
     CorsEnvironment::class,

--- a/datagsm-resource/src/main/kotlin/team/themoment/datagsm/resource/global/config/PropertiesScanConfig.kt
+++ b/datagsm-resource/src/main/kotlin/team/themoment/datagsm/resource/global/config/PropertiesScanConfig.kt
@@ -1,6 +1,5 @@
 package team.themoment.datagsm.resource.global.config
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import team.themoment.datagsm.common.global.data.ApiKeyEnvironment
@@ -8,12 +7,6 @@ import team.themoment.datagsm.common.global.data.CorsEnvironment
 import team.themoment.datagsm.common.global.data.NeisEnvironment
 
 @Configuration
-@ConfigurationPropertiesScan(
-    basePackages = [
-        "team.themoment.datagsm.resource.global.security.data",
-        "team.themoment.datagsm.resource.domain.neis.common.data",
-    ],
-)
 @EnableConfigurationProperties(
     ApiKeyEnvironment::class,
     CorsEnvironment::class,

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/global/config/PropertiesScanConfig.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/global/config/PropertiesScanConfig.kt
@@ -1,6 +1,5 @@
 package team.themoment.datagsm.web.global.config
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import team.themoment.datagsm.common.global.data.ApiKeyEnvironment
@@ -8,12 +7,6 @@ import team.themoment.datagsm.common.global.data.CorsEnvironment
 import team.themoment.datagsm.common.global.data.InternalJwtEnvironment
 
 @Configuration
-@ConfigurationPropertiesScan(
-    basePackages = [
-        "team.themoment.datagsm.web.global.security.data",
-        "team.themoment.datagsm.web.global.security.jwt",
-    ],
-)
 @EnableConfigurationProperties(
     ApiKeyEnvironment::class,
     CorsEnvironment::class,


### PR DESCRIPTION
## 개요

더 이상 사용되지 않지만, conflict 해결 착오로 인해 남아있던 ConfigurationPropertiesScan을 삭제하였습니다.

## 본문

ConfigurationPropertiesScan 대신 EnableConfigurationProperties를 사용하여 명시적으로 Properties를 가져옵니다.
