### PR TITLE
[club] 동아리 조회 서비스 트랜잭션 읽기 전용 설정 적용

### DIFF
--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/club/service/impl/QueryClubServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/club/service/impl/QueryClubServiceImpl.kt
@@ -15,11 +15,11 @@ import team.themoment.datagsm.common.domain.student.repository.StudentJpaReposit
 import team.themoment.datagsm.openapi.domain.club.service.QueryClubService
 
 @Service
-@Transactional
 class QueryClubServiceImpl(
     private val clubJpaRepository: ClubJpaRepository,
     private val studentJpaRepository: StudentJpaRepository,
 ) : QueryClubService {
+    @Transactional(readOnly = true)
     override fun execute(queryReq: QueryClubReqDto): ClubListResDto {
         val clubPage =
             clubJpaRepository.searchClubWithPaging(

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/QueryClubServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/QueryClubServiceImpl.kt
@@ -19,7 +19,7 @@ class QueryClubServiceImpl(
     private val clubJpaRepository: ClubJpaRepository,
     private val studentJpaRepository: StudentJpaRepository,
 ) : QueryClubService {
-    @Transactional
+    @Transactional(readOnly = true)
     override fun execute(queryReq: QueryClubReqDto): ClubListResDto {
         val clubPage =
             clubJpaRepository.searchClubWithPaging(


### PR DESCRIPTION
## 개요

`QueryClubServiceImpl`의 `@Transactional` 설정을 읽기 전용(`readOnly = true`)으로 변경하였습니다. `datagsm-openapi`, `datagsm-web` 모듈 양쪽 모두 동일하게 적용되었습니다.

## 본문

### 변경 배경

동아리 조회 서비스(`QueryClubServiceImpl`)는 DB에 데이터를 쓰지 않는 순수 조회 서비스임에도 불구하고, `@Transactional`이 `readOnly = true` 없이 적용되어 있었습니다.

`readOnly = true`가 없으면 Hibernate는 해당 트랜잭션 내 로드된 모든 엔티티를 dirty checking 대상에 포함시킵니다. 동아리 조회 특성상 클럽 + 참여 학생 목록까지 함께 로딩되므로, 매 요청마다 불필요한 snapshot 비교 오버헤드가 발생하고 있었습니다.

### 변경 내용

| 모듈                | 위치                     | 변경 전                    | 변경 후                                     |
|-------------------|------------------------|-------------------------|------------------------------------------|
| `datagsm-openapi` | `QueryClubServiceImpl` | 클래스 레벨 `@Transactional` | 메서드 레벨 `@Transactional(readOnly = true)` |
| `datagsm-web`     | `QueryClubServiceImpl` | 메서드 레벨 `@Transactional` | 메서드 레벨 `@Transactional(readOnly = true)` |

### 기대 효과

- Hibernate dirty checking 비활성화로 조회 트랜잭션의 오버헤드 감소
- `readOnly = true` 힌트를 통해 read replica 라우팅 등 추후 DB 이중화 적용 시 자동 활용 가능
