### PR TITLE
[global] `commit` 스킬 브랜치 네이밍 및 타입 목록 통일

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -13,14 +13,16 @@ git branch --show-current
 
 **If current branch is `develop`:**
 
+This project uses Git Flow. Feature branches must be created from `develop` and merged back into `develop`.
+
 1. Analyze all changes with `git status` and `git diff`
-2. Infer an appropriate feature branch name from the changes:
-   - Format: `feature/<kebab-case-description>`
+2. Infer an appropriate branch name from the changes:
+   - Format: `<type>/<kebab-case-description>` — use the same type as the planned commit
    - Reflect the domain scope in the name
-   - Examples: `feature/add-student-major-filter`, `feature/fix-auth-api-key-deletion`
-3. Create and checkout the feature branch:
+   - Examples: `feat/add-student-major-filter`, `fix/auth-api-key-deletion`, `refactor/optimize-club-query`
+3. Create and checkout the branch:
    ```bash
-   git checkout -b feature/<inferred-name>
+   git checkout -b <type>/<inferred-name>
    ```
 4. Proceed with the commit flow below
 
@@ -32,7 +34,7 @@ git branch --show-current
 
 Format: `type(scope): 설명`
 
-- **Types**: `add` / `update` / `fix` / `refactor` / `test` / `docs` / `merge` (English)
+- **Types**: `add` / `update` / `fix` / `refactor` / `ci/cd` / `docs` / `test` / `merge` (English)
 - **Scopes** (English):
   - **Primary**: Domain names (`auth`, `account`, `student`, `club`, `project`, `neis`, `client`, `oauth`, `utility`)
   - **Cross-cutting concerns only**: Module names (`web`, `oauth`, `openapi`) or `global`

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -17,9 +17,9 @@ This project uses Git Flow. Feature branches must be created from `develop` and 
 
 1. Analyze all changes with `git status` and `git diff`
 2. Infer an appropriate branch name from the changes:
-   - Format: `<type>/<kebab-case-description>` — use the same type as the planned commit
+   - Format: `<type>/<kebab-case-description>` — use the same type as the planned commit (exception: use `cicd/` for `ci/cd` type)
    - Reflect the domain scope in the name
-   - Examples: `feat/add-student-major-filter`, `fix/auth-api-key-deletion`, `refactor/optimize-club-query`
+   - Examples: `add/add-student-major-filter`, `fix/auth-api-key-deletion`, `refactor/optimize-club-query`
 3. Create and checkout the branch:
    ```bash
    git checkout -b <type>/<inferred-name>

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -18,9 +18,9 @@ This project uses Git Flow. Feature branches must be created from `develop` and 
 
 1. Analyze all changes with `git status` and `git diff`
 2. Infer an appropriate branch name from the changes:
-   - Format: `<type>/<kebab-case-description>` — use the same type as the planned commit
+   - Format: `<type>/<kebab-case-description>` — use the same type as the planned commit (exception: use `cicd/` for `ci/cd` type)
    - Reflect the domain scope in the name
-   - Examples: `feat/add-student-major-filter`, `fix/auth-api-key-deletion`, `refactor/optimize-club-query`
+   - Examples: `add/add-student-major-filter`, `fix/auth-api-key-deletion`, `refactor/optimize-club-query`
 3. Create and checkout the branch:
    ```bash
    git checkout -b <type>/<inferred-name>

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -14,14 +14,16 @@ git branch --show-current
 
 **If current branch is `develop`:**
 
+This project uses Git Flow. Feature branches must be created from `develop` and merged back into `develop`.
+
 1. Analyze all changes with `git status` and `git diff`
-2. Infer an appropriate feature branch name from the changes:
-   - Format: `feature/<kebab-case-description>`
+2. Infer an appropriate branch name from the changes:
+   - Format: `<type>/<kebab-case-description>` — use the same type as the planned commit
    - Reflect the domain scope in the name
-   - Examples: `feature/add-student-major-filter`, `feature/fix-auth-api-key-deletion`
-3. Create and checkout the feature branch:
+   - Examples: `feat/add-student-major-filter`, `fix/auth-api-key-deletion`, `refactor/optimize-club-query`
+3. Create and checkout the branch:
    ```bash
-   git checkout -b feature/<inferred-name>
+   git checkout -b <type>/<inferred-name>
    ```
 4. Proceed with the commit flow below
 
@@ -33,7 +35,7 @@ git branch --show-current
 
 Format: `type(scope): description`
 
-- **Types**: `add` / `update` / `fix` / `refactor` / `test` / `docs` / `merge`
+- **Types**: `add` / `update` / `fix` / `refactor` / `ci/cd` / `docs` / `test` / `merge`
 - **Scope**: domain name by default — for the full selection table, read `${CLAUDE_SKILL_DIR}/references/scope-guide.md`
 - **Description**: Korean, no period, avoid endings: `~한다/~된다`, `~하기`, `~합니다/~됩니다`, `~했습니다`
   - Good examples: `엔티티 필드 추가`, `트랜잭션 롤백 방지`, `로직 개선`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ master (프로덕션)
   ↑
 develop (스테이징)
   ↑
-feat/*, fix/*, refactor/*, ci/cd/*
+add/*, fix/*, refactor/*, cicd/*
 ```
 
 ### 브랜치 규칙
@@ -207,7 +207,7 @@ feat/*, fix/*, refactor/*, ci/cd/*
 |--------------|----------|-----------|-----------|
 | `master`     | 프로덕션 환경  | -         | -         |
 | `develop`    | 개발 환경    | `master`  | `master`  |
-| `feat/*`     | 새 기능 개발  | `develop` | `develop` |
+| `add/*`      | 새 기능 개발  | `develop` | `develop` |
 | `fix/*`      | 버그 수정    | `develop` | `develop` |
 | `refactor/*` | 코드 리팩토링  | `develop` | `develop` |
 | `cicd/*`     | CI/CD 설정 | `develop` | `develop` |
@@ -220,7 +220,7 @@ feat/*, fix/*, refactor/*, ci/cd/*
 # 새 기능 개발
 git checkout develop
 git pull origin develop
-git checkout -b feat/add-meal-api
+git checkout -b add/add-meal-api
 
 # 버그 수정
 git checkout -b fix/student-search-error
@@ -245,7 +245,7 @@ git checkout -b refactor/optimize-club-query
 |------------|-------------|----------------------------------------|
 | `update`   | 기능 개선       | `update(auth): API 키 삭제 엔드포인트 경로 변경`   |
 | `fix`      | 버그 수정       | `fix(student): 학생 검색 시 빈 문자열 처리 오류 수정` |
-| `feat`     | 새 기능 추가     | `feat(neis): 급식 조회 API 추가`             |
+| `add`      | 새 기능 추가     | `add(neis): 급식 조회 API 추가`              |
 | `refactor` | 코드 리팩토링     | `refactor(club): 동아리 조회 쿼리 최적화`        |
 | `ci/cd`    | CI/CD 설정 변경 | `ci/cd(global): PR 제목 검증 규칙 추가`        |
 | `docs`     | 문서 수정       | `docs(readme): 환경 설정 가이드 추가`           |
@@ -272,7 +272,7 @@ git checkout -b refactor/optimize-club-query
 # 좋은 예시
 git commit -m "update(auth): 변경된 API 키 삭제 엔드포인트의 경로 변수 이름 수정"
 git commit -m "fix(global): 올바르지 않은 공개 API 경로 설정 수정"
-git commit -m "feat(club): 동아리 멤버 조회 API 추가"
+git commit -m "add(club): 동아리 멤버 조회 API 추가"
 git commit -m "refactor(student): 학생 검색 로직 개선 및 중복 제거"
 
 # 나쁜 예시


### PR DESCRIPTION
## 개요

commit 스킬의 브랜치 네이밍 형식을 `feature/<name>` 고정에서 `<type>/<name>` 형식으로 변경하고, 커밋 타입 목록을 CONTRIBUTING.md 기준에 맞게 통일하였습니다.

## 본문

**브랜치 형식 수정**
- 기존: `feature/<kebab-case-description>` 고정 prefix 사용
- 변경: `<type>/<kebab-case-description>` — 커밋 타입과 동일한 prefix를 사용하도록 변경하였습니다.
- 예시: `feat/add-student-major-filter`, `fix/auth-api-key-deletion`, `refactor/optimize-club-query`
- Git Flow 기반 브랜치 전략임을 명시하는 설명을 추가하였습니다.

**커밋 타입 목록 수정**
- 기존: `add` / `update` / `fix` / `refactor` / `test` / `docs` / `merge`
- 변경: `add` / `update` / `fix` / `refactor` / `ci/cd` / `docs` / `test` / `merge`
- CONTRIBUTING.md에 정의된 `ci/cd` 타입을 목록에 추가하고 순서를 통일하였습니다.

**대상 파일**
- `.claude/skills/commit/SKILL.md`
- `.agents/skills/commit/SKILL.md`
