### PR TITLE
[global] 벌크 업데이트 및 Rate Limit 필터 버그 수정

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
@@ -435,10 +435,6 @@ class StudentJpaCustomRepositoryImpl(
         jpaQueryFactory
             .update(studentJpaEntity)
             .setNull(studentJpaEntity.majorClub)
-            .where(studentJpaEntity.id.`in`(ids))
-            .execute()
-        jpaQueryFactory
-            .update(studentJpaEntity)
             .setNull(studentJpaEntity.autonomousClub)
             .where(studentJpaEntity.id.`in`(ids))
             .execute()
@@ -525,23 +521,24 @@ class StudentJpaCustomRepositoryImpl(
                 caseWhen.`when`(studentJpaEntity.id.eq(id)).then(value)
             }.otherwise(otherwise)
 
+    // Expressions.nullExpression()과 CaseBuilder().otherwise()의 반환 타입 불일치로 인한 안전한 캐스트
+    @Suppress("UNCHECKED_CAST")
     private fun <T : Comparable<T>> buildComparableCaseExpr(
         pairs: List<Pair<Long, T?>>,
         otherwise: Expression<T>,
     ): Expression<T> {
-        val nonNullPairs = pairs.filter { it.second != null }.map { it.first to it.second!! }
-        if (nonNullPairs.isEmpty()) return otherwise
+        val first = pairs[0]
+        val firstExpr: Expression<T> =
+            first.second?.let { Expressions.constant(it) } ?: Expressions.nullExpression<T>() as Expression<T>
 
-        // CaseBuilder().otherwise()의 반환 타입이 Expression<T?>로 추론되지만, non-null otherwise 표현식을 전달하므로 안전한 캐스트
-        @Suppress("UNCHECKED_CAST")
-        return nonNullPairs
+        return pairs
             .drop(1)
             .fold(
-                CaseBuilder()
-                    .`when`(studentJpaEntity.id.eq(nonNullPairs[0].first))
-                    .then(nonNullPairs[0].second),
+                CaseBuilder().`when`(studentJpaEntity.id.eq(first.first)).then(firstExpr),
             ) { caseWhen, (id, value) ->
-                caseWhen.`when`(studentJpaEntity.id.eq(id)).then(value)
+                val expr: Expression<T> =
+                    value?.let { Expressions.constant(it) } ?: Expressions.nullExpression<T>() as Expression<T>
+                caseWhen.`when`(studentJpaEntity.id.eq(id)).then(expr)
             }.otherwise(otherwise) as Expression<T>
     }
 

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
@@ -529,8 +529,7 @@ class StudentJpaCustomRepositoryImpl(
     ): Expression<T> {
         if (pairs.isEmpty()) return otherwise
 
-        fun toExpr(value: T?): Expression<T> =
-            value?.let { Expressions.constant(it) } ?: Expressions.nullExpression<T>() as Expression<T>
+        fun toExpr(value: T?): Expression<T> = value?.let { Expressions.constant(it) } ?: Expressions.nullExpression<T>() as Expression<T>
 
         val first = pairs[0]
         return pairs

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/custom/impl/StudentJpaCustomRepositoryImpl.kt
@@ -527,18 +527,18 @@ class StudentJpaCustomRepositoryImpl(
         pairs: List<Pair<Long, T?>>,
         otherwise: Expression<T>,
     ): Expression<T> {
-        val first = pairs[0]
-        val firstExpr: Expression<T> =
-            first.second?.let { Expressions.constant(it) } ?: Expressions.nullExpression<T>() as Expression<T>
+        if (pairs.isEmpty()) return otherwise
 
+        fun toExpr(value: T?): Expression<T> =
+            value?.let { Expressions.constant(it) } ?: Expressions.nullExpression<T>() as Expression<T>
+
+        val first = pairs[0]
         return pairs
             .drop(1)
             .fold(
-                CaseBuilder().`when`(studentJpaEntity.id.eq(first.first)).then(firstExpr),
+                CaseBuilder().`when`(studentJpaEntity.id.eq(first.first)).then(toExpr(first.second)),
             ) { caseWhen, (id, value) ->
-                val expr: Expression<T> =
-                    value?.let { Expressions.constant(it) } ?: Expressions.nullExpression<T>() as Expression<T>
-                caseWhen.`when`(studentJpaEntity.id.eq(id)).then(expr)
+                caseWhen.`when`(studentJpaEntity.id.eq(id)).then(toExpr(value))
             }.otherwise(otherwise) as Expression<T>
     }
 

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/filter/OAuthClientRateLimitFilter.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/filter/OAuthClientRateLimitFilter.kt
@@ -38,6 +38,7 @@ class OAuthClientRateLimitFilter(
 
         if (!result.consumed) {
             response.status = HttpStatus.TOO_MANY_REQUESTS.value()
+            response.characterEncoding = "UTF-8"
             response.contentType = MediaType.APPLICATION_JSON_VALUE
             response.setHeader(HttpHeaders.RETRY_AFTER, result.secondsToWaitForRefill.toString())
             val errorResponse =


### PR DESCRIPTION
## 개요

PR #285 코드 리뷰에서 지적된 버그 2건을 수정하였습니다. 학생 벌크 업데이트 시 nullable `major` 필드가 CASE WHEN 식에서 누락되는 버그와, Rate Limit 필터의 응답에 UTF-8 인코딩이 설정되지 않는 문제를 수정하였습니다.

## 본문

### `fix(student)` — 벌크 업데이트 버그 2건 수정

**1. `buildComparableCaseExpr` null 값 누락 버그**

기존 구현에서는 `nonNullPairs`로 null 값을 필터링하였기 때문에, `major: Major?`가 null인 학생의 전공 필드가 CASE WHEN 식에 포함되지 않아 DB 값이 변경되지 않는 버그가 있었습니다.

`buildNullableIntCaseExpr`와 동일하게 `Expressions.nullExpression()`을 활용하여 null인 경우에도 명시적으로 처리하도록 수정하였습니다.

**2. `setNull` 쿼리 2개 → 1개로 병합**

`majorClub`과 `autonomousClub`을 각각 별도의 UPDATE 쿼리로 초기화하던 것을 `.setNull()` 체이닝을 통해 하나의 쿼리로 병합하였습니다.

### `fix(client)` — Rate Limit 필터 UTF-8 인코딩 누락 수정

`OAuthClientRateLimitFilter`에서 429 응답 작성 시 `response.characterEncoding = "UTF-8"` 설정이 누락되어 있었습니다. 필터 레벨에서 직접 `response.writer`에 쓸 때는 Spring의 `CharacterEncodingFilter` 보장이 되지 않을 수 있어, 명시적으로 설정하도록 수정하였습니다.
