### PR TITLE
[student] QueryDSL 벌크 업데이트로 엑셀 업로드 성능 개선

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/internal/StudentBulkUpdateDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/internal/StudentBulkUpdateDto.kt
@@ -1,0 +1,17 @@
+package team.themoment.datagsm.common.domain.student.dto.internal
+
+import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.constant.Major
+import team.themoment.datagsm.common.domain.student.entity.constant.Sex
+import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
+
+data class StudentBulkUpdateDto(
+    val id: Long,
+    val name: String,
+    val major: Major?,
+    val majorClub: ClubJpaEntity?,
+    val autonomousClub: ClubJpaEntity?,
+    val dormitoryRoomNumber: Int?,
+    val role: StudentRole,
+    val sex: Sex,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/StudentJpaCustomRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/StudentJpaCustomRepository.kt
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
+import team.themoment.datagsm.common.domain.student.dto.internal.StudentBulkUpdateDto
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.Major
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
@@ -62,6 +63,8 @@ interface StudentJpaCustomRepository {
     fun findAllStudents(): List<StudentJpaEntity>
 
     fun bulkUpdateEmails(emailUpdates: Map<Long, String>)
+
+    fun bulkUpdateStudentFields(updates: List<StudentBulkUpdateDto>)
 
     fun bulkClearClubReferences(clubs: List<ClubJpaEntity>)
 

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
@@ -532,6 +532,7 @@ class StudentJpaCustomRepositoryImpl(
         val nonNullPairs = pairs.filter { it.second != null }.map { it.first to it.second!! }
         if (nonNullPairs.isEmpty()) return otherwise
 
+        // CaseBuilder().otherwise()의 반환 타입이 Expression<T?>로 추론되지만, non-null otherwise 표현식을 전달하므로 안전한 캐스트
         @Suppress("UNCHECKED_CAST")
         return nonNullPairs
             .drop(1)
@@ -544,6 +545,7 @@ class StudentJpaCustomRepositoryImpl(
             }.otherwise(otherwise) as Expression<T>
     }
 
+    // Expressions.nullExpression()이 NullExpression<T>를 반환하므로 Expression<Int>로 맞추기 위한 캐스트
     @Suppress("UNCHECKED_CAST")
     private fun buildNullableIntCaseExpr(
         pairs: List<Pair<Long, Int?>>,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
@@ -3,6 +3,8 @@ package team.themoment.datagsm.common.domain.student.repository.custom.impl
 import com.querydsl.core.types.Expression
 import com.querydsl.core.types.OrderSpecifier
 import com.querydsl.core.types.dsl.CaseBuilder
+import com.querydsl.core.types.dsl.Expressions
+import com.querydsl.core.types.dsl.NumberPath
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Repository
 import team.themoment.datagsm.common.domain.account.entity.QAccountJpaEntity.Companion.accountJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
+import team.themoment.datagsm.common.domain.student.dto.internal.StudentBulkUpdateDto
 import team.themoment.datagsm.common.domain.student.entity.QStudentJpaEntity.Companion.studentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.Major
@@ -408,6 +411,48 @@ class StudentJpaCustomRepositoryImpl(
             .execute()
     }
 
+    override fun bulkUpdateStudentFields(updates: List<StudentBulkUpdateDto>) {
+        if (updates.isEmpty()) return
+        val ids = updates.map { it.id }
+
+        // scalar 필드 일괄 UPDATE (CASE WHEN + WHERE id IN)
+        jpaQueryFactory
+            .update(studentJpaEntity)
+            .set(studentJpaEntity.name, buildStringCaseExpr(updates.map { it.id to it.name }, studentJpaEntity.name))
+            .set(studentJpaEntity.major, buildComparableCaseExpr(updates.map { it.id to it.major }, studentJpaEntity.major))
+            .set(studentJpaEntity.role, buildComparableCaseExpr(updates.map { it.id to it.role }, studentJpaEntity.role))
+            .set(studentJpaEntity.sex, buildComparableCaseExpr(updates.map { it.id to it.sex }, studentJpaEntity.sex))
+            .set(
+                studentJpaEntity.dormitoryRoomNumber.dormitoryRoomNumber,
+                buildNullableIntCaseExpr(
+                    updates.map { it.id to it.dormitoryRoomNumber },
+                    studentJpaEntity.dormitoryRoomNumber.dormitoryRoomNumber,
+                ),
+            )
+            .where(studentJpaEntity.id.`in`(ids))
+            .execute()
+
+        // 동아리 FK 초기화 후 동아리별 그룹으로 재할당
+        jpaQueryFactory.update(studentJpaEntity).setNull(studentJpaEntity.majorClub).where(studentJpaEntity.id.`in`(ids)).execute()
+        jpaQueryFactory.update(studentJpaEntity).setNull(studentJpaEntity.autonomousClub).where(studentJpaEntity.id.`in`(ids)).execute()
+
+        updates.filter { it.majorClub != null }.groupBy { it.majorClub!! }.forEach { (club, group) ->
+            jpaQueryFactory
+                .update(studentJpaEntity)
+                .set(studentJpaEntity.majorClub, club)
+                .where(studentJpaEntity.id.`in`(group.map { it.id }))
+                .execute()
+        }
+
+        updates.filter { it.autonomousClub != null }.groupBy { it.autonomousClub!! }.forEach { (club, group) ->
+            jpaQueryFactory
+                .update(studentJpaEntity)
+                .set(studentJpaEntity.autonomousClub, club)
+                .where(studentJpaEntity.id.`in`(group.map { it.id }))
+                .execute()
+        }
+    }
+
     override fun bulkClearClubReferences(clubs: List<ClubJpaEntity>) {
         if (clubs.isEmpty()) return
 
@@ -457,6 +502,59 @@ class StudentJpaCustomRepositoryImpl(
             .set(clubPath, club)
             .where(studentJpaEntity.id.`in`(studentIds))
             .execute()
+    }
+
+    private fun buildStringCaseExpr(
+        pairs: List<Pair<Long, String>>,
+        otherwise: Expression<String>,
+    ): Expression<String> =
+        pairs
+            .drop(1)
+            .fold(
+                CaseBuilder()
+                    .`when`(studentJpaEntity.id.eq(pairs[0].first))
+                    .then(pairs[0].second),
+            ) { caseWhen, (id, value) ->
+                caseWhen.`when`(studentJpaEntity.id.eq(id)).then(value)
+            }.otherwise(otherwise)
+
+    private fun <T : Comparable<T>> buildComparableCaseExpr(
+        pairs: List<Pair<Long, T?>>,
+        otherwise: Expression<T>,
+    ): Expression<T> {
+        val nonNullPairs = pairs.filter { it.second != null }.map { it.first to it.second!! }
+        if (nonNullPairs.isEmpty()) return otherwise
+
+        @Suppress("UNCHECKED_CAST")
+        return nonNullPairs
+            .drop(1)
+            .fold(
+                CaseBuilder()
+                    .`when`(studentJpaEntity.id.eq(nonNullPairs[0].first))
+                    .then(nonNullPairs[0].second),
+            ) { caseWhen, (id, value) ->
+                caseWhen.`when`(studentJpaEntity.id.eq(id)).then(value)
+            }.otherwise(otherwise) as Expression<T>
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun buildNullableIntCaseExpr(
+        pairs: List<Pair<Long, Int?>>,
+        path: NumberPath<Int>,
+    ): Expression<Int> {
+        val first = pairs[0]
+        val firstExpr: Expression<Int> =
+            first.second?.let { Expressions.constant(it) } ?: Expressions.nullExpression<Int>() as Expression<Int>
+
+        return pairs
+            .drop(1)
+            .fold(
+                CaseBuilder().`when`(studentJpaEntity.id.eq(first.first)).then(firstExpr),
+            ) { caseWhen, (id, value) ->
+                val expr: Expression<Int> =
+                    value?.let { Expressions.constant(it) } ?: Expressions.nullExpression<Int>() as Expression<Int>
+                caseWhen.`when`(studentJpaEntity.id.eq(id)).then(expr)
+            }.otherwise(path)
     }
 
     private fun buildEmailCaseExpr(pairs: List<Pair<Long, String>>): Expression<String> =

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
@@ -428,13 +428,20 @@ class StudentJpaCustomRepositoryImpl(
                     updates.map { it.id to it.dormitoryRoomNumber },
                     studentJpaEntity.dormitoryRoomNumber.dormitoryRoomNumber,
                 ),
-            )
-            .where(studentJpaEntity.id.`in`(ids))
+            ).where(studentJpaEntity.id.`in`(ids))
             .execute()
 
         // 동아리 FK 초기화 후 동아리별 그룹으로 재할당
-        jpaQueryFactory.update(studentJpaEntity).setNull(studentJpaEntity.majorClub).where(studentJpaEntity.id.`in`(ids)).execute()
-        jpaQueryFactory.update(studentJpaEntity).setNull(studentJpaEntity.autonomousClub).where(studentJpaEntity.id.`in`(ids)).execute()
+        jpaQueryFactory
+            .update(studentJpaEntity)
+            .setNull(studentJpaEntity.majorClub)
+            .where(studentJpaEntity.id.`in`(ids))
+            .execute()
+        jpaQueryFactory
+            .update(studentJpaEntity)
+            .setNull(studentJpaEntity.autonomousClub)
+            .where(studentJpaEntity.id.`in`(ids))
+            .execute()
 
         updates.filter { it.majorClub != null }.groupBy { it.majorClub!! }.forEach { (club, group) ->
             jpaQueryFactory

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentExcelServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentExcelServiceImpl.kt
@@ -270,5 +270,4 @@ class ModifyStudentExcelServiceImpl(
         if (studentNumber / 100 % 10 !in 1..4) throw ExpectedException("반은 1~4반이여야 합니다.", HttpStatus.BAD_REQUEST)
         return studentNumber
     }
-
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentExcelServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentExcelServiceImpl.kt
@@ -12,7 +12,7 @@ import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
 import team.themoment.datagsm.common.domain.student.dto.internal.ExcelColumnDto
 import team.themoment.datagsm.common.domain.student.dto.internal.ExcelRowDto
-import team.themoment.datagsm.common.domain.student.entity.DormitoryRoomNumber
+import team.themoment.datagsm.common.domain.student.dto.internal.StudentBulkUpdateDto
 import team.themoment.datagsm.common.domain.student.entity.constant.Major
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
@@ -116,27 +116,34 @@ class ModifyStudentExcelServiceImpl(
                     .associateBy { it.name }
             }
 
-        excelData.forEach { dto ->
-            dto.number?.let { number ->
-                existingStudents.getValue(number).also { student ->
-                    student.name = dto.name
-                    student.major = dto.major
-                    student.majorClub =
+        val bulkUpdates =
+            excelData.mapNotNull { dto ->
+                dto.number?.let { number ->
+                    val student = existingStudents.getValue(number)
+                    val majorClub =
                         dto.majorClub?.let { clubName ->
                             existingMajorClubs[clubName]
                                 ?: throw ExpectedException("존재하지 않는 전공동아리입니다.", HttpStatus.BAD_REQUEST)
                         }
-                    student.autonomousClub =
+                    val autonomousClub =
                         dto.autonomousClub?.let { clubName ->
                             existingAutonomousClubs[clubName]
                                 ?: throw ExpectedException("존재하지 않는 창체동아리입니다.", HttpStatus.BAD_REQUEST)
                         }
-                    student.dormitoryRoomNumber = getDormitoryEmbedded(dto.dormitoryRoomNumber)
-                    student.role = dto.role
-                    student.sex = dto.sex
+                    StudentBulkUpdateDto(
+                        id = student.id!!,
+                        name = dto.name,
+                        major = dto.major,
+                        majorClub = majorClub,
+                        autonomousClub = autonomousClub,
+                        dormitoryRoomNumber = dto.dormitoryRoomNumber,
+                        role = dto.role,
+                        sex = dto.sex,
+                    )
                 }
             }
-        }
+
+        studentJpaRepository.bulkUpdateStudentFields(bulkUpdates)
 
         val emailUpdates =
             excelData
@@ -264,5 +271,4 @@ class ModifyStudentExcelServiceImpl(
         return studentNumber
     }
 
-    private fun getDormitoryEmbedded(room: Int?): DormitoryRoomNumber = DormitoryRoomNumber(room)
 }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentExcelServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentExcelServiceTest.kt
@@ -9,6 +9,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import team.themoment.datagsm.common.domain.student.dto.internal.StudentBulkUpdateDto
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.springframework.http.HttpStatus
 import org.springframework.mock.web.MockMultipartFile
@@ -136,6 +137,7 @@ class ModifyStudentExcelServiceTest :
                             listOf(majorClub)
                         every { mockClubRepository.findAllByNameInAndType(listOf("창체동아리B"), ClubType.AUTONOMOUS_CLUB) } returns
                             listOf(autonomousClub)
+                        every { mockStudentRepository.bulkUpdateStudentFields(any<List<StudentBulkUpdateDto>>()) } just Runs
                         every { mockStudentRepository.bulkUpdateEmails(any()) } just Runs
                     }
 
@@ -145,11 +147,18 @@ class ModifyStudentExcelServiceTest :
                         result.message shouldBe "엑셀 업로드 성공"
                         result.code shouldBe HttpStatus.OK.value()
 
-                        existingStudent.name shouldBe "홍길동"
-                        existingStudent.major shouldBe Major.SW_DEVELOPMENT
-                        existingStudent.majorClub shouldBe majorClub
-                        existingStudent.sex shouldBe Sex.MAN
-
+                        verify {
+                            mockStudentRepository.bulkUpdateStudentFields(
+                                match { updates ->
+                                    updates.size == 1 &&
+                                        updates[0].id == 1L &&
+                                        updates[0].name == "홍길동" &&
+                                        updates[0].major == Major.SW_DEVELOPMENT &&
+                                        updates[0].majorClub == majorClub &&
+                                        updates[0].sex == Sex.MAN
+                                },
+                            )
+                        }
                         verify { mockStudentRepository.bulkUpdateEmails(match { it[1L] == "hong@gsm.hs.kr" }) }
                     }
                 }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentExcelServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentExcelServiceTest.kt
@@ -9,13 +9,13 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import team.themoment.datagsm.common.domain.student.dto.internal.StudentBulkUpdateDto
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.springframework.http.HttpStatus
 import org.springframework.mock.web.MockMultipartFile
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.student.dto.internal.StudentBulkUpdateDto
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentNumber
 import team.themoment.datagsm.common.domain.student.entity.constant.Major


### PR DESCRIPTION
  ## 개요

  엑셀 업로드 시 학생 정보를 개별 dirty checking으로 처리하던 방식을 QueryDSL 기반 벌크 업데이트로 개선하였습니다.
  `StudentBulkUpdateDto`를 도입하고 `bulkUpdateStudentFields` 메서드를 추가하여 이름, 전공, 동아리, 기숙사 호실, 소속, 성별을 일괄 처리하도록 변경하였습니다.

  ## 본문

  ### 변경 사항

  **`StudentBulkUpdateDto` 추가 (datagsm-common)**
  - 벌크 업데이트에 필요한 학생 필드를 담는 내부 DTO를 추가하였습니다.

  **`StudentJpaCustomRepository` / Impl 수정 (datagsm-common)**
  - `bulkUpdateStudentFields(updates: List<StudentBulkUpdateDto>)` 메서드를 추가하였습니다.
  - scalar 필드(이름, 전공, 소속, 성별, 기숙사 호실)는 `CASE WHEN id = ? THEN ... WHERE id IN (...)` 단일 쿼리로 일괄 업데이트되도록 구현하였습니다.
  - 동아리 FK는 `setNull`로 초기화한 뒤 동아리별 그룹으로 재할당하는 방식으로 처리하였습니다.
  - nullable Int 처리를 위한 `buildNullableIntCaseExpr`, String 처리를 위한 `buildStringCaseExpr`, Comparable 처리를 위한 `buildComparableCaseExpr` 헬퍼 메서드를
   추가하였습니다.

  **`ModifyStudentExcelServiceImpl` 수정 (datagsm-web)**
  - 기존 엔티티 필드 직접 수정(dirty checking) 방식에서 `StudentBulkUpdateDto` 목록을 구성한 뒤 `bulkUpdateStudentFields`를 호출하는 방식으로 변경하였습니다.
  - 더 이상 사용되지 않는 `getDormitoryEmbedded` 헬퍼 메서드를 제거하였습니다.

  ### `findAllStudents()` 유지 이유

  `WHERE studentNumber IN (...)` 쿼리로 대체할 수 있으나, 현재 로직은 엑셀과 DB의 학번 집합이 완전히 일치하는지 **양방향 검증**을 수행하고 있습니다.

  - `missingInDb`: 엑셀에는 있으나 DB에 없는 학번 감지
  - `extraInDb`: DB에는 있으나 엑셀에 없는 학번 감지

  `extraInDb` 검증은 전체 DB 학번 집합이 필요하므로, `IN (...)` 쿼리로 대체할 경우 엑셀에 누락된 학생을 감지할 수 없어 `findAllStudents()`를 유지하였습니다.


