### PR TITLE
[openapi] OpenAPI 모듈 CORS 정책 변경 및 미사용 설정 제거

### DIFF
--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/global/config/PropertiesScanConfig.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/global/config/PropertiesScanConfig.kt
@@ -3,13 +3,11 @@ package team.themoment.datagsm.openapi.global.config
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import team.themoment.datagsm.common.global.data.ApiKeyEnvironment
-import team.themoment.datagsm.common.global.data.CorsEnvironment
 import team.themoment.datagsm.common.global.data.NeisEnvironment
 
 @Configuration
 @EnableConfigurationProperties(
     ApiKeyEnvironment::class,
-    CorsEnvironment::class,
     NeisEnvironment::class,
 )
 class PropertiesScanConfig

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/global/security/config/CorsConfig.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/global/security/config/CorsConfig.kt
@@ -6,20 +6,17 @@ import org.springframework.http.HttpMethod
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
-import team.themoment.datagsm.common.global.data.CorsEnvironment
 
 @Configuration
-class CorsConfig(
-    private val corsEnvironment: CorsEnvironment,
-) {
+class CorsConfig {
     @Bean
     fun configure(): CorsConfigurationSource {
         val configuration =
             CorsConfiguration().apply {
-                allowedOrigins = corsEnvironment.allowedOrigins
+                allowedOrigins = listOf("*")
                 allowedMethods = HttpMethod.values().map(HttpMethod::name)
                 addAllowedHeader("*")
-                allowCredentials = true
+                allowCredentials = false
             }
 
         return UrlBasedCorsConfigurationSource().apply {

--- a/datagsm-openapi/src/main/resources/application.yml
+++ b/datagsm-openapi/src/main/resources/application.yml
@@ -39,9 +39,6 @@ spring:
         office-code: ${NEIS_OFFICE_CODE:F10}
         school-code: ${NEIS_SCHOOL_CODE:7380292}
   security:
-    cors:
-      allowed-origins:
-        - ${CORS_ALLOWED_ORIGINS:*}
     api-key:
       expiration-days: 30
       renewal-period-days: 15


### PR DESCRIPTION
## 개요

OpenAPI 모듈의 CORS 설정을 변경하여 모든 Origin을 허용하도록 수정하고, 불필요해진 환경변수 설정을 제거했습니다.

## 본문

- `CorsConfig`에서 `allowedOrigins`를 와일드카드(`*`)로 변경하여 모든 도메인에서의 요청을 허용했습니다.
- `allowCredentials`를 `false`로 설정했습니다.
- 더 이상 사용하지 않는 `CorsEnvironment` 클래스 의존성을 `PropertiesScanConfig` 및 `CorsConfig`에서 제거했습니다.
- `application.yml`에서 불필요한 CORS 관련 설정 값을 삭제했습니다.