### PR TITLE
[global] LLM 프롬프트 최적화 및 가이드라인 문서 정리

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,11 +48,9 @@ DataGSM is a Spring Boot REST API service providing school information (students
 
 ### Query Parameter Binding (@RequestParam vs @ModelAttribute)
 
-**Guidelines:**
 - **1-2 simple parameters**: Use `@RequestParam`
 - **3+ parameters or validation required**: Use `@ModelAttribute` + DTO
 
-**Examples:**
 ```kotlin
 // 1-2 parameters → @RequestParam
 @GetMapping("/scopes")
@@ -61,37 +59,17 @@ fun getScopes(@RequestParam role: AccountRole): ApiScopeListResDto
 // 3+ parameters → @ModelAttribute + DTO
 @GetMapping("/students")
 fun getStudents(@Valid @ModelAttribute queryReq: QueryStudentReqDto): StudentListResDto
-
-data class QueryStudentReqDto(
-    @field:Positive @param:Schema(description = "Student ID")
-    val studentId: Long? = null,
-    @field:Min(0) @param:Schema(description = "Page", defaultValue = "0")
-    val page: Int = 0,
-    @field:Min(1) @field:Max(1000) @param:Schema(description = "Size", defaultValue = "300")
-    val size: Int = 300
-)
 ```
 
 ### DTO Variable Naming
 
-- **@RequestBody (Create/Update)**: Use `reqDto`
-- **@ModelAttribute (Query)**: Use `queryReq`
-
-```kotlin
-@PostMapping
-fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDto =
-    createStudentService.execute(reqDto)
-
-@GetMapping
-fun getStudents(@Valid @ModelAttribute queryReq: QueryStudentReqDto): StudentListResDto =
-    queryStudentService.execute(queryReq)
-```
+- **@RequestBody (Create/Update)**: Use `reqDto` → `service.execute(reqDto)`
+- **@ModelAttribute (Query)**: Use `queryReq` → `service.execute(queryReq)`
 
 ### Controller-Service Value Passing
 
-Pass request body/query DTO objects to service layer. PathVariable can be passed individually.
+Pass DTO objects to service layer as-is. PathVariable can be passed individually.
 
-**Correct Pattern:**
 ```kotlin
 @PostMapping
 fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDto =
@@ -100,13 +78,6 @@ fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDt
 @PutMapping("/{id}")
 fun updateStudent(@PathVariable id: Long, @Valid @RequestBody reqDto: UpdateStudentReqDto): StudentResDto =
     updateStudentService.execute(id, reqDto)
-```
-
-**Wrong Pattern:**
-```kotlin
-@PostMapping
-fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDto =
-    createStudentService.execute(reqDto.name, reqDto.email)  // Don't extract DTO fields
 ```
 
 ## Key Practices
@@ -127,8 +98,3 @@ fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDt
 - WRONG: `fix(web):` (module name) → CORRECT: `fix(auth):` (domain name)
 - Domain names first: auth, student, club, neis, oauth
 - Module names only for cross-cutting: global, ci/cd
-
-### Kotlin Style
-- WRONG: Overusing `var` → CORRECT: Prefer `val`
-- WRONG: Field injection → CORRECT: Constructor injection
-- WRONG: Excessive comments → CORRECT: Comment only non-obvious logic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,10 +21,7 @@ School information API server for Gwangju Software Meister High School (students
 - Build: `./gradlew build`
 - Test: `./gradlew test`
 - Format: `./gradlew ktlintFormat`
-- Run: `./gradlew :datagsm-oauth-authorization:bootRun`
-- Run: `./gradlew :datagsm-openapi:bootRun`
-- Run: `./gradlew :datagsm-oauth-userinfo:bootRun`
-- Run: `./gradlew :datagsm-web:bootRun`
+- Run: `./gradlew :<module>:bootRun` (modules: `datagsm-oauth-authorization`, `datagsm-openapi`, `datagsm-oauth-userinfo`, `datagsm-web`)
 
 ## Tech Stack
 
@@ -47,11 +44,9 @@ Kotlin, Spring Boot 4.0, Spring Data JPA, QueryDSL, Redis, MySQL
 
 ### Query Parameter Binding (@RequestParam vs @ModelAttribute)
 
-**Guidelines:**
 - **1-2 simple parameters**: Use `@RequestParam`
 - **3+ parameters or validation required**: Use `@ModelAttribute` + DTO
 
-**Examples:**
 ```kotlin
 // 1-2 parameters → @RequestParam
 @GetMapping("/scopes")
@@ -60,37 +55,17 @@ fun getScopes(@RequestParam role: AccountRole): ApiScopeListResDto
 // 3+ parameters → @ModelAttribute + DTO
 @GetMapping("/students")
 fun getStudents(@Valid @ModelAttribute queryReq: QueryStudentReqDto): StudentListResDto
-
-data class QueryStudentReqDto(
-    @field:Positive @param:Schema(description = "Student ID")
-    val studentId: Long? = null,
-    @field:Min(0) @param:Schema(description = "Page", defaultValue = "0")
-    val page: Int = 0,
-    @field:Min(1) @field:Max(1000) @param:Schema(description = "Size", defaultValue = "300")
-    val size: Int = 300
-)
 ```
 
 ### DTO Variable Naming
 
-- **@RequestBody (Create/Update)**: Use `reqDto`
-- **@ModelAttribute (Query)**: Use `queryReq`
-
-```kotlin
-@PostMapping
-fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDto =
-    createStudentService.execute(reqDto)
-
-@GetMapping
-fun getStudents(@Valid @ModelAttribute queryReq: QueryStudentReqDto): StudentListResDto =
-    queryStudentService.execute(queryReq)
-```
+- **@RequestBody (Create/Update)**: Use `reqDto` → `service.execute(reqDto)`
+- **@ModelAttribute (Query)**: Use `queryReq` → `service.execute(queryReq)`
 
 ### Controller-Service Value Passing
 
-Pass request body/query DTO objects to service layer. PathVariable can be passed individually.
+Pass DTO objects to service layer as-is. PathVariable can be passed individually.
 
-**Good:**
 ```kotlin
 @PostMapping
 fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDto =
@@ -99,13 +74,6 @@ fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDt
 @PutMapping("/{id}")
 fun updateStudent(@PathVariable id: Long, @Valid @RequestBody reqDto: UpdateStudentReqDto): StudentResDto =
     updateStudentService.execute(id, reqDto)
-```
-
-**Bad:**
-```kotlin
-@PostMapping
-fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDto =
-    createStudentService.execute(reqDto.name, reqDto.email)  // Don't extract DTO fields
 ```
 
 ## Common Mistakes
@@ -118,11 +86,6 @@ fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDt
 - WRONG: `fix(web):` (module name) → CORRECT: `fix(auth):` (domain name)
 - WRONG: `update(common):` → CORRECT: `update(student):`
 - Only use module names for cross-cutting concerns: `refactor(global):`, `update(ci/cd):`
-
-### Kotlin Style
-- WRONG: Overusing `var` → CORRECT: Prefer `val`
-- WRONG: Field injection → CORRECT: Constructor injection
-- WRONG: Excessive comments → CORRECT: Comment only non-obvious logic
 
 ## Context Compaction Rules
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -34,10 +34,7 @@ Each module follows: `controller/`, `service/`, `repository/`, `entity/`, `dto/`
 - Build: `./gradlew build`
 - Test: `./gradlew test`
 - Format: `./gradlew ktlintFormat`
-- Run: `./gradlew :datagsm-oauth-authorization:bootRun`
-- Run: `./gradlew :datagsm-openapi:bootRun`
-- Run: `./gradlew :datagsm-oauth-userinfo:bootRun`
-- Run: `./gradlew :datagsm-web:bootRun`
+- Run: `./gradlew :<module>:bootRun` (modules: `datagsm-oauth-authorization`, `datagsm-openapi`, `datagsm-oauth-userinfo`, `datagsm-web`)
 
 ## Coding Conventions
 
@@ -60,11 +57,9 @@ Each module follows: `controller/`, `service/`, `repository/`, `entity/`, `dto/`
 
 ### Query Parameter Binding (@RequestParam vs @ModelAttribute)
 
-**Guidelines:**
 - **1-2 simple parameters**: Use `@RequestParam`
 - **3+ parameters or validation required**: Use `@ModelAttribute` + DTO
 
-**Examples:**
 ```kotlin
 // 1-2 parameters → @RequestParam
 @GetMapping("/scopes")
@@ -73,37 +68,17 @@ fun getScopes(@RequestParam role: AccountRole): ApiScopeListResDto
 // 3+ parameters → @ModelAttribute + DTO
 @GetMapping("/students")
 fun getStudents(@Valid @ModelAttribute queryReq: QueryStudentReqDto): StudentListResDto
-
-data class QueryStudentReqDto(
-    @field:Positive @param:Schema(description = "Student ID")
-    val studentId: Long? = null,
-    @field:Min(0) @param:Schema(description = "Page", defaultValue = "0")
-    val page: Int = 0,
-    @field:Min(1) @field:Max(1000) @param:Schema(description = "Size", defaultValue = "300")
-    val size: Int = 300
-)
 ```
 
 ### DTO Variable Naming
 
-- **@RequestBody (Create/Update)**: Use `reqDto`
-- **@ModelAttribute (Query)**: Use `queryReq`
-
-```kotlin
-@PostMapping
-fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDto =
-    createStudentService.execute(reqDto)
-
-@GetMapping
-fun getStudents(@Valid @ModelAttribute queryReq: QueryStudentReqDto): StudentListResDto =
-    queryStudentService.execute(queryReq)
-```
+- **@RequestBody (Create/Update)**: Use `reqDto` → `service.execute(reqDto)`
+- **@ModelAttribute (Query)**: Use `queryReq` → `service.execute(queryReq)`
 
 ### Controller-Service Value Passing
 
-Pass request body/query DTO objects to service layer. PathVariable can be passed individually.
+Pass DTO objects to service layer as-is. PathVariable can be passed individually.
 
-**Correct Pattern:**
 ```kotlin
 @PostMapping
 fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDto =
@@ -112,13 +87,6 @@ fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDt
 @PutMapping("/{id}")
 fun updateStudent(@PathVariable id: Long, @Valid @RequestBody reqDto: UpdateStudentReqDto): StudentResDto =
     updateStudentService.execute(id, reqDto)
-```
-
-**Wrong Pattern:**
-```kotlin
-@PostMapping
-fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDto =
-    createStudentService.execute(reqDto.name, reqDto.email)  // Don't extract DTO fields
 ```
 
 ## Key Practices
@@ -145,12 +113,6 @@ fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDt
 - Use `ExpectedException` for custom exceptions
 - Map to appropriate HTTP status codes
 - Exception Handler: `datagsm-common/.../global/common/error/`
-
-## Key Paths
-
-- Common Entity: `datagsm-common/src/main/kotlin/.../domain/`
-- Exception Handler: `datagsm-common/.../global/common/error/`
-- API Response: Use `CommonApiResponse` wrapper
 
 ## Custom Commands
 


### PR DESCRIPTION
## 개요

LLM(Large Language Model) 프롬프트의 권장 최대치인 150라인에 근접함에 따라, 컨텍스트 효율을 높이기 위해 프로젝트 지침 문서를 최적화하고 내용을 간결하게 정리하였습니다.

## 본문

- **프롬프트 용량 최적화**: `.github/copilot-instructions.md`, `CLAUDE.md`, `GEMINI.md` 파일들의 중복된 코드 예시를 제거하고, 핵심 가이드라인 위주로 압축하여 토큰 사용량을 절감하였습니다.
- **일관성 개선**: 각 AI 어시스턴트 지침 문서의 명칭과 형식을 통일하여 어시스턴트 간의 혼동을 최소화하고 일관된 피드백을 받을 수 있도록 하였습니다.
- **불필요한 정보 제거**: 프로젝트 구조상 자명한 내용이나 중복되는 스타일 가이드를 제거하여 프롬프트의 가독성을 높였습니다.