### PR TITLE
[student] 학생 조회 시 학과 및 GitHub ID 필터링 기능 추가

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/request/QueryStudentReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/request/QueryStudentReqDto.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.Positive
+import team.themoment.datagsm.common.domain.student.entity.constant.Major
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentSortBy
@@ -37,6 +38,10 @@ data class QueryStudentReqDto(
     val dormitoryRoom: Int? = null,
     @param:Schema(description = "전공")
     val specialty: String? = null,
+    @param:Schema(description = "학과")
+    val major: Major? = null,
+    @param:Schema(description = "GitHub ID")
+    val githubId: String? = null,
     @param:Schema(description = "졸업생 포함 여부", defaultValue = "false")
     val includeGraduates: Boolean = false,
     @param:Schema(description = "자퇴생 포함 여부", defaultValue = "false")

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/StudentJpaCustomRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/StudentJpaCustomRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.constant.Major
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentSortBy
@@ -22,6 +23,8 @@ interface StudentJpaCustomRepository {
         role: StudentRole?,
         dormitoryRoom: Int?,
         specialty: String? = null,
+        major: Major? = null,
+        githubId: String? = null,
         includeGraduates: Boolean = false,
         includeWithdrawn: Boolean = false,
         onlyEnrolled: Boolean = false,
@@ -84,6 +87,8 @@ interface StudentJpaCustomRepository {
         role: StudentRole?,
         dormitoryRoom: Int?,
         specialty: String? = null,
+        major: Major? = null,
+        githubId: String? = null,
         includeGraduates: Boolean = false,
         includeWithdrawn: Boolean = false,
         onlyEnrolled: Boolean = false,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
@@ -13,6 +13,7 @@ import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.student.entity.QStudentJpaEntity.Companion.studentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.constant.Major
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentSortBy
@@ -34,6 +35,8 @@ class StudentJpaCustomRepositoryImpl(
         role: StudentRole?,
         dormitoryRoom: Int?,
         specialty: String?,
+        major: Major?,
+        githubId: String?,
         includeGraduates: Boolean,
         includeWithdrawn: Boolean,
         onlyEnrolled: Boolean,
@@ -58,7 +61,9 @@ class StudentJpaCustomRepositoryImpl(
                     sex?.let { studentJpaEntity.sex.eq(it) },
                     role?.let { studentJpaEntity.role.eq(it) },
                     dormitoryRoom?.let { studentJpaEntity.dormitoryRoomNumber.dormitoryRoomNumber.eq(it) },
-                    specialty?.let { studentJpaEntity.specialty.eq(it) },
+                    specialty?.let { studentJpaEntity.specialty.contains(it) },
+                    major?.let { studentJpaEntity.major.eq(it) },
+                    githubId?.let { studentJpaEntity.githubId.contains(it) },
                     if (!onlyEnrolled && !includeGraduates) studentJpaEntity.role.ne(StudentRole.GRADUATE) else null,
                     if (!onlyEnrolled && !includeWithdrawn) studentJpaEntity.role.ne(StudentRole.WITHDRAWN) else null,
                     if (onlyEnrolled) studentJpaEntity.role.notIn(StudentRole.GRADUATE, StudentRole.WITHDRAWN) else null,
@@ -98,7 +103,9 @@ class StudentJpaCustomRepositoryImpl(
                     sex?.let { studentJpaEntity.sex.eq(it) },
                     role?.let { studentJpaEntity.role.eq(it) },
                     dormitoryRoom?.let { studentJpaEntity.dormitoryRoomNumber.dormitoryRoomNumber.eq(it) },
-                    specialty?.let { studentJpaEntity.specialty.eq(it) },
+                    specialty?.let { studentJpaEntity.specialty.contains(it) },
+                    major?.let { studentJpaEntity.major.eq(it) },
+                    githubId?.let { studentJpaEntity.githubId.contains(it) },
                     if (!onlyEnrolled && !includeGraduates) studentJpaEntity.role.ne(StudentRole.GRADUATE) else null,
                     if (!onlyEnrolled && !includeWithdrawn) studentJpaEntity.role.ne(StudentRole.WITHDRAWN) else null,
                     if (onlyEnrolled) studentJpaEntity.role.notIn(StudentRole.GRADUATE, StudentRole.WITHDRAWN) else null,
@@ -281,6 +288,8 @@ class StudentJpaCustomRepositoryImpl(
         role: StudentRole?,
         dormitoryRoom: Int?,
         specialty: String?,
+        major: Major?,
+        githubId: String?,
         includeGraduates: Boolean,
         includeWithdrawn: Boolean,
         onlyEnrolled: Boolean,
@@ -307,7 +316,9 @@ class StudentJpaCustomRepositoryImpl(
                     sex?.let { studentJpaEntity.sex.eq(it) },
                     role?.let { studentJpaEntity.role.eq(it) },
                     dormitoryRoom?.let { studentJpaEntity.dormitoryRoomNumber.dormitoryRoomNumber.eq(it) },
-                    specialty?.let { studentJpaEntity.specialty.eq(it) },
+                    specialty?.let { studentJpaEntity.specialty.contains(it) },
+                    major?.let { studentJpaEntity.major.eq(it) },
+                    githubId?.let { studentJpaEntity.githubId.contains(it) },
                     if (!onlyEnrolled && !includeGraduates) studentJpaEntity.role.ne(StudentRole.GRADUATE) else null,
                     if (!onlyEnrolled && !includeWithdrawn) studentJpaEntity.role.ne(StudentRole.WITHDRAWN) else null,
                     if (onlyEnrolled) studentJpaEntity.role.notIn(StudentRole.GRADUATE, StudentRole.WITHDRAWN) else null,
@@ -349,7 +360,9 @@ class StudentJpaCustomRepositoryImpl(
                     sex?.let { studentJpaEntity.sex.eq(it) },
                     role?.let { studentJpaEntity.role.eq(it) },
                     dormitoryRoom?.let { studentJpaEntity.dormitoryRoomNumber.dormitoryRoomNumber.eq(it) },
-                    specialty?.let { studentJpaEntity.specialty.eq(it) },
+                    specialty?.let { studentJpaEntity.specialty.contains(it) },
+                    major?.let { studentJpaEntity.major.eq(it) },
+                    githubId?.let { studentJpaEntity.githubId.contains(it) },
                     if (!onlyEnrolled && !includeGraduates) studentJpaEntity.role.ne(StudentRole.GRADUATE) else null,
                     if (!onlyEnrolled && !includeWithdrawn) studentJpaEntity.role.ne(StudentRole.WITHDRAWN) else null,
                     if (onlyEnrolled) studentJpaEntity.role.notIn(StudentRole.GRADUATE, StudentRole.WITHDRAWN) else null,

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/student/service/impl/QueryStudentServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/student/service/impl/QueryStudentServiceImpl.kt
@@ -28,6 +28,8 @@ class QueryStudentServiceImpl(
                 role = queryReq.role,
                 dormitoryRoom = queryReq.dormitoryRoom,
                 specialty = queryReq.specialty,
+                major = queryReq.major,
+                githubId = queryReq.githubId,
                 includeGraduates = queryReq.includeGraduates,
                 includeWithdrawn = queryReq.includeWithdrawn,
                 onlyEnrolled = queryReq.onlyEnrolled,

--- a/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/student/service/QueryStudentServiceTest.kt
+++ b/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/student/service/QueryStudentServiceTest.kt
@@ -315,6 +315,127 @@ class QueryStudentServiceTest :
                     }
                 }
 
+                context("major 필터로 조회할 때") {
+                    beforeEach {
+                        every {
+                            mockStudentRepository.searchRegisteredStudentsWithPaging(
+                                id = null,
+                                name = null,
+                                email = null,
+                                grade = null,
+                                classNum = null,
+                                number = null,
+                                sex = null,
+                                role = null,
+                                dormitoryRoom = null,
+                                major = Major.SW_DEVELOPMENT,
+                                includeGraduates = false,
+                                includeWithdrawn = false,
+                                onlyEnrolled = false,
+                                pageable = PageRequest.of(0, 300),
+                                sortBy = any(),
+                                sortDirection = any(),
+                            )
+                        } returns PageImpl(listOf(testStudent), PageRequest.of(0, 300), 1L)
+                    }
+
+                    it("major 파라미터가 repository에 전달되어야 한다") {
+                        val queryReq = QueryStudentReqDto(major = Major.SW_DEVELOPMENT)
+                        val result = queryStudentService.execute(queryReq)
+
+                        result.totalElements shouldBe 1L
+                        result.students[0].major shouldBe Major.SW_DEVELOPMENT
+
+                        verify(exactly = 1) {
+                            mockStudentRepository.searchRegisteredStudentsWithPaging(
+                                id = null,
+                                name = null,
+                                email = null,
+                                grade = null,
+                                classNum = null,
+                                number = null,
+                                sex = null,
+                                role = null,
+                                dormitoryRoom = null,
+                                major = Major.SW_DEVELOPMENT,
+                                includeGraduates = false,
+                                includeWithdrawn = false,
+                                onlyEnrolled = false,
+                                pageable = PageRequest.of(0, 300),
+                                sortBy = any(),
+                                sortDirection = any(),
+                            )
+                        }
+                    }
+                }
+
+                context("githubId 필터로 조회할 때") {
+                    val studentWithGithub =
+                        StudentJpaEntity().apply {
+                            id = 3L
+                            name = "이민준"
+                            sex = Sex.MAN
+                            email = "lee@gsm.hs.kr"
+                            studentNumber = StudentNumber(2, 1, 5)
+                            major = Major.AI
+                            role = StudentRole.GENERAL_STUDENT
+                            githubId = "snowykte0426"
+                        }
+
+                    beforeEach {
+                        every {
+                            mockStudentRepository.searchRegisteredStudentsWithPaging(
+                                id = null,
+                                name = null,
+                                email = null,
+                                grade = null,
+                                classNum = null,
+                                number = null,
+                                sex = null,
+                                role = null,
+                                dormitoryRoom = null,
+                                githubId = "snowy",
+                                includeGraduates = false,
+                                includeWithdrawn = false,
+                                onlyEnrolled = false,
+                                pageable = PageRequest.of(0, 300),
+                                sortBy = any(),
+                                sortDirection = any(),
+                            )
+                        } returns PageImpl(listOf(studentWithGithub), PageRequest.of(0, 300), 1L)
+                    }
+
+                    it("githubId 파라미터가 repository에 전달되어야 한다") {
+                        val queryReq = QueryStudentReqDto(githubId = "snowy")
+                        val result = queryStudentService.execute(queryReq)
+
+                        result.totalElements shouldBe 1L
+                        result.students[0].githubId shouldBe "snowykte0426"
+                        result.students[0].githubUrl shouldBe "https://github.com/snowykte0426"
+
+                        verify(exactly = 1) {
+                            mockStudentRepository.searchRegisteredStudentsWithPaging(
+                                id = null,
+                                name = null,
+                                email = null,
+                                grade = null,
+                                classNum = null,
+                                number = null,
+                                sex = null,
+                                role = null,
+                                dormitoryRoom = null,
+                                githubId = "snowy",
+                                includeGraduates = false,
+                                includeWithdrawn = false,
+                                onlyEnrolled = false,
+                                pageable = PageRequest.of(0, 300),
+                                sortBy = any(),
+                                sortDirection = any(),
+                            )
+                        }
+                    }
+                }
+
                 context("onlyEnrolled = true로 조회할 때") {
                     beforeEach {
                         every {

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/QueryStudentServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/QueryStudentServiceImpl.kt
@@ -28,6 +28,8 @@ class QueryStudentServiceImpl(
                 role = queryReq.role,
                 dormitoryRoom = queryReq.dormitoryRoom,
                 specialty = queryReq.specialty,
+                major = queryReq.major,
+                githubId = queryReq.githubId,
                 includeGraduates = queryReq.includeGraduates,
                 includeWithdrawn = queryReq.includeWithdrawn,
                 onlyEnrolled = queryReq.onlyEnrolled,

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/QueryStudentServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/QueryStudentServiceTest.kt
@@ -247,6 +247,126 @@ class QueryStudentServiceTest :
                     }
                 }
 
+                context("major 필터로 조회할 때") {
+                    beforeEach {
+                        every {
+                            mockStudentRepository.searchStudentsWithPaging(
+                                id = null,
+                                name = null,
+                                email = null,
+                                grade = null,
+                                classNum = null,
+                                number = null,
+                                sex = null,
+                                role = null,
+                                dormitoryRoom = null,
+                                major = Major.AI,
+                                includeGraduates = false,
+                                includeWithdrawn = false,
+                                onlyEnrolled = false,
+                                pageable = PageRequest.of(0, 20),
+                                sortBy = any(),
+                                sortDirection = any(),
+                            )
+                        } returns PageImpl(listOf(testStudent), PageRequest.of(0, 20), 1L)
+                    }
+
+                    it("major 파라미터가 repository에 전달되어야 한다") {
+                        val queryReq = QueryStudentReqDto(major = Major.AI, page = 0, size = 20)
+                        val result = queryStudentService.execute(queryReq)
+
+                        result.totalElements shouldBe 1L
+
+                        verify(exactly = 1) {
+                            mockStudentRepository.searchStudentsWithPaging(
+                                id = null,
+                                name = null,
+                                email = null,
+                                grade = null,
+                                classNum = null,
+                                number = null,
+                                sex = null,
+                                role = null,
+                                dormitoryRoom = null,
+                                major = Major.AI,
+                                includeGraduates = false,
+                                includeWithdrawn = false,
+                                onlyEnrolled = false,
+                                pageable = PageRequest.of(0, 20),
+                                sortBy = any(),
+                                sortDirection = any(),
+                            )
+                        }
+                    }
+                }
+
+                context("githubId 필터로 조회할 때") {
+                    val studentWithGithub =
+                        StudentJpaEntity().apply {
+                            id = 3L
+                            name = "이민준"
+                            sex = Sex.MAN
+                            email = "lee@gsm.hs.kr"
+                            studentNumber = StudentNumber(2, 1, 5)
+                            major = Major.AI
+                            role = StudentRole.GENERAL_STUDENT
+                            githubId = "snowykte0426"
+                        }
+
+                    beforeEach {
+                        every {
+                            mockStudentRepository.searchStudentsWithPaging(
+                                id = null,
+                                name = null,
+                                email = null,
+                                grade = null,
+                                classNum = null,
+                                number = null,
+                                sex = null,
+                                role = null,
+                                dormitoryRoom = null,
+                                githubId = "snowy",
+                                includeGraduates = false,
+                                includeWithdrawn = false,
+                                onlyEnrolled = false,
+                                pageable = PageRequest.of(0, 20),
+                                sortBy = any(),
+                                sortDirection = any(),
+                            )
+                        } returns PageImpl(listOf(studentWithGithub), PageRequest.of(0, 20), 1L)
+                    }
+
+                    it("githubId 파라미터가 repository에 전달되어야 한다") {
+                        val queryReq = QueryStudentReqDto(githubId = "snowy", page = 0, size = 20)
+                        val result = queryStudentService.execute(queryReq)
+
+                        result.totalElements shouldBe 1L
+                        result.students[0].githubId shouldBe "snowykte0426"
+                        result.students[0].githubUrl shouldBe "https://github.com/snowykte0426"
+
+                        verify(exactly = 1) {
+                            mockStudentRepository.searchStudentsWithPaging(
+                                id = null,
+                                name = null,
+                                email = null,
+                                grade = null,
+                                classNum = null,
+                                number = null,
+                                sex = null,
+                                role = null,
+                                dormitoryRoom = null,
+                                githubId = "snowy",
+                                includeGraduates = false,
+                                includeWithdrawn = false,
+                                onlyEnrolled = false,
+                                pageable = PageRequest.of(0, 20),
+                                sortBy = any(),
+                                sortDirection = any(),
+                            )
+                        }
+                    }
+                }
+
                 context("onlyEnrolled = true로 조회할 때") {
                     beforeEach {
                         every {


### PR DESCRIPTION
## 개요

학생 조회 시 학과(Major)와 GitHub ID를 필드로 필터링할 수 있는 기능을 추가하였습니다.

## 본문

- 학생 조회 요청 DTO(`QueryStudentReqDto`)에 학과와 GitHub ID 필드를 추가하였습니다.
- `StudentJpaCustomRepository`에서 QueryDSL을 사용하여 학과 및 GitHub ID가 일치하는 학생을 검색할 수 있도록 필터링 로직을 구현하였습니다.
- `openapi` 및 `web` 모듈의 학생 조회 서비스(`QueryStudentServiceImpl`)에 신규 필터링 로직을 적용하였습니다.
- 추가된 필터링 기능의 정상 동작을 검증하기 위해 각 모듈의 테스트 코드를 보강하였습니다.
