### PR TITLE
[ci/cd] GitHub Actions CI/CD 순차 실행 및 동시 CD 방지 설정

### DIFF
--- a/.github/workflows/datagsm-prod-cd.yaml
+++ b/.github/workflows/datagsm-prod-cd.yaml
@@ -17,7 +17,7 @@ jobs:
   CD:
     runs-on: ubuntu-latest
     environment: prod
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6

--- a/.github/workflows/datagsm-stage-cd.yaml
+++ b/.github/workflows/datagsm-stage-cd.yaml
@@ -17,7 +17,7 @@ jobs:
   CD:
     runs-on: ubuntu-latest
     environment: stage
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6


### PR DESCRIPTION
 ## 개요                                                                                                                                                         
                                                                                                                                                                  
  GitHub Actions에서 CI 성공 후에만 CD가 실행되도록 하고, 동시에 여러 CD가 실행될 경우 최신 배포만 진행되도록 concurrency 설정을 추가했습니다.                    
                                                                                                                                                                  
  ## 본문                                                                                                                                                         
                                                                                                                                                                  
  ### 문제점                                                                                                                                                      
  1. **CD 동시 실행 문제**: 동일 브랜치에 빠르게 연속으로 커밋이 푸시되면 여러 CD가 동시에 실행되어 배포 순서가 뒤바뀔 위험이 있음                                
  2. **CI-CD 독립 실행 문제**: CI와 CD가 독립적으로 실행되어 CI 실패 여부와 관계없이 CD가 실행됨                                                                  
                                                                                                                                                                  
  ### 해결 방안                                                                                                                                                   
                                                                                                                                                                  
  #### 1. `concurrency` 설정으로 동시 CD 실행 방지                                                                                                                
  - 동일 브랜치의 CD가 실행 중일 때 새로운 CD가 트리거되면 이전 CD를 취소하고 최신 CD만 실행                                                                      
  - Discord 알림에 취소 케이스 추가하여 팀에 알림                                                                                                                 
                                                                                                                                                                  
  #### 2. `workflow_run` 트리거로 CI 성공 후에만 CD 실행                                                                                                          
  - CD 트리거를 `push`에서 `workflow_run`으로 변경                                                                                                                
  - CI 워크플로우가 완료되고 성공했을 때만 CD 실행                                                                                                                
  - **중요**: `github.event.workflow_run.event == 'push'` 조건 추가로 PR의 CI 성공 시에는 CD가 실행되지 않도록 함                                                 
                                                                                                                                                                  
  ### 변경 사항                                                                                                                                                   
                                                                                                                                                                  
  **대상 파일:**                                                                                                                                                  
  - `.github/workflows/datagsm-prod-cd.yaml`                                                                                                                      
  - `.github/workflows/datagsm-stage-cd.yaml`                                                                                                                     
                                                                                                                                                                  
  **주요 변경:**                                                                                                                                                  
  1. `on` 트리거를 `workflow_run`으로 변경                                                                                                                        
  2. `concurrency` 설정 추가 (`cancel-in-progress: true`)                                                                                                         
  3. CD job에 조건 추가: `if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}`                              
  4. Discord 취소 알림 추가                                                                                                                                       
                                                                                                                                                                  
  ### 실행 흐름                                                                                                                                                   
                                                                                                                                                                  
  **변경 전:**                                                                                                                                                    
  develop/master 브랜치에 push                                                                                                                                    
    ├─ CI 워크플로우 실행 (병렬)                                                                                                                                  
    └─ CD 워크플로우 실행 (병렬)                                                                                                                                  
                                                                                                                                                                  
  **변경 후:**                                                                                                                                                    
  develop/master 브랜치에 push                                                                                                                                    
    └─ CI 워크플로우 실행                                                                                                                                         
        └─ (성공 시) CD 워크플로우 실행                                                                                                                           
            └─ 동시 실행 시 이전 CD 취소, 최신만 실행                                                                                                             
                                                                                                                                                                  
  PR의 CI 실행                                                                                                                                                    
    └─ CD 실행 안 됨 (push 이벤트가 아니므로)                                                                                                                     
                                                                                                                                                                  
  ### 주의사항                                                                                                                                                    
                                                                                                                                                                  
  **⚠️ 중요**: `workflow_run` 트리거는 **기본 브랜치(master)에 병합된 워크플로우 정의**를 사용합니다.                                                     
                                                                                                                                                                  
  따라서:                                                                                                                                                         
  1. 이 PR을 master에 병합해야 설정이 적용됩니다                                                                                                          
  2. CD를 수동으로 `workflow_dispatch`로 실행하면 CI를 거치지 않았기 때문에 job이 skip됩니다                                                                      
  3. CI를 실행해야 CD가 트리거됩니다                                                                                                                              
                                                                                                                                                                      