### PR TITLE
[global] Swagger에서 공통 응답이 보이지 않던 문제 수정

### DIFF
--- a/buildSrc/src/main/kotlin/dependency/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/dependency/DependencyVersions.kt
@@ -16,7 +16,7 @@ object DependencyVersions {
     const val AWS_SDK_VERSION = "2.41.2"
 
     const val PEANUT_BUTTER_VERSION = "1.4.1"
-    const val THE_MOMENT_THE_SDK_VERSION = "1.0-RC1"
+    const val THE_MOMENT_THE_SDK_VERSION = "1.0"
 
     const val KOTLIN_COROUTINES_VERSION = "1.10.2"
 


### PR DESCRIPTION
## 개요

Swagger에서 
```json
{
  "status": "OK",
  "code": 200,
  "message": "OK",
  "data": <T object>
 
}
```
다음 구조가 보이지 않았던 것을 수정하였습니다.

## 본문

멀티모듈화 작업(#81)에서 더모먼트팀의 서버 애플리케이션에서 공통적으로 사용되는 기능(`CommonApiResponse`,`LoggingFilter`, `SwaggerConfig` 등)들을 SDK로 추상화하여 Spring Starter 형태로 제공하도록 변경하였습니다. 이때 HTTP 요청/응답 로깅과 공통 응답 형식 래핑 등은 의도한 동작을 하였지만 Swagger에서 `CommonApiResponse`를 제대로 표현하지 못하였습니다.
```json
{
  "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
  "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
}
```
이것을 [the-sdk 1.0](https://github.com/themoment-team/the-sdk/releases/tag/1.0)에서 해결하여 DataGSM의 `the-sdk` 종속성을 변경하였습니다.
이제 Swagger에서 다음과 같이 잘 표현됩니다.
```json
{
  "status": "OK",
  "code": 200,
  "message": "OK",
  "data": {
    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
  }
}
```