### PR TITLE
[application] Application 생성 시 scope ID NPE 수정

### DIFF
--- a/.github/workflows/datagsm-issue-validation.yaml
+++ b/.github/workflows/datagsm-issue-validation.yaml
@@ -20,7 +20,7 @@ jobs:
             const allowedScopes = [
               'global', 'account', 'auth', 'client', 'club',
               'neis', 'oauth', 'project', 'student',
-              'web', 'oauth', 'openapi', 'ci/cd'
+              'web', 'oauth', 'openapi', 'ci/cd', 'application'
             ];
             const titlePattern = /^\[([^\]]+)\]\s+(.+)$/;
             const match = title.match(titlePattern);

--- a/.github/workflows/datagsm-prod-ci.yaml
+++ b/.github/workflows/datagsm-prod-ci.yaml
@@ -30,7 +30,7 @@ jobs:
             const allowedScopes = [
               'global', 'account', 'auth', 'client', 'club',
               'neis', 'oauth', 'project', 'student', 'utility',
-              'web', 'openapi', 'oauth', 'ci/cd'
+              'web', 'openapi', 'oauth', 'ci/cd', 'application'
             ];
 
             const versionPattern = /^v\d{8}\.\d+$/;

--- a/.github/workflows/datagsm-stage-ci.yaml
+++ b/.github/workflows/datagsm-stage-ci.yaml
@@ -30,7 +30,7 @@ jobs:
             const allowedScopes = [
               'global', 'account', 'auth', 'client', 'club',
               'neis', 'oauth', 'project', 'student', 'utility',
-              'web', 'oauth', 'openapi', 'ci/cd'
+              'web', 'oauth', 'openapi', 'ci/cd', 'application'
             ];
 
             const versionPattern = /^v\d{8}\.\d+$/;

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/application/service/impl/CreateApplicationServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/application/service/impl/CreateApplicationServiceImpl.kt
@@ -52,9 +52,9 @@ class CreateApplicationServiceImpl(
             application.oauthScopes.add(scopeEntity)
         }
 
-        applicationJpaRepository.save(application)
+        val savedApplication = applicationJpaRepository.save(application)
 
-        return application.toResDto()
+        return savedApplication.toResDto()
     }
 }
 


### PR DESCRIPTION
## 개요

Application 생성 시 OAuthScope의 ID가 null이 되어 NPE가 발생하는 버그를 수정하였습니다.

## 본문

`ApplicationJpaEntity`는 ID를 수동 할당(`UUID`)하기 때문에, Spring Data JPA의 `save()` 메서드가 `persist()` 대신 `merge()`를 호출합니다. `merge()`는 원본 객체를 수정하지 않고 새로운 managed copy를 반환하는데, 기존 코드에서는 `save()`의 반환값을 사용하지 않고 원본 객체의 `toResDto()`를 호출하고 있었습니다.

이로 인해 cascade로 저장된 `OAuthScopeJpaEntity`의 auto increment ID가 원본 객체에 반영되지 않아 `scope.id!!`에서 NPE가 발생하였습니다.

`save()`의 반환값(managed entity)을 사용하도록 수정하여 문제를 해결하였습니다.
