### PR TITLE
[account] 이메일 인증 API에서 누락된 어노테이션 복구

### DIFF
--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/controller/AccountController.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/controller/AccountController.kt
@@ -53,7 +53,7 @@ class AccountController(
             ApiResponse(responseCode = "404", description = "인증 코드를 찾을 수 없음 / 코드 불일치", content = [Content()]),
         ],
     )
-    @GetMapping("/email/check")
+    @PostMapping("/email/check")
     fun checkEmail(
         @RequestBody @Valid reqDto: EmailCodeReqDto,
     ): CommonApiResponse<Nothing> {


### PR DESCRIPTION
## 개요
`POST /v1/account/email/check` API에서 누락된 어노테이션이 있어 복구작업을 하였습니다.

## 본문

`POST /v1/account/email/check` API에서 요청 본문임에도 `@RequestBody` 어노테이션이 누락되어 있어 이를 추가하였습니다.
