### PR TITLE
[global] review-pr `PARTIAL` 확인 방식을 `AskUserQuestion`으로 변경

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -38,7 +38,7 @@ For each comment in `pr_comments.json`, apply the following **layered judgment c
 
 - **VALID**: reviewer is correct → attempt auto code fix
 - **INVALID**: reviewer is wrong with a clear refutation → skip, post refutation reply
-- **PARTIAL**: intent is correct but application method or scope is ambiguous → console confirm
+- **PARTIAL**: intent is correct but application method or scope is ambiguous → confirm with AskUserQuestion
 
 Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`, `Kotlin: prefer val over var`).
 
@@ -54,19 +54,21 @@ Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`
    git rev-parse --short HEAD
    ```
 
-On failure: record the reason and fall back to PARTIAL console prompt.
+On failure: record the reason and fall back to PARTIAL.
 
 ### INVALID → Skip
 
 Do not modify any code. Record the refutation rationale for Step 5.
 
-### PARTIAL → Console confirm
+### PARTIAL → Confirm with AskUserQuestion
+
+Use the AskUserQuestion tool to ask:
 
 ```
-⚠️  PARTIAL: [file:line] (reviewer)
+⚠️ PARTIAL: [file:line] (reviewer)
 Review: "..."
 Rationale: ...
-Accept? (y/n/s = skip for now):
+Accept? (y / n / s = skip for now)
 ```
 
 - `y`: treat as VALID, attempt code fix

--- a/.agents/skills/review-pr/references/reply-formats.md
+++ b/.agents/skills/review-pr/references/reply-formats.md
@@ -7,7 +7,7 @@ All replies must be written in Korean.
 ## VALID — fix succeeded
 
 ```
-<abc1234>에서 반영했습니다. (근거: <출처>)
+<abc1234> 에서 반영했습니다. (근거: <출처>)
 ```
 
 ## VALID — fix failed
@@ -27,7 +27,7 @@ All replies must be written in Korean.
 ## PARTIAL — accepted
 
 ```
-부분적으로 타당하다고 판단하여 <abc1234>에서 반영했습니다.
+부분적으로 타당하다고 판단하여 <abc1234> 에서 반영했습니다.
 ```
 
 ## PARTIAL — rejected

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -39,7 +39,7 @@ For each comment in `pr_comments.json`, apply the following **layered judgment c
 
 - **VALID**: reviewer is correct → attempt auto code fix
 - **INVALID**: reviewer is wrong with a clear refutation → skip, post refutation reply
-- **PARTIAL**: intent is correct but application method or scope is ambiguous → console confirm
+- **PARTIAL**: intent is correct but application method or scope is ambiguous → confirm with AskUserQuestion
 
 Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`, `Kotlin: prefer val over var`).
 
@@ -55,19 +55,21 @@ Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`
    git rev-parse --short HEAD
    ```
 
-On failure: record the reason and fall back to PARTIAL console prompt.
+On failure: record the reason and fall back to PARTIAL.
 
 ### INVALID → Skip
 
 Do not modify any code. Record the refutation rationale for Step 5.
 
-### PARTIAL → Console confirm
+### PARTIAL → Confirm with AskUserQuestion
+
+Use the AskUserQuestion tool to ask:
 
 ```
-⚠️  PARTIAL: [file:line] (reviewer)
+⚠️ PARTIAL: [file:line] (reviewer)
 Review: "..."
 Rationale: ...
-Accept? (y/n/s = skip for now):
+Accept? (y / n / s = skip for now)
 ```
 
 - `y`: treat as VALID, attempt code fix

--- a/.claude/skills/review-pr/references/reply-formats.md
+++ b/.claude/skills/review-pr/references/reply-formats.md
@@ -7,7 +7,7 @@ All replies must be written in Korean.
 ## VALID — fix succeeded
 
 ```
-<abc1234>에서 반영했습니다. (근거: <출처>)
+<abc1234> 에서 반영했습니다. (근거: <출처>)
 ```
 
 ## VALID — fix failed
@@ -27,7 +27,7 @@ All replies must be written in Korean.
 ## PARTIAL — accepted
 
 ```
-부분적으로 타당하다고 판단하여 <abc1234>에서 반영했습니다.
+부분적으로 타당하다고 판단하여 <abc1234> 에서 반영했습니다.
 ```
 
 ## PARTIAL — rejected


### PR DESCRIPTION
## 개요

`review-pr` 스킬의 `PARTIAL` 판정 확인 방식을 콘솔 출력에서 `AskUserQuestion` 툴 사용으로 변경하였습니다.

## 본문

`PARTIAL` 판정 시 기존에는 텍스트를 출력하고 사용자가 응답을 입력하는 방식이었으나, `AskUserQuestion` 툴을 명시적으로 사용하도록 변경하였습니다.

`.agents`와 `.claude` 양쪽 `review-pr/SKILL.md`에 동일하게 반영하였으며, `reply-formats.md`의 한국어 공백 및 파일 끝 개행도 함께 정리하였습니다.
