### PR TITLE
[ci/cd] 외부 기여자의 Pull Request에서 메타데이터 설정 실패 시 CI가 중단되지 않도록 수정

### DIFF
--- a/.github/workflows/datagsm-stage-ci.yaml
+++ b/.github/workflows/datagsm-stage-ci.yaml
@@ -68,6 +68,7 @@ jobs:
 
     steps:
       - name: Setup PR Metadata
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## 개요

GitHub Actions의 `pull_request` 이벤트는 포크 레포지토리에서 올라온 PR에 대해 보안상 `GITHUB_TOKEN`을 강제로 read-only로 제한합니다. 이로 인해 `setup-pr-metadata` 잡에서 라벨 추가(`addLabelsToLabelable`) 호출이 실패하고 CI 전체가 실패 상태로 기록되는 문제가 있었습니다. 해당 스텝에 `continue-on-error: true`를 추가하여 포크 PR에서 메타데이터 설정이 실패하더라도 CI가 실패로 처리되지 않도록 수정하였습니다.

## 본문

### 문제 원인

GitHub Actions에서 `pull_request` 이벤트는 포크 레포지토리에서 제출된 PR의 경우, `permissions` 블록에 `issues: write` 또는 `pull-requests: write`를 명시하더라도 `GITHUB_TOKEN`의 실제 권한을 read-only로 강제합니다. 이는 악의적인 포크 PR이 레포지토리의 시크릿이나 쓰기 권한에 접근하는 것을 막기 위한 GitHub의 보안 정책입니다.

같은 레포지토리의 브랜치에서 올라오는 PR은 `GITHUB_TOKEN`이 정상적으로 쓰기 권한을 가지므로 `setup-pr-metadata` 잡이 성공합니다. 반면 포크 레포지토리 PR(`head_repo != base_repo`)에서는 `gh pr edit --add-label` 호출이 `GraphQL: Resource not accessible by integration (addLabelsToLabelable)` 오류로 실패합니다.

### 수정 내용

`setup-pr-metadata` 잡의 `Setup PR Metadata` 스텝에 `continue-on-error: true`를 추가하였습니다. 이를 통해 포크 PR에서 라벨 및 리뷰어 설정이 실패하더라도 해당 스텝만 실패로 기록되고, 잡 및 워크플로우 전체는 성공으로 처리됩니다.