### PR TITLE
[global] 엔티티 누락 인덱스 추가

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/entity/AccountJpaEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/entity/AccountJpaEntity.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
@@ -17,7 +18,12 @@ import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import java.time.LocalDateTime
 
-@Table(name = "tb_account")
+@Table(
+    name = "tb_account",
+    indexes = [
+        Index(name = "idx_account_student_id", columnList = "student_id"),
+    ],
+)
 @Entity
 @DynamicUpdate
 class AccountJpaEntity {

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/auth/entity/ApiKey.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/auth/entity/ApiKey.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
@@ -15,7 +16,10 @@ import team.themoment.datagsm.common.global.converter.StringSetConverter
 import java.time.LocalDateTime
 import java.util.UUID
 
-@Table(name = "tb_api_key")
+@Table(
+    name = "tb_api_key",
+    indexes = [Index(name = "idx_api_key_expires_at", columnList = "expires_at")],
+)
 @Entity
 @DynamicUpdate
 class ApiKey {
@@ -37,7 +41,7 @@ class ApiKey {
     var expiresAt: LocalDateTime = LocalDateTime.now()
 
     @OneToOne
-    @JoinColumn(name = "account_id", nullable = false, referencedColumnName = "id")
+    @JoinColumn(name = "account_id", nullable = false, referencedColumnName = "id", unique = true)
     lateinit var account: AccountJpaEntity
 
     @Convert(converter = StringSetConverter::class)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/ClientJpaEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/ClientJpaEntity.kt
@@ -4,13 +4,21 @@ import jakarta.persistence.Column
 import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
+import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.global.converter.StringSetConverter
 
-@Table(name = "tb_client")
+@Table(
+    name = "tb_client",
+    indexes = [
+        Index(name = "idx_client_account_id", columnList = "account_id"),
+        Index(name = "idx_client_client_name", columnList = "client_name"),
+        Index(name = "idx_client_service_name", columnList = "service_name"),
+    ],
+)
 @Entity
 class ClientJpaEntity {
     @Id

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/entity/StudentJpaEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/entity/StudentJpaEntity.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
@@ -25,6 +26,10 @@ import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
             name = "uk_student_number",
             columnNames = ["student_grade", "student_class", "student_number"],
         ),
+    ],
+    indexes = [
+        Index(name = "idx_student_major_club_id", columnList = "major_club_id"),
+        Index(name = "idx_student_autonomous_club_id", columnList = "autonomous_club_id"),
     ],
 )
 @Entity


### PR DESCRIPTION
## 개요

`account`, `auth`, `client`, `student` 도메인 엔티티에 누락되어 있던 DB 인덱스를 추가하였습니다.
  또한 `ApiKey` 엔티티의 `account_id` 외래키에 `unique` 제약 조건을 명시하였습니다.


## 본문

조회 성능 개선을 위해 각 엔티티의 `@Table` 어노테이션에 `indexes` 속성을 추가하였습니다.

 **AccountJpaEntity (`tb_account`)**
  - `idx_account_student_id` — `student_id` 컬럼 인덱스 추가

  **ApiKey (`tb_api_key`)**
  - `idx_api_key_expires_at` — `expires_at` 컬럼 인덱스 추가
  - `account_id` 외래키에 `unique = true` 제약 조건 명시 (1:1 관계 보장)

  **ClientJpaEntity (`tb_client`)**
  - `idx_client_account_id` — `account_id` 컬럼 인덱스 추가
  - `idx_client_client_name` — `client_name` 컬럼 인덱스 추가
  - `idx_client_service_name` — `service_name` 컬럼 인덱스 추가

  **StudentJpaEntity (`tb_student`)**
  - `idx_student_major_club_id` — `major_club_id` 컬럼 인덱스 추가
  - `idx_student_autonomous_club_id` — `autonomous_club_id` 컬럼 인덱스 추가
