### PR TITLE
[global] 예외 발생 시 응답 타입 표준화

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/common/error/GlobalExceptionHandler.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/common/error/GlobalExceptionHandler.kt
@@ -52,9 +52,7 @@ class GlobalExceptionHandler(
     fun expectedException(ex: ExpectedException): ResponseEntity<CommonApiResponse<Nothing>> {
         logger().warn("ExpectedException : {} ", ex.message)
         logger().trace("ExpectedException Details : ", ex)
-        return ResponseEntity
-            .status(ex.statusCode)
-            .body(CommonApiResponse.error(ex.message ?: "An error occurred", ex.statusCode))
+        return createErrorResponse(ex.statusCode, ex.message ?: "An error occurred")
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
@@ -72,45 +70,35 @@ class GlobalExceptionHandler(
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse)
         }
 
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(CommonApiResponse.error(methodArgumentNotValidExceptionToJson(ex), HttpStatus.BAD_REQUEST))
+        return createErrorResponse(HttpStatus.BAD_REQUEST, methodArgumentNotValidExceptionToJson(ex))
     }
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun httpMessageNotReadableException(ex: HttpMessageNotReadableException): ResponseEntity<CommonApiResponse<Nothing>> {
         logger().warn("Invalid Request Body : {}", ex.message)
         logger().trace("Invalid Request Body Details : ", ex)
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(CommonApiResponse.error("Invalid request body format", HttpStatus.BAD_REQUEST))
+        return createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request body format")
     }
 
     @ExceptionHandler(ConstraintViolationException::class)
     fun validationException(ex: ConstraintViolationException): ResponseEntity<CommonApiResponse<Nothing>> {
         logger().warn("field validation failed : {}", ex.message)
         logger().trace("field validation failed : ", ex)
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(CommonApiResponse.error("field validation failed : ${ex.message}", HttpStatus.BAD_REQUEST))
+        return createErrorResponse(HttpStatus.BAD_REQUEST, "field validation failed : ${ex.message}")
     }
 
     @ExceptionHandler(AuthorizationDeniedException::class, AccessDeniedException::class)
     fun authorizationDeniedException(ex: Exception): ResponseEntity<CommonApiResponse<Nothing>> {
         logger().warn("Authorization Denied : {}", ex.message)
         logger().trace("Authorization Denied Details : ", ex)
-        return ResponseEntity
-            .status(HttpStatus.FORBIDDEN)
-            .body(CommonApiResponse.error("접근 권한이 부족합니다", HttpStatus.FORBIDDEN))
+        return createErrorResponse(HttpStatus.FORBIDDEN, "접근 권한이 부족합니다")
     }
 
     @ExceptionHandler(IllegalStateException::class)
     fun illegalStateException(ex: IllegalStateException): ResponseEntity<CommonApiResponse<Nothing>> {
         if (ex.message?.contains("creationTime key must not be null") == true) {
             logger().warn("Corrupted session detected, treating as invalid session: {}", ex.message)
-            return ResponseEntity
-                .status(HttpStatus.UNAUTHORIZED)
-                .body(CommonApiResponse.error("Session is invalid or expired", HttpStatus.UNAUTHORIZED))
+            return createErrorResponse(HttpStatus.UNAUTHORIZED, "Session is invalid or expired")
         }
         return unExpectedException(ex)
     }
@@ -130,33 +118,33 @@ class GlobalExceptionHandler(
                 ),
         )
 
-        return ResponseEntity
-            .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(CommonApiResponse.error("internal server error has occurred", HttpStatus.INTERNAL_SERVER_ERROR))
+        return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "internal server error has occurred")
     }
 
     @ExceptionHandler(NoHandlerFoundException::class)
     fun noHandlerFoundException(ex: NoHandlerFoundException): ResponseEntity<CommonApiResponse<Nothing>> {
         logger().warn("Not Found Endpoint : {}", ex.message)
         logger().trace("Not Found Endpoint Details : ", ex)
-        return ResponseEntity
-            .status(HttpStatus.NOT_FOUND)
-            .body(CommonApiResponse.error(ex.message ?: "Endpoint not found", HttpStatus.NOT_FOUND))
+        return createErrorResponse(HttpStatus.NOT_FOUND, ex.message ?: "Endpoint not found")
     }
 
     @ExceptionHandler(MaxUploadSizeExceededException::class)
     fun maxUploadSizeExceededException(ex: MaxUploadSizeExceededException): ResponseEntity<CommonApiResponse<Nothing>> {
         logger().warn("The file is too big : {}", ex.message)
         logger().trace("The file is too big Details : ", ex)
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(
-                CommonApiResponse.error(
-                    "The file is too big, limited file size : ${ex.maxUploadSize}",
-                    HttpStatus.BAD_REQUEST,
-                ),
-            )
+        return createErrorResponse(
+            HttpStatus.BAD_REQUEST,
+            "The file is too big, limited file size : ${ex.maxUploadSize}",
+        )
     }
+
+    private fun createErrorResponse(
+        status: HttpStatus,
+        message: String,
+    ): ResponseEntity<CommonApiResponse<Nothing>> =
+        ResponseEntity
+            .status(status)
+            .body(CommonApiResponse.error(message, status))
 
     private fun methodArgumentNotValidExceptionToJson(ex: MethodArgumentNotValidException): String {
         val result = mutableMapOf<String, Any>()


### PR DESCRIPTION
## 개요

`the-sdk`의 래핑 제외 설정이 적용된 API에서 예외 발생 시 HTTP 상태 코드가 `200 OK`로 반환되는 문제를 해결하기 위해 예외 핸들러의 응답 타입을 `ResponseEntity<>`로 전환했습니다.

## 본문

**GlobalExceptionHandler 리팩토링**:
- 모든 예외 핸들러의 반환 타입을 `ResponseEntity<CommonApiResponse<Nothing>>`으로 변경했습니다.
- 이를 통해 `the-sdk`의 `not-wrapping-urls` 설정이 적용된 엔드포인트에서도 예외 발생 시 HTTP 상태 코드가 응답 본문의 `code` 필드와 일치하도록 강제했습니다.