### PR TITLE
[ci/cd] 상용환경 배포 시 저장공간 확보 단계 추가

### DIFF
--- a/scripts/prod-deploy.sh
+++ b/scripts/prod-deploy.sh
@@ -10,4 +10,7 @@ docker compose -f compose.prod.yaml down >> /home/ec2-user/deploy.log 2>&1
 echo "> Building and starting containers..." >> /home/ec2-user/deploy.log
 docker compose -f compose.prod.yaml up -d --build >> /home/ec2-user/deploy.log 2>&1
 
+echo "> Cleaning up unused Docker resources..."
+docker system prune -a --volumes -f
+
 echo "> Deployment completed successfully" >> /home/ec2-user/deploy.log


### PR DESCRIPTION
## 개요

개발환경 배포와 동일하게 상용환경 인스턴스의 저장공간을 확보할 수 있는 단계를 추가하였습니다.

## 본문

공격적으로 Docker 관련 파일을 정리하도록 명령어
```sh
docker system prune -a --volumes -f
```
를 추가하였습니다.

다소 위험한 명령어지만 상용환경 인스턴스에서 예기치 못한 삭제를 유발할 가능성이 거의 없으며 Redis 컨테이너와 볼륨이 만에하나 삭제된다 하더라도 치명적이지 않은 데이터들이기에 강한 명령어를 적용하였습니다.
