### PR TITLE
[global] 동아리 정보 조회시 N+1 문제를  `WHERE studentNumber IN (...)` 1회 조회 후 매핑으로 개선

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/entity/StudentNumber.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/entity/StudentNumber.kt
@@ -29,4 +29,13 @@ class StudentNumber {
             val number = studentNumber ?: return null
             return grade * 1000 + classNum * 100 + number
         }
+
+    companion object {
+        fun fromCode(code: Int): StudentNumber =
+            StudentNumber(
+                grade = code / 1000,
+                classNum = (code % 1000) / 100,
+                number = code % 100,
+            )
+    }
 }

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/StudentJpaRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/StudentJpaRepository.kt
@@ -1,6 +1,8 @@
 package team.themoment.datagsm.common.domain.student.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.repository.custom.StudentJpaCustomRepository
@@ -21,4 +23,10 @@ interface StudentJpaRepository :
         number: Int,
         name: String,
     ): StudentJpaEntity?
+
+    @Query(
+        "SELECT s FROM StudentJpaEntity s " +
+            "WHERE (s.studentNumber.studentGrade * 1000 + s.studentNumber.studentClass * 100 + s.studentNumber.studentNumber) IN :codes",
+    )
+    fun findAllByStudentNumberCodes(@Param("codes") codes: List<Int>): List<StudentJpaEntity>
 }

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/StudentJpaCustomRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/StudentJpaCustomRepository.kt
@@ -93,4 +93,6 @@ interface StudentJpaCustomRepository {
     fun findRegisteredStudentsByMajorClub(club: ClubJpaEntity): List<StudentJpaEntity>
 
     fun findRegisteredStudentsByAutonomousClub(club: ClubJpaEntity): List<StudentJpaEntity>
+
+    fun findAllByStudentNumberCodes(codes: List<Int>): List<StudentJpaEntity>
 }

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
@@ -404,6 +404,27 @@ class StudentJpaCustomRepositoryImpl(
             .execute()
     }
 
+    override fun findAllByStudentNumberCodes(codes: List<Int>): List<StudentJpaEntity> {
+        if (codes.isEmpty()) return emptyList()
+
+        val condition =
+            codes
+                .map { code ->
+                    val grade = code / 1000
+                    val classNum = (code % 1000) / 100
+                    val number = code % 100
+                    studentJpaEntity.studentNumber.studentGrade
+                        .eq(grade)
+                        .and(studentJpaEntity.studentNumber.studentClass.eq(classNum))
+                        .and(studentJpaEntity.studentNumber.studentNumber.eq(number))
+                }.reduce { a, b -> a.or(b) }
+
+        return jpaQueryFactory
+            .selectFrom(studentJpaEntity)
+            .where(condition)
+            .fetch()
+    }
+
     private fun buildEmailCaseExpr(pairs: List<Pair<Long, String>>): Expression<String> =
         pairs
             .drop(1)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
@@ -13,6 +13,7 @@ import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.student.entity.QStudentJpaEntity.Companion.studentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.StudentNumber
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentSortBy
@@ -410,13 +411,11 @@ class StudentJpaCustomRepositoryImpl(
         val condition =
             codes
                 .map { code ->
-                    val grade = code / 1000
-                    val classNum = (code % 1000) / 100
-                    val number = code % 100
+                    val sn = StudentNumber.fromCode(code)
                     studentJpaEntity.studentNumber.studentGrade
-                        .eq(grade)
-                        .and(studentJpaEntity.studentNumber.studentClass.eq(classNum))
-                        .and(studentJpaEntity.studentNumber.studentNumber.eq(number))
+                        .eq(sn.studentGrade)
+                        .and(studentJpaEntity.studentNumber.studentClass.eq(sn.studentClass))
+                        .and(studentJpaEntity.studentNumber.studentNumber.eq(sn.studentNumber))
                 }.reduce { a, b -> a.or(b) }
 
         return jpaQueryFactory

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/ModifyClubExcelServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/ModifyClubExcelServiceImpl.kt
@@ -10,7 +10,6 @@ import team.themoment.datagsm.common.domain.club.dto.internal.ClubInfoDto
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
-import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.web.domain.club.service.ModifyClubExcelService
 import team.themoment.sdk.exception.ExpectedException
@@ -53,17 +52,32 @@ class ModifyClubExcelServiceImpl(
             )
         }
 
+        val parsedLeaders = clubInfos.map { parseLeaderInfo(it.leaderInfo) }
+
+        val codes = parsedLeaders.map { it.code }
+        val studentsByCode = studentJpaRepository.findAllByStudentNumberCodes(codes)
+            .associateBy { it.studentNumber?.fullStudentNumber ?: 0 }
+
+        val leaderEntities = parsedLeaders.map { parsed ->
+            studentsByCode[parsed.code]
+                ?.takeIf { it.name == parsed.name }
+                ?: throw ExpectedException(
+                    "학번 ${parsed.rawStudentNumber} 이름 ${parsed.name} 에 해당하는 학생을 찾을 수 없습니다.",
+                    HttpStatus.NOT_FOUND,
+                )
+        }
+
         val existingClubs =
             clubJpaRepository
                 .findAllByNameIn(clubInfos.map { it.clubName })
                 .associateBy { it.name }
 
         val clubsToSave =
-            clubInfos.map { dto ->
+            clubInfos.mapIndexed { idx, dto ->
                 (existingClubs[dto.clubName] ?: ClubJpaEntity()).also { club ->
                     club.name = dto.clubName
                     club.type = dto.clubType
-                    club.leader = parseAndFindLeader(dto.leaderInfo)
+                    club.leader = leaderEntities[idx]
                 }
             }
         clubJpaRepository.saveAll(clubsToSave)
@@ -78,7 +92,17 @@ class ModifyClubExcelServiceImpl(
         return CommonApiResponse.success("엑셀 업로드 성공")
     }
 
-    private fun parseAndFindLeader(leaderInfo: String?): StudentJpaEntity {
+    private data class ParsedLeaderInfo(
+        val grade: Int,
+        val classNum: Int,
+        val number: Int,
+        val name: String,
+        val rawStudentNumber: String,
+    ) {
+        val code: Int get() = grade * 1000 + classNum * 100 + number
+    }
+
+    private fun parseLeaderInfo(leaderInfo: String?): ParsedLeaderInfo {
         if (leaderInfo.isNullOrBlank()) {
             throw ExpectedException(
                 "동아리 부장 정보가 비어있습니다.",
@@ -108,15 +132,12 @@ class ModifyClubExcelServiceImpl(
         val classNum = studentNumberStr[1].digitToInt()
         val number = studentNumberStr.substring(2).toInt()
 
-        return studentJpaRepository
-            .findByStudentNumberStudentGradeAndStudentNumberStudentClassAndStudentNumberStudentNumberAndName(
-                grade,
-                classNum,
-                number,
-                studentName,
-            ) ?: throw ExpectedException(
-            "학번 $studentNumberStr 이름 $studentName 에 해당하는 학생을 찾을 수 없습니다.",
-            HttpStatus.NOT_FOUND,
+        return ParsedLeaderInfo(
+            grade = grade,
+            classNum = classNum,
+            number = number,
+            name = studentName,
+            rawStudentNumber = studentNumberStr,
         )
     }
 

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/club/service/ModifyClubExcelServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/club/service/ModifyClubExcelServiceTest.kt
@@ -110,32 +110,8 @@ class ModifyClubExcelServiceTest :
                     beforeEach {
                         every { mockClubRepository.findAllByNameIn(any()) } returns emptyList()
                         every {
-                            mockStudentRepository
-                                .findByStudentNumberStudentGradeAndStudentNumberStudentClassAndStudentNumberStudentNumberAndName(
-                                    2,
-                                    4,
-                                    4,
-                                    "김철수",
-                                )
-                        } returns leader1
-                        every {
-                            mockStudentRepository
-                                .findByStudentNumberStudentGradeAndStudentNumberStudentClassAndStudentNumberStudentNumberAndName(
-                                    2,
-                                    3,
-                                    5,
-                                    "이영희",
-                                )
-                        } returns leader2
-                        every {
-                            mockStudentRepository
-                                .findByStudentNumberStudentGradeAndStudentNumberStudentClassAndStudentNumberStudentNumberAndName(
-                                    1,
-                                    2,
-                                    10,
-                                    "박민수",
-                                )
-                        } returns leader3
+                            mockStudentRepository.findAllByStudentNumberCodes(any())
+                        } returns listOf(leader1, leader3)
                         every { mockClubRepository.saveAll(any<List<ClubJpaEntity>>()) } returns emptyList()
                         every { mockClubRepository.findByNameNotIn(any()) } returns emptyList()
                     }
@@ -437,14 +413,8 @@ class ModifyClubExcelServiceTest :
                     beforeEach {
                         every { mockClubRepository.findAllByNameIn(any()) } returns emptyList()
                         every {
-                            mockStudentRepository
-                                .findByStudentNumberStudentGradeAndStudentNumberStudentClassAndStudentNumberStudentNumberAndName(
-                                    any(),
-                                    any(),
-                                    any(),
-                                    any(),
-                                )
-                        } returns null
+                            mockStudentRepository.findAllByStudentNumberCodes(any())
+                        } returns emptyList()
                     }
 
                     it("ExpectedException이 발생해야 한다") {
@@ -485,17 +455,21 @@ class ModifyClubExcelServiceTest :
                             sex = Sex.MAN
                         }
 
+                    val anotherLeader =
+                        StudentJpaEntity().apply {
+                            id = 3L
+                            name = "박민수"
+                            studentNumber = StudentNumber(1, 2, 10)
+                            email = "park@gsm.hs.kr"
+                            major = Major.SMART_IOT
+                            sex = Sex.MAN
+                        }
+
                     beforeEach {
                         every { mockClubRepository.findAllByNameIn(any()) } returns listOf(existingClub)
                         every {
-                            mockStudentRepository
-                                .findByStudentNumberStudentGradeAndStudentNumberStudentClassAndStudentNumberStudentNumberAndName(
-                                    any(),
-                                    any(),
-                                    any(),
-                                    any(),
-                                )
-                        } returns newLeader
+                            mockStudentRepository.findAllByStudentNumberCodes(any())
+                        } returns listOf(newLeader, anotherLeader)
                         every { mockClubRepository.saveAll(any<List<ClubJpaEntity>>()) } returns emptyList()
                         every { mockClubRepository.findByNameNotIn(any()) } returns emptyList()
                     }
@@ -540,17 +514,21 @@ class ModifyClubExcelServiceTest :
                             sex = Sex.MAN
                         }
 
+                    val leader2 =
+                        StudentJpaEntity().apply {
+                            id = 3L
+                            name = "박민수"
+                            studentNumber = StudentNumber(1, 2, 10)
+                            email = "park@gsm.hs.kr"
+                            major = Major.SMART_IOT
+                            sex = Sex.MAN
+                        }
+
                     beforeEach {
                         every { mockClubRepository.findAllByNameIn(any()) } returns emptyList()
                         every {
-                            mockStudentRepository
-                                .findByStudentNumberStudentGradeAndStudentNumberStudentClassAndStudentNumberStudentNumberAndName(
-                                    any(),
-                                    any(),
-                                    any(),
-                                    any(),
-                                )
-                        } returns leader1
+                            mockStudentRepository.findAllByStudentNumberCodes(any())
+                        } returns listOf(leader1, leader2)
                         every { mockClubRepository.saveAll(any<List<ClubJpaEntity>>()) } returns emptyList()
                         every { mockClubRepository.findByNameNotIn(any()) } returns listOf(orphanClub)
                         every { mockStudentRepository.bulkClearClubReferences(any()) } just Runs


### PR DESCRIPTION
## 개요
클럽 30개 기준 30번 쿼리 발생하는 문제가 있어서 . 전체 부장 학번을 모아 WHERE studentNumber IN (...) 1회 조회 후 매핑으로 개선했습니다.

## 본문
```ModifyClubExcelServiceImpl```
- 문제점 : club.leader = parseAndFindLeader(dto.leaderInfo) 가 클럽 30개 기준 30번 쿼리 발생
- 해결책 : ```WHERE studentNumber IN (...)``` 1회 조회 후 매핑으로 개선 
