### PR TITLE
[ci/cd] CI 워크플로우 내 Pull Request 메타데이터 설정 작업 안정화

### DIFF
--- a/.github/workflows/datagsm-prod-ci.yaml
+++ b/.github/workflows/datagsm-prod-ci.yaml
@@ -64,6 +64,7 @@ jobs:
   setup-pr-metadata:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/datagsm-stage-ci.yaml
+++ b/.github/workflows/datagsm-stage-ci.yaml
@@ -62,13 +62,13 @@ jobs:
   setup-pr-metadata:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write
 
     steps:
       - name: Setup PR Metadata
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## 개요

PR 메타데이터 설정 작업 실패 시 CI 워크플로우 전체가 중단되는 현상을 방지하기 위해 예외 처리 설정을 추가했습니다.

## 본문

- `datagsm-prod-ci.yaml` 및 `datagsm-stage-ci.yaml` 워크플로우의 `setup-pr-metadata` 작업(job) 수준에 `continue-on-error: true` 설정을 적용했습니다.
- `datagsm-stage-ci.yaml`에서 개별 스텝에 중복 적용되어 있던 `continue-on-error` 설정을 제거하고 작업 수준으로 통합하여 일관성을 확보했습니다.
- 이를 통해 PR 레이블링이나 설명 업데이트와 같은 부가적인 작업의 일시적인 오류가 전체 빌드 및 테스트 파이프라인의 성공 여부에 영향을 주지 않도록 개선했습니다.
