### PR TITLE
[oauth] `authorize` 단계에서 `scope`를 저장하고 세션 조회 응답에 포함되도록 OAuth flow를 개선

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/Oauth2TokenReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/Oauth2TokenReqDto.kt
@@ -30,9 +30,9 @@ data class Oauth2TokenReqDto(
     @field:JsonProperty("refresh_token")
     @field:JsonAlias("refreshToken")
     val refreshToken: String? = null,
-    @param:Schema(description = "OAuth Scopes (space-separated)", example = "read write")
+    @param:Schema(description = "OAuth Scopes", example = "[\"self:read\"]")
     @field:JsonProperty("scope")
-    val scope: String? = null,
+    val scope: Set<String>? = null,
     @param:Schema(description = "PKCE Code Verifier", example = "dBjftJeSSVPxgS31dKTHlEpQMZlzvvMpqHN0KT9LM5E")
     @field:JsonProperty("code_verifier")
     @field:JsonAlias("codeVerifier")

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
@@ -28,9 +28,9 @@ data class OauthAuthorizeReqDto(
     )
     val code_challenge_method: String? = null,
     @param:Schema(
-        description = "요청할 OAuth Scope (공백 구분, 미입력 시 client의 전체 허용 scope 사용)",
-        example = "self:read",
+        description = "요청할 OAuth Scope 목록 (미입력 시 client의 전체 허용 scope 사용)",
+        example = "[\"self:read\"]",
         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
     )
-    val scope: String? = null,
+    val scope: Set<String>? = null,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
@@ -28,9 +28,9 @@ data class OauthAuthorizeReqDto(
     )
     val code_challenge_method: String? = null,
     @param:Schema(
-        description = "요청할 OAuth Scope 목록 (미입력 시 client의 전체 허용 scope 사용)",
-        example = "[\"self:read\"]",
+        description = "요청할 OAuth Scope 목록 (공백 구분, 미입력 시 client의 전체 허용 scope 사용)",
+        example = "self:read profile:read",
         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
     )
-    val scope: Set<String>? = null,
+    val scope: String? = null,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
@@ -27,4 +27,10 @@ data class OauthAuthorizeReqDto(
         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
     )
     val code_challenge_method: String? = null,
+    @param:Schema(
+        description = "요청할 OAuth Scope (공백 구분, 미입력 시 client의 전체 허용 scope 사용)",
+        example = "self:read",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val scope: String? = null,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/response/OauthSessionResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/response/OauthSessionResDto.kt
@@ -1,6 +1,7 @@
 package team.themoment.datagsm.common.domain.oauth.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import team.themoment.datagsm.common.domain.client.dto.response.OAuthScopeResDto
 
 data class OauthSessionResDto(
     @field:Schema(description = "서비스 이름")
@@ -8,5 +9,5 @@ data class OauthSessionResDto(
     @field:Schema(description = "세션 만료 시각")
     val expiresAt: Long,
     @field:Schema(description = "클라이언트가 요청한 OAuth Scope 목록")
-    val requestedScopes: List<String>,
+    val requestedScopes: List<OAuthScopeResDto>,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/response/OauthSessionResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/response/OauthSessionResDto.kt
@@ -7,4 +7,6 @@ data class OauthSessionResDto(
     val serviceName: String,
     @field:Schema(description = "세션 만료 시각")
     val expiresAt: Long,
+    @field:Schema(description = "클라이언트가 요청한 OAuth Scope 목록")
+    val requestedScopes: List<String>,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthAuthorizeStateRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthAuthorizeStateRedisEntity.kt
@@ -13,6 +13,7 @@ data class OauthAuthorizeStateRedisEntity(
     val state: String?,
     val codeChallenge: String?,
     val codeChallengeMethod: String?,
+    val scopes: String?,
     @TimeToLive
     val ttl: Long = 600,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthAuthorizeStateRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthAuthorizeStateRedisEntity.kt
@@ -13,7 +13,7 @@ data class OauthAuthorizeStateRedisEntity(
     val state: String?,
     val codeChallenge: String?,
     val codeChallengeMethod: String?,
-    val scopes: String,
+    val scopes: Set<String>,
     @TimeToLive
     val ttl: Long = 600,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthAuthorizeStateRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthAuthorizeStateRedisEntity.kt
@@ -13,7 +13,7 @@ data class OauthAuthorizeStateRedisEntity(
     val state: String?,
     val codeChallenge: String?,
     val codeChallengeMethod: String?,
-    val scopes: String?,
+    val scopes: String,
     @TimeToLive
     val ttl: Long = 600,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthCodeRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthCodeRedisEntity.kt
@@ -11,6 +11,7 @@ data class OauthCodeRedisEntity(
     val redirectUri: String?,
     val codeChallenge: String?,
     val codeChallengeMethod: String?,
+    val scopes: String?,
     @Id
     val code: String,
     @TimeToLive

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthCodeRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthCodeRedisEntity.kt
@@ -11,7 +11,7 @@ data class OauthCodeRedisEntity(
     val redirectUri: String?,
     val codeChallenge: String?,
     val codeChallengeMethod: String?,
-    val scopes: String?,
+    val scopes: String,
     @Id
     val code: String,
     @TimeToLive

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthCodeRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthCodeRedisEntity.kt
@@ -11,7 +11,7 @@ data class OauthCodeRedisEntity(
     val redirectUri: String?,
     val codeChallenge: String?,
     val codeChallengeMethod: String?,
-    val scopes: String,
+    val scopes: Set<String>,
     @Id
     val code: String,
     @TimeToLive

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthRefreshTokenRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthRefreshTokenRedisEntity.kt
@@ -14,6 +14,7 @@ data class OauthRefreshTokenRedisEntity(
     @Indexed
     val clientId: String,
     val token: String,
+    val scopes: Set<String>,
     @TimeToLive
     val ttl: Long,
 ) {
@@ -22,6 +23,7 @@ data class OauthRefreshTokenRedisEntity(
             email: String,
             clientId: String,
             token: String,
+            scopes: Set<String>,
             ttl: Long,
         ): OauthRefreshTokenRedisEntity =
             OauthRefreshTokenRedisEntity(
@@ -29,6 +31,7 @@ data class OauthRefreshTokenRedisEntity(
                 email = email,
                 clientId = clientId,
                 token = token,
+                scopes = scopes,
                 ttl = ttl,
             )
     }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
@@ -37,7 +37,12 @@ class CompleteOauthAuthorizeFlowServiceImpl(
                     OAuthException.InvalidRequest("인증 토큰이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
                 }
 
-        val (_, clientId, redirectUri, state, codeChallenge, codeChallengeMethod) = stateEntity
+        val clientId = stateEntity.clientId
+        val redirectUri = stateEntity.redirectUri
+        val state = stateEntity.state
+        val codeChallenge = stateEntity.codeChallenge
+        val codeChallengeMethod = stateEntity.codeChallengeMethod
+        val scopes = stateEntity.scopes
 
         val account =
             accountJpaRepository
@@ -57,6 +62,7 @@ class CompleteOauthAuthorizeFlowServiceImpl(
                 redirectUri = redirectUri,
                 codeChallenge = codeChallenge,
                 codeChallengeMethod = codeChallengeMethod,
+                scopes = scopes,
                 code = code,
                 ttl = oauthEnvironment.codeExpirationSeconds,
             )

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
@@ -110,7 +110,7 @@ class Oauth2TokenServiceImpl(
                 .orElseThrow { ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
 
         val codeScopes = parseScopes(oauthCode.scopes)
-        val tokenScopes = parseScopes(reqDto.scope)
+        val tokenScopes = reqDto.scope ?: emptySet()
         if (tokenScopes.isNotEmpty() && !codeScopes.containsAll(tokenScopes)) {
             throw OAuthException.InvalidScope("요청한 scope가 인가 코드의 scope를 초과합니다.")
         }
@@ -180,7 +180,7 @@ class Oauth2TokenServiceImpl(
                 .findByEmail(email)
                 .orElseThrow { ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
 
-        val requestedScopes = parseScopes(reqDto.scope)
+        val requestedScopes = reqDto.scope ?: emptySet()
         val grantedScopes = calculateGrantedScopes(client.scopes, requestedScopes)
 
         val newAccessToken = jwtProvider.generateOauthAccessToken(email, account.role, clientIdFromToken, grantedScopes)
@@ -202,7 +202,7 @@ class Oauth2TokenServiceImpl(
 
         val client = validateClient(reqDto.clientId!!, reqDto.clientSecret!!)
 
-        val requestedScopes = parseScopes(reqDto.scope)
+        val requestedScopes = reqDto.scope ?: emptySet()
         val grantedScopes = calculateGrantedScopes(client.scopes, requestedScopes)
 
         val accessToken = jwtProvider.generateClientCredentialsAccessToken(client.id, grantedScopes)

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
@@ -109,12 +109,11 @@ class Oauth2TokenServiceImpl(
                 .findByEmail(oauthCode.email)
                 .orElseThrow { ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
 
-        val codeScopes = parseScopes(oauthCode.scopes)
         val tokenScopes = reqDto.scope ?: emptySet()
-        if (tokenScopes.isNotEmpty() && !codeScopes.containsAll(tokenScopes)) {
+        if (tokenScopes.isNotEmpty() && !oauthCode.scopes.containsAll(tokenScopes)) {
             throw OAuthException.InvalidScope("요청한 scope가 인가 코드의 scope를 초과합니다.")
         }
-        val scopesToGrant = if (tokenScopes.isNotEmpty()) tokenScopes else codeScopes
+        val scopesToGrant = if (tokenScopes.isNotEmpty()) tokenScopes else oauthCode.scopes
         val grantedScopes = stringsToScopes(scopesToGrant)
 
         val accessToken = jwtProvider.generateOauthAccessToken(account.email, account.role, client.id, grantedScopes)
@@ -234,8 +233,6 @@ class Oauth2TokenServiceImpl(
     private fun validateClientWithoutSecret(clientId: String): ClientJpaEntity =
         clientJpaRepository.findByIdOrNull(clientId)
             ?: throw OAuthException.InvalidClient("존재하지 않는 클라이언트입니다.")
-
-    private fun parseScopes(scopeString: String?): Set<String> = scopeString?.split(" ")?.filter { it.isNotBlank() }?.toSet() ?: emptySet()
 
     private fun calculateGrantedScopes(
         clientScopes: Set<String>,

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
@@ -119,7 +119,7 @@ class Oauth2TokenServiceImpl(
         val accessToken = jwtProvider.generateOauthAccessToken(account.email, account.role, client.id, grantedScopes)
         val refreshToken = jwtProvider.generateOauthRefreshToken(account.email, client.id)
 
-        saveRefreshToken(account.email, client.id, refreshToken)
+        saveRefreshToken(account.email, client.id, refreshToken, scopesToGrant)
         oauthCodeRedisRepository.delete(oauthCode)
 
         return Oauth2TokenResDto(
@@ -179,13 +179,12 @@ class Oauth2TokenServiceImpl(
                 .findByEmail(email)
                 .orElseThrow { ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
 
-        val requestedScopes = reqDto.scope ?: emptySet()
-        val grantedScopes = calculateGrantedScopes(client.scopes, requestedScopes)
+        val grantedScopes = stringsToScopes(storedToken.scopes)
 
         val newAccessToken = jwtProvider.generateOauthAccessToken(email, account.role, clientIdFromToken, grantedScopes)
         val newRefreshToken = jwtProvider.generateOauthRefreshToken(email, clientIdFromToken)
 
-        saveRefreshToken(email, clientIdFromToken, newRefreshToken)
+        saveRefreshToken(email, clientIdFromToken, newRefreshToken, storedToken.scopes)
 
         return Oauth2TokenResDto(
             accessToken = newAccessToken,
@@ -278,6 +277,7 @@ class Oauth2TokenServiceImpl(
         email: String,
         clientId: String,
         token: String,
+        scopes: Set<String>,
     ) {
         oauthRefreshTokenRedisRepository.deleteByEmailAndClientId(email, clientId)
         val ttlSeconds = jwtEnvironment.refreshTokenExpiration / 1000
@@ -286,6 +286,7 @@ class Oauth2TokenServiceImpl(
                 email = email,
                 clientId = clientId,
                 token = token,
+                scopes = scopes,
                 ttl = ttlSeconds,
             )
         oauthRefreshTokenRedisRepository.save(entity)

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
@@ -109,8 +109,21 @@ class Oauth2TokenServiceImpl(
                 .findByEmail(oauthCode.email)
                 .orElseThrow { ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
 
-        val requestedScopes = parseScopes(reqDto.scope)
-        val grantedScopes = calculateGrantedScopes(client.scopes, requestedScopes)
+        val grantedScopes =
+            if (oauthCode.scopes != null) {
+                // 신규 flow: code에 scope가 저장된 경우
+                val codeScopes = parseScopes(oauthCode.scopes)
+                val tokenScopes = parseScopes(reqDto.scope)
+                if (tokenScopes.isNotEmpty() && !codeScopes.containsAll(tokenScopes)) {
+                    throw OAuthException.InvalidScope("요청한 scope가 인가 코드의 scope를 초과합니다.")
+                }
+                val scopesToGrant = if (tokenScopes.isNotEmpty()) tokenScopes else codeScopes
+                stringsToScopes(scopesToGrant)
+            } else {
+                // 하위 호환: 기존 code (scopes=null) - 기존 로직 유지
+                val requestedScopes = parseScopes(reqDto.scope)
+                calculateGrantedScopes(client.scopes, requestedScopes)
+            }
 
         val accessToken = jwtProvider.generateOauthAccessToken(account.email, account.role, client.id, grantedScopes)
         val refreshToken = jwtProvider.generateOauthRefreshToken(account.email, client.id)

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
@@ -109,11 +109,10 @@ class Oauth2TokenServiceImpl(
                 .findByEmail(oauthCode.email)
                 .orElseThrow { ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
 
-        val tokenScopes = reqDto.scope ?: emptySet()
-        if (tokenScopes.isNotEmpty() && !oauthCode.scopes.containsAll(tokenScopes)) {
+        val scopesToGrant = reqDto.scope ?: oauthCode.scopes
+        if (!oauthCode.scopes.containsAll(scopesToGrant)) {
             throw OAuthException.InvalidScope("요청한 scope가 인가 코드의 scope를 초과합니다.")
         }
-        val scopesToGrant = if (tokenScopes.isNotEmpty()) tokenScopes else oauthCode.scopes
         val grantedScopes = stringsToScopes(scopesToGrant)
 
         val accessToken = jwtProvider.generateOauthAccessToken(account.email, account.role, client.id, grantedScopes)

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
@@ -109,21 +109,13 @@ class Oauth2TokenServiceImpl(
                 .findByEmail(oauthCode.email)
                 .orElseThrow { ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
 
-        val grantedScopes =
-            if (oauthCode.scopes != null) {
-                // 신규 flow: code에 scope가 저장된 경우
-                val codeScopes = parseScopes(oauthCode.scopes)
-                val tokenScopes = parseScopes(reqDto.scope)
-                if (tokenScopes.isNotEmpty() && !codeScopes.containsAll(tokenScopes)) {
-                    throw OAuthException.InvalidScope("요청한 scope가 인가 코드의 scope를 초과합니다.")
-                }
-                val scopesToGrant = if (tokenScopes.isNotEmpty()) tokenScopes else codeScopes
-                stringsToScopes(scopesToGrant)
-            } else {
-                // 하위 호환: 기존 code (scopes=null) - 기존 로직 유지
-                val requestedScopes = parseScopes(reqDto.scope)
-                calculateGrantedScopes(client.scopes, requestedScopes)
-            }
+        val codeScopes = parseScopes(oauthCode.scopes)
+        val tokenScopes = parseScopes(reqDto.scope)
+        if (tokenScopes.isNotEmpty() && !codeScopes.containsAll(tokenScopes)) {
+            throw OAuthException.InvalidScope("요청한 scope가 인가 코드의 scope를 초과합니다.")
+        }
+        val scopesToGrant = if (tokenScopes.isNotEmpty()) tokenScopes else codeScopes
+        val grantedScopes = stringsToScopes(scopesToGrant)
 
         val accessToken = jwtProvider.generateOauthAccessToken(account.email, account.role, client.id, grantedScopes)
         val refreshToken = jwtProvider.generateOauthRefreshToken(account.email, client.id)

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryOauthSessionServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryOauthSessionServiceImpl.kt
@@ -31,7 +31,7 @@ class QueryOauthSessionServiceImpl(
                 .findByIdOrNull(stateEntity.clientId)
                 ?: throw ExpectedException("유효하지 않은 클라이언트입니다.", HttpStatus.UNAUTHORIZED)
         val expiresAt = Instant.now().toEpochMilli() + oauthEnvironment.authorizeStateExpirationMs
-        val requestedScopes = stateEntity.scopes.split(" ").filter { it.isNotBlank() }
+        val requestedScopes = stateEntity.scopes.toList()
         return OauthSessionResDto(serviceName = client.serviceName, expiresAt = expiresAt, requestedScopes = requestedScopes)
     }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryOauthSessionServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryOauthSessionServiceImpl.kt
@@ -31,12 +31,7 @@ class QueryOauthSessionServiceImpl(
                 .findByIdOrNull(stateEntity.clientId)
                 ?: throw ExpectedException("유효하지 않은 클라이언트입니다.", HttpStatus.UNAUTHORIZED)
         val expiresAt = Instant.now().toEpochMilli() + oauthEnvironment.authorizeStateExpirationMs
-        // scopes=null인 기존 세션은 client 전체 scope로 fallback
-        val requestedScopes =
-            stateEntity.scopes
-                ?.split(" ")
-                ?.filter { it.isNotBlank() }
-                ?: client.scopes.toList()
+        val requestedScopes = stateEntity.scopes.split(" ").filter { it.isNotBlank() }
         return OauthSessionResDto(serviceName = client.serviceName, expiresAt = expiresAt, requestedScopes = requestedScopes)
     }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryOauthSessionServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryOauthSessionServiceImpl.kt
@@ -4,6 +4,9 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.application.repository.ThirdPartyScopeJpaRepository
+import team.themoment.datagsm.common.domain.client.dto.response.OAuthScopeResDto
+import team.themoment.datagsm.common.domain.client.entity.constant.OAuthScope
 import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.common.domain.oauth.dto.response.OauthSessionResDto
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
@@ -17,6 +20,7 @@ class QueryOauthSessionServiceImpl(
     private val oauthAuthorizeStateRedisRepository: OauthAuthorizeStateRedisRepository,
     private val clientJpaRepository: ClientJpaRepository,
     private val oauthEnvironment: OauthEnvironment,
+    private val thirdPartyScopeJpaRepository: ThirdPartyScopeJpaRepository,
 ) : QueryOauthSessionService {
     // OAuth 모듈이지만 OAuthException을 사용하지 않는 이유는 해당 API는 공개적으로 공인된 API가 아니며 서비스 내부에서만 사용되기 때문입니다.
     // 따라서 일반적인 인증 실패로 간주하여 ExpectedException을 사용합니다.
@@ -31,7 +35,28 @@ class QueryOauthSessionServiceImpl(
                 .findByIdOrNull(stateEntity.clientId)
                 ?: throw ExpectedException("유효하지 않은 클라이언트입니다.", HttpStatus.UNAUTHORIZED)
         val expiresAt = Instant.now().toEpochMilli() + oauthEnvironment.authorizeStateExpirationMs
-        val requestedScopes = stateEntity.scopes.toList()
+        val requestedScopes = resolveScopes(stateEntity.scopes)
         return OauthSessionResDto(serviceName = client.serviceName, expiresAt = expiresAt, requestedScopes = requestedScopes)
+    }
+
+    private fun resolveScopes(scopeStrings: Set<String>): List<OAuthScopeResDto> {
+        val builtinScopes = scopeStrings.mapNotNull { OAuthScope.fromString(it) }
+        val thirdPartyStrings = scopeStrings.subtract(builtinScopes.map { it.scope }.toSet())
+
+        val thirdPartyScopes =
+            if (thirdPartyStrings.isNotEmpty()) {
+                val appIds = thirdPartyStrings.map { it.substringBefore(':') }.toSet()
+                val fetched =
+                    thirdPartyScopeJpaRepository
+                        .findAllByApplicationIdIn(appIds)
+                        .associateBy { "${it.application.id}:${it.scopeName}" }
+                thirdPartyStrings
+                    .mapNotNull { fetched[it] }
+                    .map { OAuthScopeResDto(scope = "${it.application.id}:${it.scopeName}", description = it.description) }
+            } else {
+                emptyList()
+            }
+
+        return builtinScopes.map { OAuthScopeResDto(scope = it.scope, description = it.description) } + thirdPartyScopes
     }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryOauthSessionServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryOauthSessionServiceImpl.kt
@@ -31,6 +31,12 @@ class QueryOauthSessionServiceImpl(
                 .findByIdOrNull(stateEntity.clientId)
                 ?: throw ExpectedException("유효하지 않은 클라이언트입니다.", HttpStatus.UNAUTHORIZED)
         val expiresAt = Instant.now().toEpochMilli() + oauthEnvironment.authorizeStateExpirationMs
-        return OauthSessionResDto(serviceName = client.serviceName, expiresAt = expiresAt)
+        // scopes=null인 기존 세션은 client 전체 scope로 fallback
+        val requestedScopes =
+            stateEntity.scopes
+                ?.split(" ")
+                ?.filter { it.isNotBlank() }
+                ?: client.scopes.toList()
+        return OauthSessionResDto(serviceName = client.serviceName, expiresAt = expiresAt, requestedScopes = requestedScopes)
     }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -82,7 +82,7 @@ class StartOauthAuthorizeFlowServiceImpl(
         requestedScopes: Set<String>?,
         clientScopes: Set<String>,
     ): Set<String> {
-        if (requestedScopes.isNullOrEmpty()) return clientScopes
+        if (requestedScopes == null) return clientScopes
         val invalid = requestedScopes - clientScopes
         if (invalid.isNotEmpty()) {
             throw OAuthException.InvalidScope("클라이언트에 허용되지 않은 scope입니다: ${invalid.joinToString(", ")}")

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -81,12 +81,12 @@ class StartOauthAuthorizeFlowServiceImpl(
     private fun resolveScopes(
         requestedScopes: Set<String>?,
         clientScopes: Set<String>,
-    ): String {
-        if (requestedScopes.isNullOrEmpty()) return clientScopes.joinToString(" ")
+    ): Set<String> {
+        if (requestedScopes.isNullOrEmpty()) return clientScopes
         val invalid = requestedScopes - clientScopes
         if (invalid.isNotEmpty()) {
             throw OAuthException.InvalidScope("클라이언트에 허용되지 않은 scope입니다: ${invalid.joinToString(", ")}")
         }
-        return requestedScopes.joinToString(" ")
+        return requestedScopes
     }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -46,6 +46,8 @@ class StartOauthAuthorizeFlowServiceImpl(
                 ?: throw OAuthException.InvalidRequest("지원하지 않는 code_challenge_method입니다.")
         }
 
+        val resolvedScopes = resolveScopes(reqDto.scope, client.scopes)
+
         val token = UUID.randomUUID().toString()
 
         val stateEntity =
@@ -56,6 +58,7 @@ class StartOauthAuthorizeFlowServiceImpl(
                 state = state,
                 codeChallenge = codeChallenge,
                 codeChallengeMethod = codeChallengeMethod,
+                scopes = resolvedScopes,
                 ttl = oauthEnvironment.authorizeStateExpirationMs / 1000,
             )
 
@@ -73,5 +76,20 @@ class StartOauthAuthorizeFlowServiceImpl(
             .status(HttpStatus.FOUND)
             .location(location)
             .build()
+    }
+
+    // scope가 null이면 client 전체 scope 사용, 있으면 client 허용 범위 내인지 검증
+    // DB 조회 없이 문자열 집합 비교만 수행 (ThirdPartyScope DB 조회는 token 발급 시에만)
+    private fun resolveScopes(
+        requestedScopeStr: String?,
+        clientScopes: Set<String>,
+    ): String {
+        if (requestedScopeStr.isNullOrBlank()) return clientScopes.joinToString(" ")
+        val requested = requestedScopeStr.split(" ").filter { it.isNotBlank() }.toSet()
+        val invalid = requested - clientScopes
+        if (invalid.isNotEmpty()) {
+            throw OAuthException.InvalidScope("클라이언트에 허용되지 않은 scope입니다: ${invalid.joinToString(", ")}")
+        }
+        return requested.joinToString(" ")
     }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -46,10 +46,11 @@ class StartOauthAuthorizeFlowServiceImpl(
                 ?: throw OAuthException.InvalidRequest("지원하지 않는 code_challenge_method입니다.")
         }
 
-        val requestedScopes = reqDto.scope
-            ?.split(" ")
-            ?.filter { it.isNotBlank() }
-            ?.toSet()
+        val requestedScopes =
+            reqDto.scope
+                ?.split(" ")
+                ?.filter { it.isNotBlank() }
+                ?.toSet()
         val resolvedScopes = resolveScopes(requestedScopes, client.scopes)
 
         val token = UUID.randomUUID().toString()

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -78,18 +78,15 @@ class StartOauthAuthorizeFlowServiceImpl(
             .build()
     }
 
-    // scope가 null이면 client 전체 scope 사용, 있으면 client 허용 범위 내인지 검증
-    // DB 조회 없이 문자열 집합 비교만 수행 (ThirdPartyScope DB 조회는 token 발급 시에만)
     private fun resolveScopes(
-        requestedScopeStr: String?,
+        requestedScopes: Set<String>?,
         clientScopes: Set<String>,
     ): String {
-        if (requestedScopeStr.isNullOrBlank()) return clientScopes.joinToString(" ")
-        val requested = requestedScopeStr.split(" ").filter { it.isNotBlank() }.toSet()
-        val invalid = requested - clientScopes
+        if (requestedScopes.isNullOrEmpty()) return clientScopes.joinToString(" ")
+        val invalid = requestedScopes - clientScopes
         if (invalid.isNotEmpty()) {
             throw OAuthException.InvalidScope("클라이언트에 허용되지 않은 scope입니다: ${invalid.joinToString(", ")}")
         }
-        return requested.joinToString(" ")
+        return requestedScopes.joinToString(" ")
     }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -46,7 +46,11 @@ class StartOauthAuthorizeFlowServiceImpl(
                 ?: throw OAuthException.InvalidRequest("지원하지 않는 code_challenge_method입니다.")
         }
 
-        val resolvedScopes = resolveScopes(reqDto.scope, client.scopes)
+        val requestedScopes = reqDto.scope
+            ?.split(" ")
+            ?.filter { it.isNotBlank() }
+            ?.toSet()
+        val resolvedScopes = resolveScopes(requestedScopes, client.scopes)
 
         val token = UUID.randomUUID().toString()
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/password/service/impl/ModifyPasswordServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/password/service/impl/ModifyPasswordServiceImplTest.kt
@@ -174,6 +174,7 @@ class ModifyPasswordServiceImplTest :
                     email = email,
                     clientId = "client1",
                     token = "token1",
+                    scopes = emptySet(),
                     ttl = 3600,
                 )
             val token2 =
@@ -181,6 +182,7 @@ class ModifyPasswordServiceImplTest :
                     email = email,
                     clientId = "client2",
                     token = "token2",
+                    scopes = emptySet(),
                     ttl = 3600,
                 )
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
@@ -84,6 +84,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                             state = "random-state",
                             codeChallenge = "challenge",
                             codeChallengeMethod = "S256",
+                            scopes = "self:read",
                             ttl = 600,
                         )
 
@@ -118,6 +119,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         savedEntitySlot.captured.redirectUri shouldBe testRedirectUri
                         savedEntitySlot.captured.codeChallenge shouldBe "challenge"
                         savedEntitySlot.captured.codeChallengeMethod shouldBe "S256"
+                        savedEntitySlot.captured.scopes shouldBe "self:read"
                         savedEntitySlot.captured.ttl shouldBe codeExpirationSeconds
                     }
 
@@ -125,6 +127,43 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         completeOauthAuthorizeFlowService.execute(reqDto)
 
                         verify(exactly = 1) { mockOauthAuthorizeStateRedisRepository.deleteById(testToken) }
+                    }
+                }
+
+                context("state entity의 scopes가 null일 때") {
+                    val reqDto =
+                        OauthAuthorizeSubmitReqDto(
+                            email = testEmail,
+                            password = "password123!",
+                            token = testToken,
+                        )
+
+                    val mockStateEntityWithNullScopes =
+                        OauthAuthorizeStateRedisEntity(
+                            token = testToken,
+                            clientId = testClientId,
+                            redirectUri = testRedirectUri,
+                            state = null,
+                            codeChallenge = null,
+                            codeChallengeMethod = null,
+                            scopes = null,
+                            ttl = 600,
+                        )
+
+                    val savedEntitySlot = slot<OauthCodeRedisEntity>()
+
+                    beforeEach {
+                        every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns
+                            Optional.of(mockStateEntityWithNullScopes)
+                        every { mockAccountJpaRepository.findByEmail(testEmail) } returns Optional.of(mockAccount)
+                        every { mockPasswordEncoder.matches("password123!", mockAccount.password) } returns true
+                        every { mockOauthCodeRedisRepository.save(capture(savedEntitySlot)) } answers { firstArg() }
+                    }
+
+                    it("code entity의 scopes도 null이어야 한다") {
+                        completeOauthAuthorizeFlowService.execute(reqDto)
+
+                        savedEntitySlot.captured.scopes shouldBe null
                     }
                 }
 
@@ -169,6 +208,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                             state = "random-state",
                             codeChallenge = "challenge",
                             codeChallengeMethod = "S256",
+                            scopes = "self:read",
                             ttl = 600,
                         )
 
@@ -206,6 +246,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                             state = "random-state",
                             codeChallenge = "challenge",
                             codeChallengeMethod = "S256",
+                            scopes = "self:read",
                             ttl = 600,
                         )
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
@@ -84,7 +84,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                             state = "random-state",
                             codeChallenge = "challenge",
                             codeChallengeMethod = "S256",
-                            scopes = "self:read",
+                            scopes = setOf("self:read"),
                             ttl = 600,
                         )
 
@@ -119,7 +119,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         savedEntitySlot.captured.redirectUri shouldBe testRedirectUri
                         savedEntitySlot.captured.codeChallenge shouldBe "challenge"
                         savedEntitySlot.captured.codeChallengeMethod shouldBe "S256"
-                        savedEntitySlot.captured.scopes shouldBe "self:read"
+                        savedEntitySlot.captured.scopes shouldBe setOf("self:read")
                         savedEntitySlot.captured.ttl shouldBe codeExpirationSeconds
                     }
 
@@ -171,7 +171,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                             state = "random-state",
                             codeChallenge = "challenge",
                             codeChallengeMethod = "S256",
-                            scopes = "self:read",
+                            scopes = setOf("self:read"),
                             ttl = 600,
                         )
 
@@ -209,7 +209,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                             state = "random-state",
                             codeChallenge = "challenge",
                             codeChallengeMethod = "S256",
-                            scopes = "self:read",
+                            scopes = setOf("self:read"),
                             ttl = 600,
                         )
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
@@ -130,43 +130,6 @@ class CompleteOauthAuthorizeFlowServiceTest :
                     }
                 }
 
-                context("state entity의 scopes가 null일 때") {
-                    val reqDto =
-                        OauthAuthorizeSubmitReqDto(
-                            email = testEmail,
-                            password = "password123!",
-                            token = testToken,
-                        )
-
-                    val mockStateEntityWithNullScopes =
-                        OauthAuthorizeStateRedisEntity(
-                            token = testToken,
-                            clientId = testClientId,
-                            redirectUri = testRedirectUri,
-                            state = null,
-                            codeChallenge = null,
-                            codeChallengeMethod = null,
-                            scopes = null,
-                            ttl = 600,
-                        )
-
-                    val savedEntitySlot = slot<OauthCodeRedisEntity>()
-
-                    beforeEach {
-                        every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns
-                            Optional.of(mockStateEntityWithNullScopes)
-                        every { mockAccountJpaRepository.findByEmail(testEmail) } returns Optional.of(mockAccount)
-                        every { mockPasswordEncoder.matches("password123!", mockAccount.password) } returns true
-                        every { mockOauthCodeRedisRepository.save(capture(savedEntitySlot)) } answers { firstArg() }
-                    }
-
-                    it("code entity의 scopes도 null이어야 한다") {
-                        completeOauthAuthorizeFlowService.execute(reqDto)
-
-                        savedEntitySlot.captured.scopes shouldBe null
-                    }
-                }
-
                 context("토큰이 유효하지 않거나 만료되었을 때") {
                     val reqDto =
                         OauthAuthorizeSubmitReqDto(

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOauthSessionServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOauthSessionServiceTest.kt
@@ -50,6 +50,7 @@ class QueryOauthSessionServiceTest :
                         state = null,
                         codeChallenge = null,
                         codeChallengeMethod = null,
+                        scopes = "self:read",
                     )
 
                 val mockClient =
@@ -82,6 +83,38 @@ class QueryOauthSessionServiceTest :
 
                         result.expiresAt shouldBeGreaterThanOrEqual before
                         result.expiresAt shouldBeLessThanOrEqual after
+                    }
+
+                    it("state entity의 scopes가 requestedScopes로 반환되어야 한다") {
+                        val result = queryOauthSessionService.execute(testToken)
+
+                        result.requestedScopes shouldBe listOf("self:read")
+                    }
+                }
+
+                context("state entity의 scopes가 null일 때") {
+                    val mockStateEntityWithNullScopes =
+                        OauthAuthorizeStateRedisEntity(
+                            token = testToken,
+                            clientId = testClientId,
+                            redirectUri = "https://example.com/callback",
+                            state = null,
+                            codeChallenge = null,
+                            codeChallengeMethod = null,
+                            scopes = null,
+                        )
+
+                    beforeEach {
+                        every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns
+                            Optional.of(mockStateEntityWithNullScopes)
+                        every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(mockClient)
+                        every { mockOauthEnvironment.authorizeStateExpirationMs } returns 600000L
+                    }
+
+                    it("client의 전체 scope가 requestedScopes로 반환되어야 한다") {
+                        val result = queryOauthSessionService.execute(testToken)
+
+                        result.requestedScopes shouldBe listOf("self:read")
                     }
                 }
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOauthSessionServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOauthSessionServiceTest.kt
@@ -92,32 +92,6 @@ class QueryOauthSessionServiceTest :
                     }
                 }
 
-                context("state entity의 scopes가 null일 때") {
-                    val mockStateEntityWithNullScopes =
-                        OauthAuthorizeStateRedisEntity(
-                            token = testToken,
-                            clientId = testClientId,
-                            redirectUri = "https://example.com/callback",
-                            state = null,
-                            codeChallenge = null,
-                            codeChallengeMethod = null,
-                            scopes = null,
-                        )
-
-                    beforeEach {
-                        every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns
-                            Optional.of(mockStateEntityWithNullScopes)
-                        every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(mockClient)
-                        every { mockOauthEnvironment.authorizeStateExpirationMs } returns 600000L
-                    }
-
-                    it("client의 전체 scope가 requestedScopes로 반환되어야 한다") {
-                        val result = queryOauthSessionService.execute(testToken)
-
-                        result.requestedScopes shouldBe listOf("self:read")
-                    }
-                }
-
                 context("Redis에 존재하지 않는 토큰이 주어졌을 때") {
                     beforeEach {
                         every { mockOauthAuthorizeStateRedisRepository.findById("expired-token") } returns Optional.empty()

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOauthSessionServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOauthSessionServiceTest.kt
@@ -50,7 +50,7 @@ class QueryOauthSessionServiceTest :
                         state = null,
                         codeChallenge = null,
                         codeChallengeMethod = null,
-                        scopes = "self:read",
+                        scopes = setOf("self:read"),
                     )
 
                 val mockClient =

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOauthSessionServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOauthSessionServiceTest.kt
@@ -2,6 +2,7 @@ package team.themoment.datagsm.oauth.authorization.domain.oauth.service
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.longs.shouldBeLessThanOrEqual
 import io.kotest.matchers.shouldBe
@@ -9,6 +10,10 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import org.springframework.http.HttpStatus
+import team.themoment.datagsm.common.domain.application.entity.ApplicationJpaEntity
+import team.themoment.datagsm.common.domain.application.entity.ThirdPartyScopeJpaEntity
+import team.themoment.datagsm.common.domain.application.repository.ThirdPartyScopeJpaRepository
+import team.themoment.datagsm.common.domain.client.dto.response.OAuthScopeResDto
 import team.themoment.datagsm.common.domain.client.entity.ClientJpaEntity
 import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
@@ -24,12 +29,14 @@ class QueryOauthSessionServiceTest :
         val mockOauthAuthorizeStateRedisRepository = mockk<OauthAuthorizeStateRedisRepository>()
         val mockClientJpaRepository = mockk<ClientJpaRepository>()
         val mockOauthEnvironment = mockk<OauthEnvironment>()
+        val mockThirdPartyScopeJpaRepository = mockk<ThirdPartyScopeJpaRepository>()
 
         val queryOauthSessionService =
             QueryOauthSessionServiceImpl(
                 mockOauthAuthorizeStateRedisRepository,
                 mockClientJpaRepository,
                 mockOauthEnvironment,
+                mockThirdPartyScopeJpaRepository,
             )
 
         afterEach {
@@ -63,7 +70,7 @@ class QueryOauthSessionServiceTest :
                         serviceName = "Test Service"
                     }
 
-                context("유효한 세션 토큰이 주어졌을 때") {
+                context("built-in scope만 포함된 유효한 세션 토큰이 주어졌을 때") {
                     beforeEach {
                         every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns Optional.of(mockStateEntity)
                         every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(mockClient)
@@ -85,10 +92,55 @@ class QueryOauthSessionServiceTest :
                         result.expiresAt shouldBeLessThanOrEqual after
                     }
 
-                    it("state entity의 scopes가 requestedScopes로 반환되어야 한다") {
+                    it("scope와 description이 포함된 requestedScopes가 반환되어야 한다") {
                         val result = queryOauthSessionService.execute(testToken)
 
-                        result.requestedScopes shouldBe listOf("self:read")
+                        result.requestedScopes shouldBe listOf(OAuthScopeResDto(scope = "self:read", description = "내 정보 조회"))
+                    }
+                }
+
+                context("ThirdPartyScope가 포함된 유효한 세션 토큰이 주어졌을 때") {
+                    val thirdPartyStateEntity =
+                        OauthAuthorizeStateRedisEntity(
+                            token = testToken,
+                            clientId = testClientId,
+                            redirectUri = "https://example.com/callback",
+                            state = null,
+                            codeChallenge = null,
+                            codeChallengeMethod = null,
+                            scopes = setOf("self:read", "app-1:profile"),
+                        )
+
+                    val mockApplication =
+                        ApplicationJpaEntity().apply {
+                            id = "app-1"
+                            name = "Test App"
+                        }
+
+                    val mockThirdPartyScopeEntity =
+                        ThirdPartyScopeJpaEntity().apply {
+                            id = 1L
+                            scopeName = "profile"
+                            description = "프로필 정보 조회"
+                            application = mockApplication
+                        }
+
+                    beforeEach {
+                        every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns Optional.of(thirdPartyStateEntity)
+                        every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(mockClient)
+                        every { mockOauthEnvironment.authorizeStateExpirationMs } returns 600000L
+                        every { mockThirdPartyScopeJpaRepository.findAllByApplicationIdIn(setOf("app-1")) } returns
+                            listOf(mockThirdPartyScopeEntity)
+                    }
+
+                    it("built-in scope와 ThirdPartyScope 모두 description이 포함되어 반환되어야 한다") {
+                        val result = queryOauthSessionService.execute(testToken)
+
+                        result.requestedScopes shouldContainExactlyInAnyOrder
+                            listOf(
+                                OAuthScopeResDto(scope = "self:read", description = "내 정보 조회"),
+                                OAuthScopeResDto(scope = "app-1:profile", description = "프로필 정보 조회"),
+                            )
                     }
                 }
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -137,7 +137,7 @@ class StartOauthAuthorizeFlowServiceTest :
                                 client_id = testClientId,
                                 redirect_uri = testRedirectUri,
                                 response_type = "code",
-                                scope = "self:read",
+                                scope = setOf("self:read"),
                             )
                         startOauthAuthorizeFlowService.execute(reqDto)
 
@@ -156,7 +156,7 @@ class StartOauthAuthorizeFlowServiceTest :
                                 client_id = testClientId,
                                 redirect_uri = testRedirectUri,
                                 response_type = "code",
-                                scope = "admin:write",
+                                scope = setOf("admin:write"),
                             )
                         val exception =
                             shouldThrow<OAuthException.InvalidScope> {

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -137,11 +137,44 @@ class StartOauthAuthorizeFlowServiceTest :
                                 client_id = testClientId,
                                 redirect_uri = testRedirectUri,
                                 response_type = "code",
-                                scope = setOf("self:read"),
+                                scope = "self:read",
                             )
                         startOauthAuthorizeFlowService.execute(reqDto)
 
                         savedEntitySlot.captured.scopes shouldBe setOf("self:read")
+                    }
+                }
+
+                context("허용된 여러 scope를 공백으로 구분하여 요청할 때") {
+                    val multiScopeClient =
+                        ClientJpaEntity().apply {
+                            id = testClientId
+                            secret = "encodedSecret"
+                            redirectUrls = setOf(testRedirectUri)
+                            scopes = setOf("self:read", "profile:read")
+                            clientName = "Test Client"
+                            serviceName = "Test Service"
+                        }
+                    val savedEntitySlot = slot<OauthAuthorizeStateRedisEntity>()
+
+                    beforeEach {
+                        every { mockOauthEnvironment.frontendUrl } returns "http://localhost:3000"
+                        every { mockOauthEnvironment.authorizeStateExpirationMs } returns 600000L
+                        every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(multiScopeClient)
+                        every { mockOauthAuthorizeStateRedisRepository.save(capture(savedEntitySlot)) } answers { firstArg() }
+                    }
+
+                    it("요청한 모든 scope가 state entity에 저장되어야 한다") {
+                        val reqDto =
+                            OauthAuthorizeReqDto(
+                                client_id = testClientId,
+                                redirect_uri = testRedirectUri,
+                                response_type = "code",
+                                scope = "self:read profile:read",
+                            )
+                        startOauthAuthorizeFlowService.execute(reqDto)
+
+                        savedEntitySlot.captured.scopes shouldBe setOf("self:read", "profile:read")
                     }
                 }
 
@@ -156,7 +189,7 @@ class StartOauthAuthorizeFlowServiceTest :
                                 client_id = testClientId,
                                 redirect_uri = testRedirectUri,
                                 response_type = "code",
-                                scope = setOf("admin:write"),
+                                scope = "admin:write",
                             )
                         val exception =
                             shouldThrow<OAuthException.InvalidScope> {

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -54,6 +54,7 @@ class StartOauthAuthorizeFlowServiceTest :
                         id = testClientId
                         secret = "encodedSecret"
                         redirectUrls = setOf(testRedirectUri)
+                        scopes = setOf("self:read")
                         clientName = "Test Client"
                         serviceName = "Test Service"
                     }
@@ -93,6 +94,78 @@ class StartOauthAuthorizeFlowServiceTest :
                         savedEntitySlot.captured.codeChallenge shouldBe "challenge"
                         savedEntitySlot.captured.codeChallengeMethod shouldBe "S256"
                         savedEntitySlot.captured.ttl shouldBe 600
+                        savedEntitySlot.captured.scopes shouldBe "self:read"
+                    }
+                }
+
+                context("scope 파라미터가 null일 때") {
+                    val savedEntitySlot = slot<OauthAuthorizeStateRedisEntity>()
+
+                    beforeEach {
+                        every { mockOauthEnvironment.frontendUrl } returns "http://localhost:3000"
+                        every { mockOauthEnvironment.authorizeStateExpirationMs } returns 600000L
+                        every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(mockClient)
+                        every { mockOauthAuthorizeStateRedisRepository.save(capture(savedEntitySlot)) } answers { firstArg() }
+                    }
+
+                    it("client의 전체 scope가 state entity에 저장되어야 한다") {
+                        val reqDto =
+                            OauthAuthorizeReqDto(
+                                client_id = testClientId,
+                                redirect_uri = testRedirectUri,
+                                response_type = "code",
+                            )
+                        startOauthAuthorizeFlowService.execute(reqDto)
+
+                        savedEntitySlot.captured.scopes shouldBe "self:read"
+                    }
+                }
+
+                context("허용된 scope를 요청할 때") {
+                    val savedEntitySlot = slot<OauthAuthorizeStateRedisEntity>()
+
+                    beforeEach {
+                        every { mockOauthEnvironment.frontendUrl } returns "http://localhost:3000"
+                        every { mockOauthEnvironment.authorizeStateExpirationMs } returns 600000L
+                        every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(mockClient)
+                        every { mockOauthAuthorizeStateRedisRepository.save(capture(savedEntitySlot)) } answers { firstArg() }
+                    }
+
+                    it("요청한 scope가 state entity에 저장되어야 한다") {
+                        val reqDto =
+                            OauthAuthorizeReqDto(
+                                client_id = testClientId,
+                                redirect_uri = testRedirectUri,
+                                response_type = "code",
+                                scope = "self:read",
+                            )
+                        startOauthAuthorizeFlowService.execute(reqDto)
+
+                        savedEntitySlot.captured.scopes shouldBe "self:read"
+                    }
+                }
+
+                context("허용되지 않은 scope를 요청할 때") {
+                    beforeEach {
+                        every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(mockClient)
+                    }
+
+                    it("InvalidScope 예외가 발생하고 Redis에 저장되지 않아야 한다") {
+                        val reqDto =
+                            OauthAuthorizeReqDto(
+                                client_id = testClientId,
+                                redirect_uri = testRedirectUri,
+                                response_type = "code",
+                                scope = "admin:write",
+                            )
+                        val exception =
+                            shouldThrow<OAuthException.InvalidScope> {
+                                startOauthAuthorizeFlowService.execute(reqDto)
+                            }
+
+                        exception.error shouldBe "invalid_scope"
+
+                        verify(exactly = 0) { mockOauthAuthorizeStateRedisRepository.save(any()) }
                     }
                 }
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -94,7 +94,7 @@ class StartOauthAuthorizeFlowServiceTest :
                         savedEntitySlot.captured.codeChallenge shouldBe "challenge"
                         savedEntitySlot.captured.codeChallengeMethod shouldBe "S256"
                         savedEntitySlot.captured.ttl shouldBe 600
-                        savedEntitySlot.captured.scopes shouldBe "self:read"
+                        savedEntitySlot.captured.scopes shouldBe setOf("self:read")
                     }
                 }
 
@@ -117,7 +117,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         startOauthAuthorizeFlowService.execute(reqDto)
 
-                        savedEntitySlot.captured.scopes shouldBe "self:read"
+                        savedEntitySlot.captured.scopes shouldBe setOf("self:read")
                     }
                 }
 
@@ -141,7 +141,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         startOauthAuthorizeFlowService.execute(reqDto)
 
-                        savedEntitySlot.captured.scopes shouldBe "self:read"
+                        savedEntitySlot.captured.scopes shouldBe setOf("self:read")
                     }
                 }
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
@@ -74,6 +74,7 @@ class Oauth2TokenServiceImplTest :
                             redirectUri = "https://example.com/callback",
                             codeChallenge = null,
                             codeChallengeMethod = null,
+                            scopes = null,
                             code = "test-code",
                             ttl = 300,
                         )
@@ -120,6 +121,102 @@ class Oauth2TokenServiceImplTest :
                     }
                 }
 
+                context("code에 scopes가 저장된 신규 flow일 때") {
+                    val codeWithScopes =
+                        OauthCodeRedisEntity(
+                            email = "test@gsm.hs.kr",
+                            clientId = "test-client",
+                            redirectUri = "https://example.com/callback",
+                            codeChallenge = null,
+                            codeChallengeMethod = null,
+                            scopes = "self:read",
+                            code = "test-code",
+                            ttl = 300,
+                        )
+
+                    val client =
+                        ClientJpaEntity().apply {
+                            id = "test-client"
+                            secret = "hashed-secret"
+                            redirectUrls = setOf("https://example.com/callback")
+                            scopes = setOf("self:read")
+                        }
+
+                    val account =
+                        AccountJpaEntity().apply {
+                            email = "test@gsm.hs.kr"
+                            role = AccountRole.USER
+                        }
+
+                    val baseSetup = {
+                        every { mockOauthCodeRedisRepository.findById("test-code") } returns Optional.of(codeWithScopes)
+                        every { mockClientJpaRepository.findById("test-client") } returns Optional.of(client)
+                        every { mockPasswordEncoder.matches("test-secret", "hashed-secret") } returns true
+                        every { mockAccountJpaRepository.findByEmail("test@gsm.hs.kr") } returns Optional.of(account)
+                        every { mockJwtProvider.generateOauthAccessToken(any(), any(), any(), any()) } returns "access-token"
+                        every { mockJwtProvider.generateOauthRefreshToken(any(), any()) } returns "refresh-token"
+                        every { mockJwtEnvironment.accessTokenExpiration } returns 3600000L
+                        every { mockJwtEnvironment.refreshTokenExpiration } returns 2592000000L
+                        every { mockOauthRefreshTokenRedisRepository.deleteByEmailAndClientId(any(), any()) } returns Unit
+                        every { mockOauthRefreshTokenRedisRepository.save(any()) } answers { firstArg() }
+                        every { mockOauthCodeRedisRepository.delete(any()) } returns Unit
+                    }
+
+                    it("reqDto.scope가 null이면 code의 scope로 토큰이 발급된다") {
+                        baseSetup()
+                        val reqDto =
+                            Oauth2TokenReqDto(
+                                grantType = "authorization_code",
+                                code = "test-code",
+                                clientId = "test-client",
+                                clientSecret = "test-secret",
+                                redirectUri = "https://example.com/callback",
+                            )
+
+                        val result = service.execute(reqDto)
+
+                        result.scope shouldBe "self:read"
+                    }
+
+                    it("reqDto.scope가 code scope의 부분집합이면 허용된다") {
+                        baseSetup()
+                        val reqDto =
+                            Oauth2TokenReqDto(
+                                grantType = "authorization_code",
+                                code = "test-code",
+                                clientId = "test-client",
+                                clientSecret = "test-secret",
+                                redirectUri = "https://example.com/callback",
+                                scope = "self:read",
+                            )
+
+                        val result = service.execute(reqDto)
+
+                        result.scope shouldBe "self:read"
+                    }
+
+                    it("reqDto.scope가 code scope를 초과하면 InvalidScope 예외가 발생한다") {
+                        baseSetup()
+                        val reqDto =
+                            Oauth2TokenReqDto(
+                                grantType = "authorization_code",
+                                code = "test-code",
+                                clientId = "test-client",
+                                clientSecret = "test-secret",
+                                redirectUri = "https://example.com/callback",
+                                scope = "admin:write",
+                            )
+
+                        val exception =
+                            shouldThrow<OAuthException.InvalidScope> {
+                                service.execute(reqDto)
+                            }
+
+                        exception.error shouldBe "invalid_scope"
+                        exception.errorDescription shouldBe "요청한 scope가 인가 코드의 scope를 초과합니다."
+                    }
+                }
+
                 context("PKCE를 사용하는 authorization_code 요청일 때") {
                     val reqDto =
                         Oauth2TokenReqDto(
@@ -137,6 +234,7 @@ class Oauth2TokenServiceImplTest :
                             redirectUri = null,
                             codeChallenge = "challenge-hash",
                             codeChallengeMethod = "S256",
+                            scopes = null,
                             code = "test-code",
                             ttl = 300,
                         )

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
@@ -74,7 +74,7 @@ class Oauth2TokenServiceImplTest :
                             redirectUri = "https://example.com/callback",
                             codeChallenge = null,
                             codeChallengeMethod = null,
-                            scopes = "self:read",
+                            scopes = setOf("self:read"),
                             code = "test-code",
                             ttl = 300,
                         )
@@ -129,7 +129,7 @@ class Oauth2TokenServiceImplTest :
                             redirectUri = "https://example.com/callback",
                             codeChallenge = null,
                             codeChallengeMethod = null,
-                            scopes = "self:read",
+                            scopes = setOf("self:read"),
                             code = "test-code",
                             ttl = 300,
                         )
@@ -234,7 +234,7 @@ class Oauth2TokenServiceImplTest :
                             redirectUri = null,
                             codeChallenge = "challenge-hash",
                             codeChallengeMethod = "S256",
-                            scopes = "self:read",
+                            scopes = setOf("self:read"),
                             code = "test-code",
                             ttl = 300,
                         )

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
@@ -187,7 +187,7 @@ class Oauth2TokenServiceImplTest :
                                 clientId = "test-client",
                                 clientSecret = "test-secret",
                                 redirectUri = "https://example.com/callback",
-                                scope = "self:read",
+                                scope = setOf("self:read"),
                             )
 
                         val result = service.execute(reqDto)
@@ -204,7 +204,7 @@ class Oauth2TokenServiceImplTest :
                                 clientId = "test-client",
                                 clientSecret = "test-secret",
                                 redirectUri = "https://example.com/callback",
-                                scope = "admin:write",
+                                scope = setOf("admin:write"),
                             )
 
                         val exception =
@@ -328,7 +328,7 @@ class Oauth2TokenServiceImplTest :
                             grantType = "client_credentials",
                             clientId = "test-client",
                             clientSecret = "test-secret",
-                            scope = "self:read",
+                            scope = setOf("self:read"),
                         )
 
                     val client =

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
@@ -74,7 +74,7 @@ class Oauth2TokenServiceImplTest :
                             redirectUri = "https://example.com/callback",
                             codeChallenge = null,
                             codeChallengeMethod = null,
-                            scopes = null,
+                            scopes = "self:read",
                             code = "test-code",
                             ttl = 300,
                         )
@@ -234,7 +234,7 @@ class Oauth2TokenServiceImplTest :
                             redirectUri = null,
                             codeChallenge = "challenge-hash",
                             codeChallengeMethod = "S256",
-                            scopes = null,
+                            scopes = "self:read",
                             code = "test-code",
                             ttl = 300,
                         )

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
@@ -289,6 +289,7 @@ class Oauth2TokenServiceImplTest :
                             email = "test@gsm.hs.kr",
                             clientId = "test-client",
                             token = "valid-refresh-token",
+                            scopes = setOf("self:read"),
                             ttl = 2592000L,
                         )
 
@@ -319,6 +320,26 @@ class Oauth2TokenServiceImplTest :
 
                         verify(exactly = 1) { mockJwtProvider.validateToken("valid-refresh-token") }
                         verify(exactly = 1) { mockOauthRefreshTokenRedisRepository.save(any()) }
+                    }
+
+                    it("저장된 scope가 그대로 access token에 사용된다") {
+                        val result = service.execute(reqDto)
+
+                        result.scope shouldBe "self:read"
+                    }
+
+                    it("client scope가 변경되어도 저장된 scope를 사용한다") {
+                        val clientWithDifferentScopes =
+                            ClientJpaEntity().apply {
+                                id = "test-client"
+                                secret = "hashed-secret"
+                                scopes = setOf("admin:write") // storedToken.scopes와 다름
+                            }
+                        every { mockClientJpaRepository.findById("test-client") } returns Optional.of(clientWithDifferentScopes)
+
+                        val result = service.execute(reqDto)
+
+                        result.scope shouldBe "self:read"
                     }
                 }
 


### PR DESCRIPTION
## 개요

OAuth 2.0 RFC 6749 표준에 맞게 `GET /v1/oauth/authorize` 단계에서 scope를 수신·검증·저장하도록 흐름을 개선하였습니다. 이를 통해 FE 로그인 페이지에서 요청된 scope를 사용자에게 표시할 수 있게 되었으며, token 발급 시에는 code에 저장된 scope를 우선 사용하도록 수정되었습니다.

## 본문

### 변경 배경

기존에는 scope가 `POST /v1/oauth/token` 시점에만 전달되어, FE 로그인 페이지에서 "이 서비스가 어떤 권한을 요청한다"는 정보를 사용자에게 표시할 수 없었습니다. OAuth 2.0 RFC 6749에서도 scope는 authorize 단계에 포함하도록 정의되어 있어 이를 반영하였습니다.

### 주요 변경 사항

**공통 DTO/Entity 확장 (`datagsm-common`)**
- `OauthAuthorizeReqDto`: `scope: Set<String>?` 쿼리 파라미터 추가 (선택값, 미입력 시 client 전체 scope 사용)
- `OauthAuthorizeStateRedisEntity`: `scopes: Set<String>` 필드 추가
- `OauthCodeRedisEntity`: `scopes: Set<String>` 필드 추가
- `OauthSessionResDto`: `requestedScopes: List<String>` 응답 필드 추가

**서비스 로직 수정 (`datagsm-oauth-authorization`)**
- `StartOauthAuthorizeFlowServiceImpl`: authorize 요청 시 scope를 검증하고 Redis state entity에 저장하도록 수정. scope 미입력 시 client 전체 scope 사용, 입력 시 client 허용 범위 초과 여부를 검증 (`OAuthException.InvalidScope` 발생). ThirdPartyScope DB 조회는 수행하지 않고 문자열 집합 비교만 수행
- `CompleteOauthAuthorizeFlowServiceImpl`: state entity의 scopes를 code entity로 전달하도록 수정
- `QueryOauthSessionServiceImpl`: `OauthSessionResDto` 반환 시 state entity의 `scopes`를 `requestedScopes`로 포함
- `Oauth2TokenServiceImpl`: code에 저장된 `scopes`를 직접 사용하도록 수정. token 요청 시 scope가 code scope를 초과하면 `OAuthException.InvalidScope` 발생