### PR TITLE
[club] 동아리 삭제 전 학생의 동아리 FK `null` 처리 누락 수정 

### DIFF
--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/DeleteClubServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/DeleteClubServiceImpl.kt
@@ -4,12 +4,14 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.web.domain.club.service.DeleteClubService
 import team.themoment.sdk.exception.ExpectedException
 
 @Service
 class DeleteClubServiceImpl(
     private val clubJpaRepository: ClubJpaRepository,
+    private val studentJpaRepository: StudentJpaRepository,
 ) : DeleteClubService {
     @Transactional
     override fun execute(clubId: Long) {
@@ -17,6 +19,7 @@ class DeleteClubServiceImpl(
             clubJpaRepository
                 .findById(clubId)
                 .orElseThrow { ExpectedException("동아리를 찾을 수 없습니다. clubId: $clubId", HttpStatus.NOT_FOUND) }
+        studentJpaRepository.bulkClearClubReferences(listOf(club))
         clubJpaRepository.delete(club)
     }
 }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/club/service/DeleteClubServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/club/service/DeleteClubServiceTest.kt
@@ -11,6 +11,7 @@ import io.mockk.verify
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.web.domain.club.service.impl.DeleteClubServiceImpl
 import team.themoment.sdk.exception.ExpectedException
 import java.util.Optional
@@ -19,11 +20,13 @@ class DeleteClubServiceTest :
     DescribeSpec({
 
         lateinit var mockClubRepository: ClubJpaRepository
+        lateinit var mockStudentRepository: StudentJpaRepository
         lateinit var deleteClubService: DeleteClubService
 
         beforeEach {
             mockClubRepository = mockk<ClubJpaRepository>()
-            deleteClubService = DeleteClubServiceImpl(mockClubRepository)
+            mockStudentRepository = mockk<StudentJpaRepository>()
+            deleteClubService = DeleteClubServiceImpl(mockClubRepository, mockStudentRepository)
         }
 
         describe("DeleteClubService 클래스의") {
@@ -41,13 +44,15 @@ class DeleteClubServiceTest :
                                 type = ClubType.MAJOR_CLUB
                             }
                         every { mockClubRepository.findById(clubId) } returns Optional.of(existing)
+                        every { mockStudentRepository.bulkClearClubReferences(listOf(existing)) } just runs
                         every { mockClubRepository.delete(existing) } just runs
                     }
 
-                    it("delete가 1회 호출되어야 한다") {
+                    it("bulkClearClubReferences 후 delete가 각 1회 호출되어야 한다") {
                         deleteClubService.execute(clubId)
 
                         verify(exactly = 1) { mockClubRepository.findById(clubId) }
+                        verify(exactly = 1) { mockStudentRepository.bulkClearClubReferences(listOf(existing)) }
                         verify(exactly = 1) { mockClubRepository.delete(existing) }
                     }
                 }
@@ -65,6 +70,7 @@ class DeleteClubServiceTest :
                         ex.message shouldBe "동아리를 찾을 수 없습니다. clubId: $clubId"
 
                         verify(exactly = 1) { mockClubRepository.findById(clubId) }
+                        verify(exactly = 0) { mockStudentRepository.bulkClearClubReferences(any()) }
                         verify(exactly = 0) { mockClubRepository.delete(any()) }
                     }
                 }


### PR DESCRIPTION
## 개요

동아리 삭제 시 해당 동아리를 참조하는 학생들의 FK를 먼저 null 처리하지 않아 `TransientPropertyValueException`이 발생하던 문제를 수정하였습니다.

## 본문

### 문제 원인

`DELETE /v1/clubs/{clubId}` 호출 시 500 에러가 발생하였습니다.

Hibernate flush 시점에 이미 transient 상태가 된 `ClubJpaEntity`를 `StudentJpaEntity`의 `majorClub` / `autonomousClub` 필드가 여전히 참조하고 있어 `TransientPropertyValueException`이 발생하였습니다.

학생 자퇴/졸업 처리 시에는 `student.majorClub = null` 처리가 존재하였으나, 동아리 삭제 시에는 역방향 참조 해제 로직이 누락되어 있었습니다.

### 수정 내용

`DeleteClubServiceImpl`에 `StudentJpaRepository` 의존성을 추가하였습니다.

`clubJpaRepository.delete(club)` 호출 이전에 `studentJpaRepository.bulkClearClubReferences(listOf(club))`를 먼저 호출하여 해당 동아리를 참조하는 학생들의 `majorClub` / `autonomousClub` 필드를 null로 일괄 처리하였습니다.

`bulkClearClubReferences`는 이미 `ModifyClubExcelServiceImpl`에서 동일한 목적으로 사용 중인 QueryDSL bulk update 기반 메서드를 재사용하였습니다.

### 처리 순서

1. `studentJpaRepository.bulkClearClubReferences(listOf(club))` — 학생의 동아리 참조 해제
2. `clubJpaRepository.delete(club)` — 동아리 삭제

### 테스트 수정

- `mockStudentRepository` mock을 추가하였습니다.
- 동아리 삭제 성공 케이스에 `bulkClearClubReferences` 1회 호출 검증을 추가하였습니다.
- 동아리 미존재 케이스에 `bulkClearClubReferences` 0회 호출 검증을 추가하였습니다.
