### PR TITLE
[ci/cd] CD 실행시 checkout 대상 브랜치가 제대로 설정되지 않던 문제 해결

### DIFF
--- a/.github/workflows/datagsm-prod-cd.yaml
+++ b/.github/workflows/datagsm-prod-cd.yaml
@@ -8,6 +8,12 @@ on:
     branches:
       - 'master'
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy'
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,6 +27,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || 'master' }}
 
       - name: Setup JDK 25
         uses: actions/setup-java@v5

--- a/.github/workflows/datagsm-stage-cd.yaml
+++ b/.github/workflows/datagsm-stage-cd.yaml
@@ -8,6 +8,12 @@ on:
     branches:
       - 'develop'
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy'
+        required: false
+        default: 'develop'
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,6 +27,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || 'develop' }}
 
       - name: Setup JDK 25
         uses: actions/setup-java@v5


### PR DESCRIPTION
## 개요

CD 실행시 checkout 대상 브랜치가 제대로 설정되지 않던 문제를 해결했습니다.

## 본문

#124 에서 CD의 실행 조건을 브랜치에 push 하는 것에서 CI workflow가 끝나는 것으로 변경되었고,
push 한 브랜치를 기준으로 자동으로 해당 브랜치에 checkout 할 수 없게 되어 [Actions](https://github.com/themoment-team/datagsm-server/actions/runs/21334343987) 처럼 develop 브랜치의 CI/CD 임에도 기본 브랜치인 main에 checkout하는 문제가 발생하였습니다.

수동 실행시 workflow_dispatch input, 자동 실행시 workflow_run.head_branch에서 대상 브랜치를 가져오도록 하여 해당 문제를 해결하였습니다.

prod-cd에도 변경 사항이 있지만 나중에 병합하더라도 문제가 없는 사안이기에 따로 필요가 없다면 릴리즈를 작성하지 않아도 될 것 같습니다.