### PR TITLE
[global] Gradle 설정에서 불안정한 API 사용 경고 제거

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,10 +7,9 @@ pluginManagement {
     }
 }
 
+@Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
-    @Suppress("UnstableApiUsage")
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    @Suppress("UnstableApiUsage")
     repositories {
         mavenCentral()
         maven("https://jitpack.io")


### PR DESCRIPTION
## 개요

settings.gradle.kts 파일의 repositories 블록에서 발생하는 UnstableApiUsage 경고를 억제하였습니다.

## 본문

- @Suppress("UnstableApiUsage") 어노테이션을 추가하여 Gradle의 불안정한 API 사용 경고를 억제하였습니다.
- 해당 수정은 오류를 가리는 성격의 PR이지만, 현재 repositories 블록에서의 경고가 불필요한 노이즈를 발생시키며 작업 진행에 무의미하다고 판단하여 억제 처리하였습니다.
