### PR TITLE
[oauth] OAuth 클라이언트 요청 제한 추가

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/data/OAuthClientRateLimitEnvironment.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/data/OAuthClientRateLimitEnvironment.kt
@@ -1,0 +1,11 @@
+package team.themoment.datagsm.common.global.data
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "spring.security.oauth-client.rate-limit")
+data class OAuthClientRateLimitEnvironment(
+    val enabled: Boolean,
+    val capacity: Long,
+    val refillTokens: Long,
+    val refillDurationSeconds: Long,
+)

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
@@ -12,6 +12,7 @@ import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeState
 import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthAuthorizeFlowService
+import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
 import team.themoment.sdk.exception.ExpectedException
 import java.net.URI
 import java.security.SecureRandom
@@ -24,6 +25,7 @@ class CompleteOauthAuthorizeFlowServiceImpl(
     private val oauthAuthorizeStateRedisRepository: OauthAuthorizeStateRedisRepository,
     private val passwordEncoder: PasswordEncoder,
     private val oauthEnvironment: OauthEnvironment,
+    private val oauthClientRateLimitService: OAuthClientRateLimitService,
 ) : CompleteOauthAuthorizeFlowService {
     companion object {
         private val secureRandom = SecureRandom()
@@ -38,6 +40,11 @@ class CompleteOauthAuthorizeFlowServiceImpl(
                 }
 
         val (_, clientId, redirectUri, state, codeChallenge, codeChallengeMethod) = stateEntity
+
+        val rateLimitResult = oauthClientRateLimitService.tryConsumeAndReturnRemaining(clientId)
+        if (!rateLimitResult.consumed) {
+            throw ExpectedException("요청 한도를 초과했습니다.", HttpStatus.TOO_MANY_REQUESTS)
+        }
 
         val account =
             accountJpaRepository

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
@@ -22,6 +22,7 @@ import team.themoment.datagsm.common.domain.oauth.repository.OauthRefreshTokenRe
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.Oauth2TokenService
 import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
 import team.themoment.datagsm.oauth.authorization.global.security.jwt.JwtProvider
+import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
 import team.themoment.datagsm.oauth.authorization.global.util.PkceVerifier
 import team.themoment.sdk.exception.ExpectedException
 import team.themoment.sdk.logging.logger.logger
@@ -37,10 +38,18 @@ class Oauth2TokenServiceImpl(
     private val jwtProvider: JwtProvider,
     private val jwtEnvironment: OauthJwtProvisionEnvironment,
     private val thirdPartyScopeJpaRepository: ThirdPartyScopeJpaRepository,
+    private val oauthClientRateLimitService: OAuthClientRateLimitService,
 ) : Oauth2TokenService {
     @Transactional(readOnly = true)
     override fun execute(reqDto: Oauth2TokenReqDto): Oauth2TokenResDto {
         val grantType = GrantType.from(reqDto.grantType)
+
+        reqDto.clientId?.let { clientId ->
+            val result = oauthClientRateLimitService.tryConsumeAndReturnRemaining(clientId)
+            if (!result.consumed) {
+                throw ExpectedException("요청 한도를 초과했습니다.", HttpStatus.TOO_MANY_REQUESTS)
+            }
+        }
 
         return when (grantType) {
             GrantType.AUTHORIZATION_CODE -> handleAuthorizationCode(reqDto)

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/config/PropertiesScanConfig.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/config/PropertiesScanConfig.kt
@@ -3,6 +3,7 @@ package team.themoment.datagsm.oauth.authorization.global.config
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import team.themoment.datagsm.common.global.data.CorsEnvironment
+import team.themoment.datagsm.common.global.data.OAuthClientRateLimitEnvironment
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.common.global.data.PasswordResetRateLimitEnvironment
 import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
@@ -13,5 +14,6 @@ import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionE
     OauthJwtProvisionEnvironment::class,
     OauthEnvironment::class,
     PasswordResetRateLimitEnvironment::class,
+    OAuthClientRateLimitEnvironment::class,
 )
 class PropertiesScanConfig

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/security/service/OAuthClientRateLimitService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/security/service/OAuthClientRateLimitService.kt
@@ -1,0 +1,7 @@
+package team.themoment.datagsm.oauth.authorization.global.security.service
+
+import team.themoment.datagsm.common.global.dto.internal.RateLimitConsumeResult
+
+interface OAuthClientRateLimitService {
+    fun tryConsumeAndReturnRemaining(clientId: String): RateLimitConsumeResult
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/security/service/impl/OAuthClientRateLimitServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/security/service/impl/OAuthClientRateLimitServiceImpl.kt
@@ -1,0 +1,52 @@
+package team.themoment.datagsm.oauth.authorization.global.security.service.impl
+
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.BucketConfiguration
+import io.github.bucket4j.distributed.proxy.ProxyManager
+import org.springframework.stereotype.Service
+import team.themoment.datagsm.common.global.data.OAuthClientRateLimitEnvironment
+import team.themoment.datagsm.common.global.dto.internal.RateLimitConsumeResult
+import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
+import java.time.Duration
+
+@Service
+class OAuthClientRateLimitServiceImpl(
+    private val proxyManager: ProxyManager<String>,
+    private val oauthClientRateLimitEnvironment: OAuthClientRateLimitEnvironment,
+) : OAuthClientRateLimitService {
+    override fun tryConsumeAndReturnRemaining(clientId: String): RateLimitConsumeResult {
+        if (!oauthClientRateLimitEnvironment.enabled) {
+            return RateLimitConsumeResult(
+                consumed = true,
+                remainingTokens = oauthClientRateLimitEnvironment.capacity,
+                secondsToWaitForRefill = 0,
+            )
+        }
+
+        val bucket =
+            proxyManager.builder().build(
+                "rate_limit:oauth_client:$clientId",
+            ) { createBucketConfiguration() }
+        val probe = bucket.tryConsumeAndReturnRemaining(1)
+        return RateLimitConsumeResult(
+            consumed = probe.isConsumed,
+            remainingTokens = probe.remainingTokens,
+            secondsToWaitForRefill = probe.nanosToWaitForRefill / 1_000_000_000,
+        )
+    }
+
+    private fun createBucketConfiguration(): BucketConfiguration {
+        val bandwidth =
+            Bandwidth
+                .builder()
+                .capacity(oauthClientRateLimitEnvironment.capacity)
+                .refillIntervally(
+                    oauthClientRateLimitEnvironment.refillTokens,
+                    Duration.ofSeconds(oauthClientRateLimitEnvironment.refillDurationSeconds),
+                ).build()
+        return BucketConfiguration
+            .builder()
+            .addLimit(bandwidth)
+            .build()
+    }
+}

--- a/datagsm-oauth-authorization/src/main/resources/application.yml
+++ b/datagsm-oauth-authorization/src/main/resources/application.yml
@@ -56,6 +56,12 @@ spring:
       code-expiration-seconds: ${OAUTH_CODE_EXPIRATION:300}
       frontend-url: ${OAUTH_FRONTEND_URL:http://localhost:3000}
       authorize-state-expiration-ms: ${OAUTH_AUTHORIZE_STATE_EXPIRATION_MS:600000}
+    oauth-client:
+      rate-limit:
+        enabled: true
+        capacity: 300
+        refill-tokens: 300
+        refill-duration-seconds: 60
     password-reset-rate-limit:
       enabled: true
       send:

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
@@ -22,7 +22,9 @@ import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.common.global.dto.internal.RateLimitConsumeResult
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.CompleteOauthAuthorizeFlowServiceImpl
+import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
 import team.themoment.sdk.exception.ExpectedException
 import java.util.Optional
 
@@ -34,6 +36,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
         val mockOauthAuthorizeStateRedisRepository = mockk<OauthAuthorizeStateRedisRepository>(relaxed = true)
         val mockPasswordEncoder = mockk<PasswordEncoder>()
         val mockOauthEnvironment = mockk<OauthEnvironment>()
+        val mockOauthClientRateLimitService = mockk<OAuthClientRateLimitService>()
 
         val completeOauthAuthorizeFlowService =
             CompleteOauthAuthorizeFlowServiceImpl(
@@ -42,6 +45,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                 mockOauthAuthorizeStateRedisRepository,
                 mockPasswordEncoder,
                 mockOauthEnvironment,
+                mockOauthClientRateLimitService,
             )
 
         afterEach {
@@ -66,6 +70,8 @@ class CompleteOauthAuthorizeFlowServiceTest :
 
                 beforeEach {
                     every { mockOauthEnvironment.codeExpirationSeconds } returns codeExpirationSeconds
+                    every { mockOauthClientRateLimitService.tryConsumeAndReturnRemaining(any()) } returns
+                        RateLimitConsumeResult(consumed = true, remainingTokens = 299, secondsToWaitForRefill = 0)
                 }
 
                 context("유효한 토큰과 인증 정보가 주어졌을 때") {

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
@@ -22,8 +22,10 @@ import team.themoment.datagsm.common.domain.oauth.entity.OauthRefreshTokenRedisE
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthRefreshTokenRedisRepository
+import team.themoment.datagsm.common.global.dto.internal.RateLimitConsumeResult
 import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
 import team.themoment.datagsm.oauth.authorization.global.security.jwt.JwtProvider
+import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
 import java.util.Optional
 
 class Oauth2TokenServiceImplTest :
@@ -37,6 +39,7 @@ class Oauth2TokenServiceImplTest :
         val mockJwtProvider = mockk<JwtProvider>()
         val mockJwtEnvironment = mockk<OauthJwtProvisionEnvironment>()
         val mockThirdPartyScopeJpaRepository = mockk<ThirdPartyScopeJpaRepository>()
+        val mockOauthClientRateLimitService = mockk<OAuthClientRateLimitService>()
 
         val service =
             Oauth2TokenServiceImpl(
@@ -48,10 +51,16 @@ class Oauth2TokenServiceImplTest :
                 mockJwtProvider,
                 mockJwtEnvironment,
                 mockThirdPartyScopeJpaRepository,
+                mockOauthClientRateLimitService,
             )
 
         afterEach {
             clearAllMocks()
+        }
+
+        beforeEach {
+            every { mockOauthClientRateLimitService.tryConsumeAndReturnRemaining(any()) } returns
+                RateLimitConsumeResult(consumed = true, remainingTokens = 299, secondsToWaitForRefill = 0)
         }
 
         describe("Oauth2TokenServiceImpl 클래스의") {

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/config/PropertiesScanConfig.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/config/PropertiesScanConfig.kt
@@ -2,10 +2,12 @@ package team.themoment.datagsm.oauth.userinfo.global.config
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
+import team.themoment.datagsm.common.global.data.OAuthClientRateLimitEnvironment
 import team.themoment.datagsm.oauth.userinfo.global.data.OauthJwtVerificationEnvironment
 
 @Configuration
 @EnableConfigurationProperties(
     OauthJwtVerificationEnvironment::class,
+    OAuthClientRateLimitEnvironment::class,
 )
 class PropertiesScanConfig

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
@@ -14,9 +14,12 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.web.cors.CorsConfigurationSource
+import team.themoment.datagsm.common.global.data.OAuthClientRateLimitEnvironment
+import team.themoment.datagsm.oauth.userinfo.global.security.filter.OAuthClientRateLimitFilter
 import team.themoment.datagsm.oauth.userinfo.global.security.handler.CustomAuthenticationEntryPoint
 import team.themoment.datagsm.oauth.userinfo.global.security.jwt.JwtProvider
 import team.themoment.datagsm.oauth.userinfo.global.security.jwt.filter.JwtAuthenticationFilter
+import team.themoment.datagsm.oauth.userinfo.global.security.service.OAuthClientRateLimitService
 import tools.jackson.databind.ObjectMapper
 
 @Configuration
@@ -27,6 +30,8 @@ class SecurityConfig(
     private val jwtProvider: JwtProvider,
     private val customAuthenticationEntryPoint: CustomAuthenticationEntryPoint,
     private val objectMapper: ObjectMapper,
+    private val oauthClientRateLimitService: OAuthClientRateLimitService,
+    private val oauthClientRateLimitEnvironment: OAuthClientRateLimitEnvironment,
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
@@ -41,6 +46,9 @@ class SecurityConfig(
             .addFilterBefore(
                 JwtAuthenticationFilter(jwtProvider, objectMapper),
                 UsernamePasswordAuthenticationFilter::class.java,
+            ).addFilterAfter(
+                OAuthClientRateLimitFilter(oauthClientRateLimitService, oauthClientRateLimitEnvironment, objectMapper),
+                JwtAuthenticationFilter::class.java,
             ).authorizeHttpRequests {
                 it
                     .requestMatchers("/userinfo")

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/filter/OAuthClientRateLimitFilter.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/filter/OAuthClientRateLimitFilter.kt
@@ -1,0 +1,54 @@
+package team.themoment.datagsm.oauth.userinfo.global.security.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.OncePerRequestFilter
+import team.themoment.datagsm.common.global.data.OAuthClientRateLimitEnvironment
+import team.themoment.datagsm.oauth.userinfo.global.security.authentication.OauthAuthenticationToken
+import team.themoment.datagsm.oauth.userinfo.global.security.service.OAuthClientRateLimitService
+import team.themoment.sdk.response.CommonApiResponse
+import tools.jackson.databind.ObjectMapper
+
+class OAuthClientRateLimitFilter(
+    private val oauthClientRateLimitService: OAuthClientRateLimitService,
+    private val oauthClientRateLimitEnvironment: OAuthClientRateLimitEnvironment,
+    private val objectMapper: ObjectMapper,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val authentication = SecurityContextHolder.getContext().authentication
+        if (authentication == null || authentication !is OauthAuthenticationToken) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        val clientId = authentication.principal.clientId
+        val result = oauthClientRateLimitService.tryConsumeAndReturnRemaining(clientId)
+
+        response.setHeader("X-RateLimit-Limit", oauthClientRateLimitEnvironment.capacity.toString())
+        response.setHeader("X-RateLimit-Remaining", result.remainingTokens.toString())
+
+        if (!result.consumed) {
+            response.status = HttpStatus.TOO_MANY_REQUESTS.value()
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.setHeader(HttpHeaders.RETRY_AFTER, result.secondsToWaitForRefill.toString())
+            val errorResponse =
+                CommonApiResponse.error(
+                    "API 요청 제한을 초과했습니다. ${result.secondsToWaitForRefill}초 후에 다시 시도해주세요.",
+                    HttpStatus.TOO_MANY_REQUESTS,
+                )
+            response.writer.write(objectMapper.writeValueAsString(errorResponse))
+            return
+        }
+
+        filterChain.doFilter(request, response)
+    }
+}

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/service/OAuthClientRateLimitService.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/service/OAuthClientRateLimitService.kt
@@ -1,0 +1,7 @@
+package team.themoment.datagsm.oauth.userinfo.global.security.service
+
+import team.themoment.datagsm.common.global.dto.internal.RateLimitConsumeResult
+
+interface OAuthClientRateLimitService {
+    fun tryConsumeAndReturnRemaining(clientId: String): RateLimitConsumeResult
+}

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/service/impl/OAuthClientRateLimitServiceImpl.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/service/impl/OAuthClientRateLimitServiceImpl.kt
@@ -1,0 +1,52 @@
+package team.themoment.datagsm.oauth.userinfo.global.security.service.impl
+
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.BucketConfiguration
+import io.github.bucket4j.distributed.proxy.ProxyManager
+import org.springframework.stereotype.Service
+import team.themoment.datagsm.common.global.data.OAuthClientRateLimitEnvironment
+import team.themoment.datagsm.common.global.dto.internal.RateLimitConsumeResult
+import team.themoment.datagsm.oauth.userinfo.global.security.service.OAuthClientRateLimitService
+import java.time.Duration
+
+@Service
+class OAuthClientRateLimitServiceImpl(
+    private val proxyManager: ProxyManager<String>,
+    private val oauthClientRateLimitEnvironment: OAuthClientRateLimitEnvironment,
+) : OAuthClientRateLimitService {
+    override fun tryConsumeAndReturnRemaining(clientId: String): RateLimitConsumeResult {
+        if (!oauthClientRateLimitEnvironment.enabled) {
+            return RateLimitConsumeResult(
+                consumed = true,
+                remainingTokens = oauthClientRateLimitEnvironment.capacity,
+                secondsToWaitForRefill = 0,
+            )
+        }
+
+        val bucket =
+            proxyManager.builder().build(
+                "rate_limit:oauth_client:$clientId",
+            ) { createBucketConfiguration() }
+        val probe = bucket.tryConsumeAndReturnRemaining(1)
+        return RateLimitConsumeResult(
+            consumed = probe.isConsumed,
+            remainingTokens = probe.remainingTokens,
+            secondsToWaitForRefill = probe.nanosToWaitForRefill / 1_000_000_000,
+        )
+    }
+
+    private fun createBucketConfiguration(): BucketConfiguration {
+        val bandwidth =
+            Bandwidth
+                .builder()
+                .capacity(oauthClientRateLimitEnvironment.capacity)
+                .refillIntervally(
+                    oauthClientRateLimitEnvironment.refillTokens,
+                    Duration.ofSeconds(oauthClientRateLimitEnvironment.refillDurationSeconds),
+                ).build()
+        return BucketConfiguration
+            .builder()
+            .addLimit(bandwidth)
+            .build()
+    }
+}

--- a/datagsm-oauth-userinfo/src/main/resources/application.yml
+++ b/datagsm-oauth-userinfo/src/main/resources/application.yml
@@ -33,6 +33,12 @@ spring:
   security:
     oauth-jwt:
       public-key: ${JWT_PUBLIC_KEY}
+    oauth-client:
+      rate-limit:
+        enabled: true
+        capacity: 300
+        refill-tokens: 300
+        refill-duration-seconds: 60
   web:
     error:
       whitelabel:


### PR DESCRIPTION
## 개요

OAuth 클라이언트별 요청 제한 기능을 authorization, userinfo 서버에 추가하였습니다.
공통 rate limit 설정값을 분리하고, 토큰 발급 및 사용자 정보 조회 흐름에서 요청 한도를 초과한 경우 적절한 응답을 반환하도록 구성하였습니다.

## 본문

- `OAuthClientRateLimitEnvironment`를 추가하여 클라이언트 요청 제한 설정을 공통으로 관리할 수 있도록 구성하였습니다.
- authorization 서버의 인가 완료 및 토큰 발급 흐름에서 클라이언트별 토큰 버킷을 차감하고, 한도 초과 시 `429 TOO_MANY_REQUESTS` 예외를 반환하도록 처리하였습니다.
- userinfo 서버에 `OAuthClientRateLimitFilter`와 전용 rate limit 서비스를 추가하여 인증된 클라이언트 요청에 제한을 적용하였습니다.
- userinfo 응답에 `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `Retry-After` 헤더를 포함하도록 구성하였습니다.
- authorization, userinfo 양쪽 `application.yml`과 properties scan 설정에 rate limit 관련 값을 추가하였습니다.
- authorization 서버 테스트에 rate limit 서비스 목을 주입하여 기존 인증 및 토큰 발급 테스트가 새로운 제약 조건을 반영하도록 수정하였습니다.
