### PR TITLE
[auth] API 키 검색 시 권한범위 조건에 대한 문제 수정

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/auth/repository/custom/impl/ApiKeyJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/auth/repository/custom/impl/ApiKeyJpaCustomRepositoryImpl.kt
@@ -70,7 +70,7 @@ class ApiKeyJpaCustomRepositoryImpl(
                                 "JSON_CONTAINS({0}, {1})",
                                 apiKey.scopes,
                                 Expressions.constant(objectMapper.writeValueAsString(scopeValue)),
-                            ).eq(Integer.valueOf(1))
+                            ).eq(1)
                     },
                     isExpired?.let {
                         if (it) apiKey.expiresAt.before(now) else apiKey.expiresAt.after(now)


### PR DESCRIPTION
## 개요
API 키 검색을 수행할 때 권한범위 조건절을 이용하면 예외가 발생하던 문제를 수정하였습니다.
## 본문
현재 #102 에서 작업된 권한범위 검색 방식을 사용하고 있었는데 해당 방식은 옮은 접근이긴 하였지만 `JSON_CONTAIN` 절을 Hibernate에서 조건절로 인식하지 못하는 문제가 있었습니다. 해당 문제를 조건절의 반환값을 정수로 변환후 Boolean으로 인식할 수 있도록 로직을 변경하여 문제를 해결하였습니다.