### PR TITLE
[docs] 횡단 관심사 처리를 위한 Claude Code Slash Command 지침 수정

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -3,21 +3,23 @@ description: Create Git commits by splitting changes into logical units
 ---
 
 Create Git commits following these rules:
+
 - Follow commit message format: `type(scope): description`
-  - Types: add/update/fix/refactor/test/docs/merge
-  - Scopes: ONLY domain names (auth, account, student, club, project, neis, client, oauth) OR global. No other scopes allowed.
-  - Description: Korean, lowercase start, no period, avoid noun-ending style (e.g., "~ 추가", "~ 수정")
+    - Types: add/update/fix/refactor/test/docs/merge
+    - Scopes: ONLY domain names (auth, account, student, club, project, neis, client, oauth) OR module names (web, authorization, resource) OR global. No other scopes allowed.
+    - Description: Korean, lowercase start, no period, avoid noun-ending style (e.g., "~ 추가", "~ 수정")
 - Use subject line only (no commit body)
 - Do NOT add Claude as co-author
 - Split changes into appropriate logical units with multiple commits
 - Each commit should have a single responsibility
 
 Steps:
+
 1. Check changes with `git status` and `git diff`
 2. Categorize changes into logical units (e.g., feature addition, bug fix, refactoring)
 3. Group files by each unit
 4. For each group:
-   - Stage only relevant files with `git add`
-   - Write concise commit message following conventions (subject only)
-   - Execute `git commit -m "message"`
+    - Stage only relevant files with `git add`
+    - Write concise commit message following conventions (subject only)
+    - Execute `git commit -m "message"`
 5. Verify results with `git log --oneline -n [number of commits]`


### PR DESCRIPTION
## 개요

모듈명을 scopes에 사용할 수 있게 Claude 지침을 수정하였습니다.

## 본문
Claude Code에서 사용 가능한 Slash Command 중 `/commit` 명령어의 지침을 수정하여 횡단 관심사 처리를 위한 모듈명 사용을 허가하였습니다.
