### PR TITLE
[auth] API 키 인증 필터 화이트리스트에 Swagger 경로 추가

### DIFF
--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/global/security/filter/ApiKeyAuthenticationFilter.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/global/security/filter/ApiKeyAuthenticationFilter.kt
@@ -24,7 +24,8 @@ class ApiKeyAuthenticationFilter(
     ) {
         val requestPath = request.servletPath
         if (requestPath == "/v1/health" ||
-            requestPath.startsWith("/swagger-ui") ||
+            requestPath == "/swagger-ui.html" ||
+            requestPath.startsWith("/swagger-ui/") ||
             requestPath.startsWith("/v3/api-docs")
         ) {
             filterChain.doFilter(request, response)


### PR DESCRIPTION
## 개요

OpenAPI 모듈의 API 키 인증 필터에서 Swagger 관련 경로가 차단되는 문제를 해결하기 위해 화이트리스트를 업데이트했습니다.

## 본문

Swagger UI와 API 문서에 접근할 때 API 키 인증을 요구하지 않도록 `ApiKeyAuthenticationFilter`의 화이트리스트 로직을 수정했습니다.

- **화이트리스트 경로 추가**: `/swagger-ui` 및 `/v3/api-docs`로 시작하는 경로를 인증 제외 대상에 포함시켰습니다.
- **기대 효과**: API 키가 없는 상태에서도 개발자가 Swagger UI를 통해 API 명세서를 원활하게 확인하고 테스트할 수 있습니다.
