### PR TITLE
[student] 학생 본인 전공 수정 접근 제어 수정

### DIFF
--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/global/security/config/SecurityConfig.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/global/security/config/SecurityConfig.kt
@@ -48,6 +48,8 @@ class SecurityConfig(
                 it
                     .requestMatchers(*AuthenticationPathConfig.PUBLIC_PATHS.toTypedArray())
                     .permitAll()
+                    .requestMatchers(HttpMethod.PATCH, "/v1/students/me/specialty")
+                    .authenticated()
                     .requestMatchers(
                         "/v1/students/**",
                         "/v1/projects/**",


### PR DESCRIPTION
## 개요

학생이 자신의 전공을 수정하는 `PATCH /v1/students/me/specialty` API가 기존 보안 규칙에 의해 관리자 권한으로만 제한되던 문제를 수정하였습니다.
해당 경로를 인증 사용자에게 허용하도록 예외 처리하여 학생 계정에서도 정상 호출되도록 변경하였습니다.

## 본문

기존 `SecurityConfig`에서는 `/v1/students/**` 경로 전체가 `ADMIN`, `ROOT` 권한으로 제한되고 있었습니다.
이 때문에 학생 본인이 호출해야 하는 `PATCH /v1/students/me/specialty` 역시 동일한 규칙에 포함되어 실제 서비스 의도와 다르게 차단되고 있었습니다.

이를 해결하기 위해 `PATCH /v1/students/me/specialty` 경로를 관리자 전용 규칙보다 먼저 선언하고, `authenticated()`로 접근 가능하도록 조정하였습니다.
해당 변경으로 로그인한 계정은 본인 전공 수정 API를 호출할 수 있으며, 기존 학생 관리 API 전체에 대한 관리자 전용 정책은 그대로 유지되도록 구성하였습니다.

변경 후 `./gradlew :datagsm-web:compileKotlin`으로 컴파일 검증을 진행하여 설정 변경에 따른 오류가 없음을 확인하였습니다.
