### PR TITLE
[global] `pr-draft` 커맨드 프롬프트 개선 및 출력 파일 `.gitignore` 추가

### DIFF
--- a/.claude/commands/pr-draft.md
+++ b/.claude/commands/pr-draft.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git log:*), Bash(git diff:*), Bash(git branch:*), Bash(gh pr:*), Read, Write
+allowed-tools: Bash(git log:*), Bash(git diff:*), Bash(git branch:*), Read, Write
 description: Generate PR body and title suggestions
 ---
 
@@ -9,19 +9,32 @@ description: Generate PR body and title suggestions
 - Commits diff from develop: !`git log develop..HEAD --oneline`
 - File changes stats from develop: !`git diff develop...HEAD --stat`
 - Detailed changes from develop: !`git diff develop...HEAD`
-- Recent PR title conventions: !`gh pr list --limit 10 --json title,headRefName --jq '.[] | "\(.headRefName): \(.title)"'`
-- PR template: !`cat .github/PULL_REQUEST_TEMPLATE.md`
+- PR template: Read `.github/PULL_REQUEST_TEMPLATE.md` file
+
+## PR Title Convention
+
+This project uses the following PR title format: `[scope] description`
+
+**Available Scopes:**
+- Domain names: auth, account, student, club, project, neis, client, oauth
+- Module names: web, authorization, resource, common
+- Others: ci/cd, global
+
+**Recent PR Title Examples:**
+- `[global] 기여자 지침 문서 추가`
+- `[global] 올바르지 않은 공개 API 경로 설정 수정`
+- `[student] 졸업생 전환 및 저장 기능 구현`
+- `[ci/cd] CD 파이프라인 ZIP 패키징 및 빌드 최적화`
+- `[client] 클라이언트 조회 시 페이지네이션 파라미터 추가`
 
 ## Your task
 
 Based on the above information, perform the following tasks:
 
 1. **PR Title Suggestions**:
-   - Suggest 3 appropriate titles based on recent PR title conventions
+   - Suggest 3 appropriate titles based on the convention above
    - Format: `[scope] description`
-   - Scopes: ONLY domain names (auth, account, student, club, project, neis, client, oauth) OR module names (web, authorization, resource, common) OR ci/cd OR global
    - Description: Korean, clear and concise
-   - Examples: `[global] 기여자 지침 문서 추가`, `[ci/cd] CD 파이프라인 최적화`, `[student] 졸업생 전환 및 저장 기능 구현`
    - No emojis
 
 2. **PR Body**:

--- a/.gemini/commands/pr-draft.toml
+++ b/.gemini/commands/pr-draft.toml
@@ -7,19 +7,32 @@ prompt = """Based on the following information, generate PR title suggestions an
 - Commits diff from develop: !{git log develop..HEAD --oneline}
 - File changes stats from develop: !{git diff develop...HEAD --stat}
 - Detailed changes from develop: !{git diff develop...HEAD}
-- Recent PR title conventions: !{gh pr list --limit 10 --json title,headRefName --jq '.[] | "\\(.headRefName): \\(.title)"'}
 - PR template: @{.github/PULL_REQUEST_TEMPLATE.md}
+
+## PR Title Convention
+
+This project uses the following PR title format: `[scope] description`
+
+**Available Scopes:**
+- Domain names: auth, account, student, club, project, neis, client, oauth
+- Module names: web, authorization, resource, common
+- Others: ci/cd, global
+
+**Recent PR Title Examples:**
+- `[global] 기여자 지침 문서 추가`
+- `[global] 올바르지 않은 공개 API 경로 설정 수정`
+- `[student] 졸업생 전환 및 저장 기능 구현`
+- `[ci/cd] CD 파이프라인 ZIP 패키징 및 빌드 최적화`
+- `[client] 클라이언트 조회 시 페이지네이션 파라미터 추가`
 
 ## Your task
 
-Perform the following tasks:
+Generate PR title suggestions and PR body following these rules:
 
 1. **PR Title Suggestions**:
-   - Suggest 3 appropriate titles based on recent PR title conventions
+   - Suggest 3 appropriate titles based on the convention above
    - Format: `[scope] description`
-   - Scopes: ONLY domain names (auth, account, student, club, project, neis, client, oauth) OR module names (web, authorization, resource, common) OR ci/cd OR global
    - Description: Korean, clear and concise
-   - Examples: `[global] 기여자 지침 문서 추가`, `[ci/cd] CD 파이프라인 최적화`, `[student] 졸업생 전환 및 저장 기능 구현`
    - No emojis
 
 2. **PR Body**:
@@ -30,24 +43,26 @@ Perform the following tasks:
    - Write in Korean
    - Be clear and specific
 
-3. **Output format**:
-   ```
-   ## 추천 PR 제목
+3. **Save to file**:
+   - Use the write_file tool to save the PR body to PR_BODY.md in the project root
+   - File path: PR_BODY.md (relative to current directory)
+   - This will overwrite the file if it already exists
 
-   1. [title1]
-   2. [title2]
-   3. [title3]
+4. **Output format**:
 
-   ## PR 본문
+First, output the title suggestions:
 
-   [generated PR body content following the template structure]
-   ```
+## 추천 PR 제목
 
-After generating the PR body, save it to PR_BODY.md in the project root directory by running:
+1. [title1]
+2. [title2]
+3. [title3]
 
-!{cat > PR_BODY.md << 'EOF'
-[generated PR body content]
-EOF}
+---
 
-Then show the user the title suggestions and body preview.
+Then use write_file tool to save the PR body to PR_BODY.md and show a preview:
+
+## PR 본문 (PR_BODY.md에 저장됨)
+
+[preview of generated content]
 """

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ out/
 /datagsm-resource/src/main/resources/application-prod.yml
 /datagsm-web/src/main/resources/application-stage.yml
 /datagsm-web/src/main/resources/application-prod.yml
+
+### LLM Outputs ###
+PR_BODY.md


### PR DESCRIPTION
## 개요

`pr-draft` 커맨드의 프롬프트를 개선하여 더 정확한 PR 제목과 본문을 생성하도록 수정하고, 생성된 본문을 `PR_BODY.md` 파일로 저장하는 기능을 추가했습니다. 또한 `gh` CLI 의존성을 제거하고 PR 제목 컨벤션을 프롬프트에 직접 명시하여 안정성을 높였습니다.

## 본문

### 주요 변경 사항

- **프롬프트 개선**: `.claude/commands/pr-draft.md` 및 `.gemini/commands/pr-draft.toml` 파일의 프롬프트를 수정하여 PR 제목 컨벤션을 명확히 안내하고, 생성된 결과의 품질을 높였습니다.
- **gh CLI 의존성 제거**: 기존에 `gh pr list`를 통해 최근 PR 제목을 가져오던 방식을 제거하고, 프롬프트 내에 컨벤션 예시를 직접 포함시켰습니다. 이를 통해 `gh` CLI가 설치되지 않은 환경에서도 원활하게 동작합니다.
- **파일 저장 기능 추가**: 생성된 PR 본문을 터미널에 출력하는 것뿐만 아니라 `PR_BODY.md` 파일로 자동 저장하도록 변경했습니다.
- **.gitignore 업데이트**: 생성되는 `PR_BODY.md` 파일이 git에 추적되지 않도록 `.gitignore`에 추가했습니다.

### 상세 내용

- Claude 및 Gemini용 `pr-draft` 커맨드 설정 파일에서 `allowed-tools` 목록을 정리했습니다.
- 프롬프트 내에 프로젝트의 PR 제목 컨벤션(Scope 및 예시)을 명시적으로 작성했습니다.
- `write_file` 도구를 사용하여 결과를 파일로 저장하는 로직을 프롬프트에 포함시켰습니다.