### PR TITLE
[global] Jackson 신규 버전과 호환되지 않던 종속성 설정 수정

### DIFF
--- a/buildSrc/src/main/kotlin/dependency/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependency/Dependencies.kt
@@ -2,6 +2,7 @@ package dependency
 
 import dependency.DependencyVersions.AWS_SDK_VERSION
 import dependency.DependencyVersions.BUCKET4J_VERSION
+import dependency.DependencyVersions.JACKSON_VERSION
 import dependency.DependencyVersions.JJWT_VERSION
 import dependency.DependencyVersions.KOTEST_VERSION
 import dependency.DependencyVersions.KOTLIN_COROUTINES_VERSION
@@ -73,10 +74,10 @@ object Dependencies {
     // Kotlin
     const val KOTLIN_REFLECT = "org.jetbrains.kotlin:kotlin-reflect"
     const val KOTLIN_COROUTINES = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${KOTLIN_COROUTINES_VERSION}"
-    const val JACKSON_KOTLIN = "com.fasterxml.jackson.module:jackson-module-kotlin"
+    const val JACKSON_KOTLIN = "tools.jackson.module:jackson-module-kotlin:${JACKSON_VERSION}"
 
     // Jackson
-    const val JACKSON_DATABIND = "com.fasterxml.jackson.core:jackson-databind"
+    const val JACKSON_DATABIND = "tools.jackson.core:jackson-databind"
 
     // AWS SDK
     const val AWS_CLOUDWATCH_LOGS = "software.amazon.awssdk:cloudwatchlogs"

--- a/buildSrc/src/main/kotlin/dependency/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/dependency/DependencyVersions.kt
@@ -23,4 +23,6 @@ object DependencyVersions {
     const val BUCKET4J_VERSION = "8.16.0"
 
     const val POI_VERSION = "5.5.1"
+
+    const val JACKSON_VERSION = "3.0.3"
 }


### PR DESCRIPTION
## 개요

Spring Boot 4.0.0 업그레이드 후 발생한 Jackson 버전 불일치 문제를 해결하기 위해 jackson-module-kotlin을 3.0.3으로 업그레이드했습니다. 이로 인해 이메일 전송 API에서 발생하던 400 "Invalid request body format" 에러가 해결되었습니다.

## 본문

### 문제 상황

이메일 전송 API(`POST /v1/account/email/send`)에 정상적인 요청을 보냈음에도 불구하고 400 에러가 발생했습니다.

```json
// 요청
{
  "email": "datagsm.oauth@gmail.com"
}

// 응답
{
  "code": 400,
  "message": "Invalid request body format",
  "status": "400 BAD_REQUEST"
}
```

서버 로그를 확인한 결과, 다음과 같은 Jackson 역직렬화 에러가 발생했습니다:

```
JSON parse error: Cannot construct instance of `team.themoment.datagsm.common.domain.account.dto.request.SendEmailReqDto`
(although at least one Creator exists): cannot deserialize from Object value (no delegate- or property-based Creator)
```

### 원인 분석

Spring Boot 4.0.0으로 업그레이드하면서 **Jackson 라이브러리가 2.x에서 3.x로 버전 변경**이 되었습니다.

**의존성 트리**
- Spring Boot 4.0.0이 사용하는 Jackson: `tools.jackson.core:jackson-databind:3.0.2` (Jackson 3.x)
- 프로젝트의 jackson-module-kotlin: `com.fasterxml.jackson.module:jackson-module-kotlin:2.20.1` (Jackson 2.x)

**문제 원인**
Jackson 2.x와 3.x는 패키지명이 다릅니다:
- Jackson 2.x: `com.fasterxml.jackson.*`
- Jackson 3.x: `tools.jackson.*`

이로 인해 jackson-module-kotlin 2.x가 Jackson 3.x 환경에서 제대로 동작하지 않아, Kotlin data class를 역직렬화할 수 없었습니다.

### 해결

jackson-module-kotlin을 Jackson 3.x 호환 버전으로 업그레이드했습니다.

**변경 내용**

1. `DependencyVersions.kt`에 Jackson 버전 추가:
```kotlin
const val JACKSON_VERSION = "3.0.3"
```

2. `Dependencies.kt`에서 Jackson 의존성 업데이트:
```kotlin
// Before
const val JACKSON_KOTLIN = "com.fasterxml.jackson.module:jackson-module-kotlin"
const val JACKSON_DATABIND = "com.fasterxml.jackson.core:jackson-databind"

// After
const val JACKSON_KOTLIN = "tools.jackson.module:jackson-module-kotlin:${JACKSON_VERSION}"
const val JACKSON_DATABIND = "tools.jackson.core:jackson-databind"
```

### 참고

- [Jackson 3.0 Migration Guide](https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0)
