### PR TITLE
[account] 인증코드의 자릿수가 일정하지 않던 문제 해결

### DIFF
--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/SendEmailServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/SendEmailServiceImpl.kt
@@ -13,6 +13,7 @@ import team.themoment.datagsm.web.global.security.annotation.EmailRateLimitType
 import team.themoment.datagsm.web.global.security.annotation.EmailRateLimited
 import team.themoment.sdk.exception.ExpectedException
 import java.security.SecureRandom
+import kotlin.math.pow
 
 @Service
 class SendEmailServiceImpl(
@@ -22,6 +23,8 @@ class SendEmailServiceImpl(
 ) : SendEmailService {
     companion object {
         private val secureRandom = SecureRandom()
+        private const val EMAIL_CODE_LENGTH = 8
+        private val EMAIL_RANDOM_MAX = 10.0.pow(EMAIL_CODE_LENGTH).toInt()
     }
 
     @EmailRateLimited(type = EmailRateLimitType.SEND_EMAIL)
@@ -58,5 +61,5 @@ class SendEmailServiceImpl(
         }
     }
 
-    private fun generateCode(): String = secureRandom.nextInt(0, 100000000).toString().padStart(6, '0')
+    private fun generateCode(): String = secureRandom.nextInt(0, EMAIL_RANDOM_MAX).toString().padStart(EMAIL_CODE_LENGTH, '0')
 }


### PR DESCRIPTION
## 개요

인증코드의 자릿수가 일정하지 않던 문제를 해결했습니다.

## 본문

기존에 자릿수를 늘리기 위해 random max 값은 올렸지만, pad 함수 값 수정을 빼먹어 문제가 발생하였습니다.
pad에도 동일한 길이가 적용되도록 하였고, 재발 방지를 위하여 companion object에서 길이에 대한 값을 담도록 바꾸었습니다.
