### PR TITLE
[student] GitHub 아이디 필드 추가 및 수정 기능 구현

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/request/UpdateStudentReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/request/UpdateStudentReqDto.kt
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
@@ -46,4 +47,8 @@ data class UpdateStudentReqDto(
     @field:Size(max = 50)
     @param:Schema(description = "전공", example = "백엔드", maxLength = 50)
     val specialty: String? = null,
+    @field:Size(max = 39)
+    @field:Pattern(regexp = "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$", message = "유효하지 않은 GitHub 아이디 형식입니다.")
+    @param:Schema(description = "GitHub 아이디", example = "torvalds", maxLength = 39)
+    val githubId: String? = null,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/response/StudentResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/response/StudentResDto.kt
@@ -37,4 +37,8 @@ data class StudentResDto(
     val majorClub: ClubSummaryDto?,
     @field:Schema(description = "자율 동아리")
     val autonomousClub: ClubSummaryDto?,
+    @field:Schema(description = "GitHub 아이디", example = "torvalds")
+    val githubId: String?,
+    @field:Schema(description = "GitHub 프로필 URL", example = "https://github.com/torvalds")
+    val githubUrl: String?,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/entity/StudentJpaEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/entity/StudentJpaEntity.kt
@@ -56,6 +56,9 @@ class StudentJpaEntity {
     @field:Column(name = "specialty", nullable = true, length = 50)
     var specialty: String? = null
 
+    @field:Column(name = "github_id", nullable = true, length = 39)
+    var githubId: String? = null
+
     @field:JoinColumn(name = "major_club_id", nullable = true, referencedColumnName = "id")
     @field:ManyToOne(optional = true)
     var majorClub: ClubJpaEntity? = null

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
@@ -46,5 +46,7 @@ class QueryUserInfoServiceImpl(
             dormitoryRoom = student.dormitoryRoomNumber?.dormitoryRoomNumber,
             majorClub = student.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
             autonomousClub = student.autonomousClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
+            githubId = student.githubId,
+            githubUrl = student.githubId?.let { "https://github.com/$it" },
         )
 }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/student/service/impl/CreateStudentServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/student/service/impl/CreateStudentServiceImpl.kt
@@ -109,6 +109,8 @@ class CreateStudentServiceImpl(
             dormitoryRoom = savedStudent.dormitoryRoomNumber?.dormitoryRoomNumber,
             majorClub = savedStudent.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
             autonomousClub = savedStudent.autonomousClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
+            githubId = savedStudent.githubId,
+            githubUrl = savedStudent.githubId?.let { "https://github.com/$it" },
         )
     }
 }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/student/service/impl/ModifyStudentServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/student/service/impl/ModifyStudentServiceImpl.kt
@@ -60,6 +60,7 @@ class ModifyStudentServiceImpl(
         student.studentNumber = StudentNumber(reqDto.grade, reqDto.classNum, reqDto.number)
         student.major = major
         student.specialty = reqDto.specialty
+        student.githubId = reqDto.githubId
         student.role = reqDto.role
         student.dormitoryRoomNumber = DormitoryRoomNumber(reqDto.dormitoryRoomNumber)
         val clubIds = listOfNotNull(reqDto.majorClubId, reqDto.autonomousClubId)
@@ -93,6 +94,8 @@ class ModifyStudentServiceImpl(
             dormitoryRoom = student.dormitoryRoomNumber?.dormitoryRoomNumber,
             majorClub = student.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
             autonomousClub = student.autonomousClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
+            githubId = student.githubId,
+            githubUrl = student.githubId?.let { "https://github.com/$it" },
         )
     }
 }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/student/service/impl/QueryStudentServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/student/service/impl/QueryStudentServiceImpl.kt
@@ -57,6 +57,8 @@ class QueryStudentServiceImpl(
                         dormitoryRoom = entity.dormitoryRoomNumber?.dormitoryRoomNumber,
                         majorClub = entity.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
                         autonomousClub = entity.autonomousClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
+                        githubId = entity.githubId,
+                        githubUrl = entity.githubId?.let { "https://github.com/$it" },
                     )
                 },
         )

--- a/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/student/service/ModifyStudentServiceTest.kt
+++ b/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/student/service/ModifyStudentServiceTest.kt
@@ -246,6 +246,49 @@ class ModifyStudentServiceTest :
                         verify(exactly = 0) { mockStudentRepository.existsByStudentEmailAndNotId(any(), any()) }
                     }
                 }
+
+                context("githubId를 포함하여 수정할 때") {
+                    val studentId = 8L
+                    lateinit var existingStudent: StudentJpaEntity
+                    val req =
+                        UpdateStudentReqDto(
+                            name = "수정된이름",
+                            sex = Sex.WOMAN,
+                            email = "updated@gsm.hs.kr",
+                            grade = 3,
+                            classNum = 2,
+                            number = 15,
+                            role = StudentRole.GENERAL_STUDENT,
+                            githubId = "torvalds",
+                        )
+
+                    beforeEach {
+                        existingStudent =
+                            StudentJpaEntity().apply {
+                                this.id = studentId
+                                name = "기존이름"
+                                sex = Sex.MAN
+                                email = "old@gsm.hs.kr"
+                                studentNumber = StudentNumber(2, 1, 10)
+                                role = StudentRole.GENERAL_STUDENT
+                            }
+
+                        every { mockStudentRepository.findById(studentId) } returns Optional.of(existingStudent)
+                        every {
+                            mockStudentRepository.existsByStudentEmailAndNotId(req.email, studentId)
+                        } returns false
+                        every {
+                            mockStudentRepository.existsByStudentNumberAndNotId(req.grade, req.classNum, req.number, studentId)
+                        } returns false
+                    }
+
+                    it("githubId와 githubUrl이 응답에 포함되어야 한다") {
+                        val res = modifyStudentService.execute(studentId, req)
+
+                        res.githubId shouldBe "torvalds"
+                        res.githubUrl shouldBe "https://github.com/torvalds"
+                    }
+                }
             }
         }
     })

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
@@ -46,5 +46,7 @@ class QueryMyInfoServiceImpl(
             dormitoryRoom = student.dormitoryRoomNumber?.dormitoryRoomNumber,
             majorClub = student.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
             autonomousClub = student.autonomousClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
+            githubId = student.githubId,
+            githubUrl = student.githubId?.let { "https://github.com/$it" },
         )
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/controller/StudentController.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/controller/StudentController.kt
@@ -27,12 +27,14 @@ import team.themoment.datagsm.common.domain.student.dto.request.UpdateStudentSta
 import team.themoment.datagsm.common.domain.student.dto.response.GraduateStudentResDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentListResDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
+import team.themoment.datagsm.web.domain.student.dto.request.UpdateMyGithubIdReqDto
 import team.themoment.datagsm.web.domain.student.dto.request.UpdateMySpecialtyReqDto
 import team.themoment.datagsm.web.domain.student.service.BatchOperationService
 import team.themoment.datagsm.web.domain.student.service.CreateStudentExcelService
 import team.themoment.datagsm.web.domain.student.service.CreateStudentService
 import team.themoment.datagsm.web.domain.student.service.GraduateStudentService
 import team.themoment.datagsm.web.domain.student.service.GraduateThirdGradeStudentsService
+import team.themoment.datagsm.web.domain.student.service.ModifyMyGithubIdService
 import team.themoment.datagsm.web.domain.student.service.ModifyMySpecialtyService
 import team.themoment.datagsm.web.domain.student.service.ModifyStudentExcelService
 import team.themoment.datagsm.web.domain.student.service.ModifyStudentService
@@ -55,6 +57,7 @@ class StudentController(
     private val modifyStudentStatusService: ModifyStudentStatusService,
     private val batchOperationService: BatchOperationService,
     private val modifyMySpecialtyService: ModifyMySpecialtyService,
+    private val modifyMyGithubIdService: ModifyMyGithubIdService,
 ) {
     @Operation(summary = "학생 정보 조회", description = "필터 조건에 맞는 학생 정보를 조회합니다.")
     @ApiResponses(
@@ -196,5 +199,19 @@ class StudentController(
         @RequestBody @Valid reqDto: UpdateMySpecialtyReqDto,
     ) {
         modifyMySpecialtyService.execute(reqDto)
+    }
+
+    @Operation(summary = "내 GitHub 아이디 수정", description = "로그인한 학생 본인의 GitHub 아이디를 수정합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "수정 성공"),
+            ApiResponse(responseCode = "403", description = "학생 정보가 연결되지 않은 계정", content = [Content()]),
+        ],
+    )
+    @PatchMapping("/me/github-id")
+    fun updateMyGithubId(
+        @RequestBody @Valid reqDto: UpdateMyGithubIdReqDto,
+    ) {
+        modifyMyGithubIdService.execute(reqDto)
     }
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/dto/request/UpdateMyGithubIdReqDto.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/dto/request/UpdateMyGithubIdReqDto.kt
@@ -1,0 +1,15 @@
+package team.themoment.datagsm.web.domain.student.dto.request
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+data class UpdateMyGithubIdReqDto(
+    // Github 서비스 자체 ID 제약조건과 동일
+    @field:Size(max = 39)
+    @field:Pattern(regexp = "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$", message = "유효하지 않은 GitHub 아이디 형식입니다.")
+    @field:JsonProperty("githubId")
+    @param:Schema(description = "GitHub 아이디", example = "torvalds", maxLength = 39)
+    val githubId: String?,
+)

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyMyGithubIdService.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyMyGithubIdService.kt
@@ -1,0 +1,7 @@
+package team.themoment.datagsm.web.domain.student.service
+
+import team.themoment.datagsm.web.domain.student.dto.request.UpdateMyGithubIdReqDto
+
+interface ModifyMyGithubIdService {
+    fun execute(reqDto: UpdateMyGithubIdReqDto)
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/CreateStudentServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/CreateStudentServiceImpl.kt
@@ -109,6 +109,8 @@ class CreateStudentServiceImpl(
             dormitoryRoom = savedStudent.dormitoryRoomNumber?.dormitoryRoomNumber,
             majorClub = savedStudent.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
             autonomousClub = savedStudent.autonomousClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
+            githubId = savedStudent.githubId,
+            githubUrl = savedStudent.githubId?.let { "https://github.com/$it" },
         )
     }
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyMyGithubIdServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyMyGithubIdServiceImpl.kt
@@ -1,0 +1,23 @@
+package team.themoment.datagsm.web.domain.student.service.impl
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.web.domain.student.dto.request.UpdateMyGithubIdReqDto
+import team.themoment.datagsm.web.domain.student.service.ModifyMyGithubIdService
+import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class ModifyMyGithubIdServiceImpl(
+    private val currentUserProvider: CurrentUserProvider,
+) : ModifyMyGithubIdService {
+    @Transactional
+    override fun execute(reqDto: UpdateMyGithubIdReqDto) {
+        val account = currentUserProvider.getCurrentAccount()
+        val student =
+            account.student
+                ?: throw ExpectedException("학생 정보가 연결되지 않은 계정입니다.", HttpStatus.FORBIDDEN)
+        student.githubId = reqDto.githubId
+    }
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentServiceImpl.kt
@@ -62,6 +62,7 @@ class ModifyStudentServiceImpl(
         student.studentNumber = StudentNumber(reqDto.grade, reqDto.classNum, reqDto.number)
         student.major = major
         student.specialty = reqDto.specialty
+        student.githubId = reqDto.githubId
         student.role = reqDto.role
         student.dormitoryRoomNumber = DormitoryRoomNumber(reqDto.dormitoryRoomNumber)
         val clubIds = listOfNotNull(reqDto.majorClubId, reqDto.autonomousClubId)
@@ -95,6 +96,8 @@ class ModifyStudentServiceImpl(
             dormitoryRoom = student.dormitoryRoomNumber?.dormitoryRoomNumber,
             majorClub = student.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
             autonomousClub = student.autonomousClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
+            githubId = student.githubId,
+            githubUrl = student.githubId?.let { "https://github.com/$it" },
         )
     }
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/QueryStudentServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/QueryStudentServiceImpl.kt
@@ -57,6 +57,8 @@ class QueryStudentServiceImpl(
                         dormitoryRoom = entity.dormitoryRoomNumber?.dormitoryRoomNumber,
                         majorClub = entity.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
                         autonomousClub = entity.autonomousClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
+                        githubId = entity.githubId,
+                        githubUrl = entity.githubId?.let { "https://github.com/$it" },
                     )
                 },
         )

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentServiceTest.kt
@@ -515,6 +515,62 @@ class ModifyStudentServiceTest :
                         result.role shouldBe StudentRole.STUDENT_COUNCIL
                     }
                 }
+
+                context("githubId를 포함하여 수정할 때") {
+                    val updateRequest =
+                        UpdateStudentReqDto(
+                            name = "수정된이름",
+                            sex = Sex.MAN,
+                            email = "existing@gsm.hs.kr",
+                            grade = 2,
+                            classNum = 1,
+                            number = 5,
+                            role = StudentRole.GENERAL_STUDENT,
+                            dormitoryRoomNumber = 201,
+                            githubId = "torvalds",
+                        )
+
+                    beforeEach {
+                        every { mockStudentRepository.findById(studentId) } returns Optional.of(existingStudent)
+                        every { mockStudentRepository.existsByStudentEmailAndNotId("existing@gsm.hs.kr", studentId) } returns false
+                        every { mockStudentRepository.existsByStudentNumberAndNotId(2, 1, 5, studentId) } returns false
+                    }
+
+                    it("githubId와 githubUrl이 응답에 포함되어야 한다") {
+                        val result = modifyStudentService.execute(studentId, updateRequest)
+
+                        result.githubId shouldBe "torvalds"
+                        result.githubUrl shouldBe "https://github.com/torvalds"
+                    }
+                }
+
+                context("githubId를 null로 설정하여 수정할 때") {
+                    val updateRequest =
+                        UpdateStudentReqDto(
+                            name = "수정된이름",
+                            sex = Sex.MAN,
+                            email = "existing@gsm.hs.kr",
+                            grade = 2,
+                            classNum = 1,
+                            number = 5,
+                            role = StudentRole.GENERAL_STUDENT,
+                            dormitoryRoomNumber = 201,
+                            githubId = null,
+                        )
+
+                    beforeEach {
+                        every { mockStudentRepository.findById(studentId) } returns Optional.of(existingStudent)
+                        every { mockStudentRepository.existsByStudentEmailAndNotId("existing@gsm.hs.kr", studentId) } returns false
+                        every { mockStudentRepository.existsByStudentNumberAndNotId(2, 1, 5, studentId) } returns false
+                    }
+
+                    it("githubId와 githubUrl이 null이어야 한다") {
+                        val result = modifyStudentService.execute(studentId, updateRequest)
+
+                        result.githubId shouldBe null
+                        result.githubUrl shouldBe null
+                    }
+                }
             }
         }
     })

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyMyGithubIdServiceImplTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyMyGithubIdServiceImplTest.kt
@@ -1,0 +1,100 @@
+package team.themoment.datagsm.web.domain.student.service.impl
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.constant.Sex
+import team.themoment.datagsm.web.domain.student.dto.request.UpdateMyGithubIdReqDto
+import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
+import team.themoment.sdk.exception.ExpectedException
+
+class ModifyMyGithubIdServiceImplTest :
+    BehaviorSpec({
+        val currentUserProvider = mockk<CurrentUserProvider>()
+        val service = ModifyMyGithubIdServiceImpl(currentUserProvider)
+
+        Given("학생이 연결된 계정으로 GitHub ID를 수정할 때") {
+            val student =
+                StudentJpaEntity().apply {
+                    id = 1L
+                    name = "홍길동"
+                    email = "hong@gsm.hs.kr"
+                    sex = Sex.MAN
+                }
+            val account =
+                AccountJpaEntity().apply {
+                    id = 10L
+                    email = "hong@gsm.hs.kr"
+                    password = "password"
+                    this.student = student
+                }
+            val reqDto = UpdateMyGithubIdReqDto(githubId = "torvalds")
+
+            every { currentUserProvider.getCurrentAccount() } returns account
+
+            When("서비스를 실행하면") {
+                service.execute(reqDto)
+
+                Then("학생의 githubId가 변경된다") {
+                    student.githubId shouldBe "torvalds"
+                }
+            }
+        }
+
+        Given("기존에 GitHub ID가 설정된 학생이 null로 삭제를 요청할 때") {
+            val student =
+                StudentJpaEntity().apply {
+                    id = 2L
+                    name = "김학생"
+                    email = "kim@gsm.hs.kr"
+                    sex = Sex.WOMAN
+                    githubId = "existing-user"
+                }
+            val account =
+                AccountJpaEntity().apply {
+                    id = 20L
+                    email = "kim@gsm.hs.kr"
+                    password = "password"
+                    this.student = student
+                }
+            val reqDto = UpdateMyGithubIdReqDto(githubId = null)
+
+            every { currentUserProvider.getCurrentAccount() } returns account
+
+            When("서비스를 실행하면") {
+                service.execute(reqDto)
+
+                Then("학생의 githubId가 null로 변경된다") {
+                    student.githubId shouldBe null
+                }
+            }
+        }
+
+        Given("학생 정보가 연결되지 않은 계정으로 GitHub ID 수정을 시도할 때") {
+            val account =
+                AccountJpaEntity().apply {
+                    id = 30L
+                    email = "nonstudent@gsm.hs.kr"
+                    password = "password"
+                    student = null
+                }
+            val reqDto = UpdateMyGithubIdReqDto(githubId = "torvalds")
+
+            every { currentUserProvider.getCurrentAccount() } returns account
+
+            When("서비스를 실행하면") {
+                Then("ExpectedException이 발생한다") {
+                    val exception =
+                        shouldThrow<ExpectedException> {
+                            service.execute(reqDto)
+                        }
+
+                    exception.message shouldBe "학생 정보가 연결되지 않은 계정입니다."
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## 개요

학생 도메인에 GitHub 아이디 필드를 추가하고, 로그인한 학생 본인이 자신의 GitHub 아이디를 직접 수정할 수 있는 기능을 구현하였습니다.

## 본문

### 학생 도메인 데이터 모델 확장
- `StudentJpaEntity`에 `github_id` 필드를 추가하여 GitHub 계정 정보를 저장할 수 있도록 조치하였습니다.
- `UpdateStudentReqDto`와 `StudentResDto`에 GitHub 아이디 정보를 포함하여 데이터 교환이 가능하도록 수정하였습니다.

### 학생 정보 조회 및 응답 로직 개선
- `datagsm-oauth-userinfo`, `datagsm-openapi`, `datagsm-web` 모듈의 각 서비스 구현체에서 학생 정보를 조회할 때 GitHub 아이디와 GitHub 프로필 URL(`https://github.com/{githubId}`)을 함께 반환하도록 기능을 추가하였습니다.
- 관리자 및 공개 API를 통한 학생 정보 생성/수정 시에도 GitHub 아이디가 반영되도록 로직을 업데이트하였습니다.

### 내 GitHub 아이디 수정 API 구현
- `StudentController`에 `PATCH /me/github-id` 엔드포인트를 추가하여 로그인한 학생 본인이 자신의 GitHub 아이디를 수정할 수 있는 기능을 개발하였습니다.
- `ModifyMyGithubIdService` 인터페이스와 `ModifyMyGithubIdServiceImpl` 구현체를 추가하여 관련 비즈니스 로직을 처리하도록 하였습니다.

### 유효성 검증 및 기타 사항
- GitHub 아이디 형식에 맞는 정규표현식을 사용하여 입력 데이터의 유효성 검증 로직을 추가하였습니다.
- 기존의 학생 정보 조회 결과에 GitHub URL 정보가 누락되지 않도록 모든 모듈의 서비스 로직을 동기화하였습니다.

Close #270
