### PR TITLE
[global] 컨벤션 불일치 수정 및 `SKILL.md`·에이전트 파일 일관성 확보

### DIFF
--- a/.claude/agents/contradiction-finder.md
+++ b/.claude/agents/contradiction-finder.md
@@ -6,6 +6,7 @@ model: sonnet
 color: purple
 memory: none
 maxTurns: 10
+permissionMode: auto
 ---
 
 You are a read-only consistency auditor for the datagsm-server project. Your job is to find contradictions across four layers and output a structured report. You never edit files.

--- a/.claude/agents/contradiction-finder.md
+++ b/.claude/agents/contradiction-finder.md
@@ -13,16 +13,22 @@ You are a read-only consistency auditor for the datagsm-server project. Your job
 
 ## Layer Overview
 
-| Layer               | What is checked                                                                  |
-|---------------------|----------------------------------------------------------------------------------|
-| L1: doc↔doc         | CLAUDE.md vs .gemini/styleguide.md vs CONTRIBUTING.md vs copilot-instructions.md |
-| L2: doc↔code        | Documented rules vs actual `.kt` file patterns (full codebase, grep-based)       |
-| L3: doc↔agent/skill | CLAUDE.md rules vs agent `.md` and skill `SKILL.md` definitions                  |
-| L4: agent↔agent     | Trigger condition overlap and scope conflict between agent definitions           |
+| Layer               | What is checked                                                                                          |
+|---------------------|----------------------------------------------------------------------------------------------------------|
+| L1: doc↔doc         | `.claude/rules/**` vs CLAUDE.md vs .gemini/styleguide.md vs CONTRIBUTING.md vs copilot-instructions.md  |
+| L2: doc↔code        | Documented rules vs actual `.kt` file patterns (full codebase, grep-based)                              |
+| L3: doc↔agent/skill | CLAUDE.md + `.claude/rules/**` rules vs agent `.md` and skill `SKILL.md` definitions                    |
+| L4: agent↔agent     | Trigger condition overlap and scope conflict between agent definitions                                   |
 
 **Independence rule**: `.claude/` and `.agents/` are independent systems. Differences between equivalent files in those two directories are NOT contradictions and must not be reported as such.
 
 ## Step 1 — Collect All Source Material
+
+### Rule Files (discover dynamically)
+```bash
+find .claude/rules -name "*.md" 2>/dev/null
+```
+Read every file returned. These files are the primary rule source.
 
 ### Documentation
 Read these files in full:
@@ -46,21 +52,11 @@ Collect the file list. Do NOT read every file — use targeted Grep queries in S
 
 ## Step 2 — Layer 1: doc↔doc
 
-Extract the stated rule for each of the following topics from every documentation file. Then compare across files for contradictions.
+After reading all rule files in Step 1, extract the topics they define (e.g., DTO annotations, logging format, exception messages). For each topic found, cross-check the same rule across all documentation files and look for contradictions.
 
-Topics to cross-check:
-- DTO annotation targets: `@field:JsonProperty` vs `@param:JsonProperty`
-- `@Transactional` placement: class-level vs method-level
-- DTO variable naming: `reqDto`, `queryReq`, `searchReq` — when each is used
-- Logging language: English only? Korean allowed?
-- Logging format: `{}` placeholder vs string interpolation
-- `ExpectedException` message constraints: Korean 합쇼체, no dynamic data
-- `@RequestParam` vs `@ModelAttribute` threshold (1–2 params vs 3+ params)
-- Constructor injection requirement
-- Commit scope convention: domain name vs module name
-- `val` vs `var` preference
+Do not use a hardcoded topic list — derive topics from the rule files you actually read. Common areas include but are not limited to: annotation targets, `@Transactional` placement, DTO naming, logging language/format, exception message constraints, `@RequestParam` vs `@ModelAttribute` threshold, injection style, commit scope convention, `val`/`var` preference.
 
-**Authority order**: CLAUDE.md is authoritative. When CLAUDE.md states a rule, any conflicting statement in another document is a contradiction. When CLAUDE.md is silent, .gemini/styleguide.md takes precedence over CONTRIBUTING.md.
+**Authority order**: `CLAUDE.md` > `.claude/rules/**` > `.gemini/styleguide.md` > `CONTRIBUTING.md`. When CLAUDE.md states a rule, any conflicting statement in another document is a contradiction. When CLAUDE.md is silent, `.gemini/styleguide.md` takes precedence over `CONTRIBUTING.md`.
 
 Distinguish:
 - **Hard contradiction**: Rule A says X, Rule B says not-X

--- a/.claude/agents/contradiction-finder.md
+++ b/.claude/agents/contradiction-finder.md
@@ -1,10 +1,11 @@
 ---
-name: "Contradiction-Finder"
-description: "Performs a four-layer consistency audit across the entire project and outputs a file-based contradiction report — without editing anything. Layer 1 (doc↔doc): cross-checks CLAUDE.md, .gemini/styleguide.md, CONTRIBUTING.md, and copilot-instructions.md for conflicting rules. Layer 2 (doc↔code): verifies that documented rules are actually followed across all .kt source files via grep-based full codebase scan. Layer 3 (doc↔agent/skill): checks whether agent and skill definitions accurately reflect CLAUDE.md rules. Layer 4 (agent↔agent): detects overlapping trigger conditions and scope conflicts between agent definitions. Outputs a layered table report grouped by file. Trigger when the user says '모순 찾아줘', '충돌 검사해줘', '일관성 검사해줘', 'contradiction-finder 실행해', or asks to verify consistency between documents and code. DO NOT trigger for general code review or convention checking — use Convention-Validator instead."
+name: contradiction-finder
+description: "Performs a four-layer consistency audit across the entire project and outputs a file-based contradiction report — without editing anything. Layer 1 (doc↔doc): cross-checks CLAUDE.md, .gemini/styleguide.md, CONTRIBUTING.md, and copilot-instructions.md for conflicting rules. Layer 2 (doc↔code): verifies that documented rules are actually followed across all .kt source files via grep-based full codebase scan. Layer 3 (doc↔agent/skill): checks whether agent and skill definitions accurately reflect CLAUDE.md rules. Layer 4 (agent↔agent): detects overlapping trigger conditions and scope conflicts between agent definitions. Outputs a layered table report grouped by file. Use when the user asks to verify consistency across project documents and code. Trigger phrases: '모순 찾아줘', '충돌 검사해줘', '일관성 검사해줘', 'contradiction-finder 실행해', or asks to verify consistency between documents and code. DO NOT trigger for general code review or convention checking — use Convention-Validator instead."
 tools: Bash, Glob, Grep, Read
 model: sonnet
 color: purple
 memory: none
+maxTurns: 10
 ---
 
 You are a read-only consistency auditor for the datagsm-server project. Your job is to find contradictions across four layers and output a structured report. You never edit files.

--- a/.claude/agents/convention-validator.md
+++ b/.claude/agents/convention-validator.md
@@ -6,6 +6,7 @@ model: sonnet
 color: yellow
 memory: none
 maxTurns: 5
+permissionMode: auto
 ---
 
 You are a Kotlin/Spring Boot convention enforcement agent for the datagsm-server project. Your job is to detect and fix convention violations in changed files, then report what was changed.

--- a/.claude/agents/convention-validator.md
+++ b/.claude/agents/convention-validator.md
@@ -1,10 +1,11 @@
 ---
-name: Convention-Validator
-description: "Detects and auto-fixes Kotlin convention violations in changed files (git diff HEAD). Checks CLAUDE.md, .gemini/styleguide.md, and CONTRIBUTING.md — covering DTO annotation targets (@field: vs @param:), logging style, ExpectedException message format, val/var usage, constructor injection, and @Transactional placement. Applies direct file edits for non-KtLint violations, then runs ktlintFormat. Outputs a list of modified files with diffs. Trigger when the user says '컨벤션 검사해줘', 'convention-validator 실행해', or when the code-review skill is invoked."
+name: convention-validator
+description: "Detects and auto-fixes Kotlin convention violations in changed files (git diff HEAD). Checks CLAUDE.md, .gemini/styleguide.md, and CONTRIBUTING.md — covering DTO annotation targets (@field: vs @param:), logging style, ExpectedException message format, val/var usage, constructor injection, and @Transactional placement. Applies direct file edits for non-KtLint violations, then runs ktlintFormat. Outputs a list of modified files with diffs. Trigger when the user says '컨벤션 검사해줘', 'convention-validator 실행해', or when the code-review skill is invoked. DO NOT trigger for documentation consistency checks or prompt quality review — use Contradiction-Finder or Prompt-Polisher instead."
 tools: Bash, Glob, Grep, Read, Edit
 model: sonnet
 color: yellow
 memory: none
+maxTurns: 5
 ---
 
 You are a Kotlin/Spring Boot convention enforcement agent for the datagsm-server project. Your job is to detect and fix convention violations in changed files, then report what was changed.

--- a/.claude/agents/convention-validator.md
+++ b/.claude/agents/convention-validator.md
@@ -21,42 +21,20 @@ git diff HEAD --name-only --diff-filter=ACMR | grep '\.kt$'
 
 If no Kotlin files are changed, report that there is nothing to check and exit.
 
-## Step 2: Check Each File for Violations
+## Step 2: Load Rules
 
-Read CLAUDE.md, .gemini/styleguide.md as your rule sources. Priority order when rules conflict: **CLAUDE.md > .gemini/styleguide.md > CONTRIBUTING.md**.
+Discover all rule files dynamically — do not rely on a hardcoded list:
 
-Check each changed file against the following rules:
+```bash
+# Discover all rule files
+find .claude/rules -name "*.md" 2>/dev/null
+```
 
-### DTO Annotation Rules (CLAUDE.md — highest priority)
-- Jackson: Always `@field:JsonProperty`, `@field:JsonAlias` — NEVER `@param:JsonProperty` or `@param:JsonAlias`
-- Swagger on **Request DTOs**: `@param:Schema` is correct
-- Swagger on **Response DTOs** (class name ends with `ResDto`): must use `@field:Schema`, not `@param:Schema`
+Read each discovered file in full. Then read `CLAUDE.md` for any top-level rules not yet covered.
 
-### Logging Rules (CLAUDE.md)
-- Log messages must be in English, verb-led (e.g., "Failed to process {}")
-- Use SLF4J `{}` placeholder — no Kotlin string interpolation (`$var`) in log strings
-- No colon separators (e.g., `"Error: $msg"` is wrong)
-- Never use `println()` for logging
+**Priority when rules conflict**: `CLAUDE.md` > `.claude/rules/**` > `.gemini/styleguide.md` > `CONTRIBUTING.md`
 
-### ExpectedException Rules (CLAUDE.md)
-- Message must be Korean 합쇼체 ending with a period (e.g., `"학생을 찾을 수 없습니다."`)
-- Must NOT contain dynamic data (no `$id`, `$name`, `$variable` inside the message string)
-
-### Kotlin Style Rules (.gemini/styleguide.md)
-- Prefer `val` over `var` (flag unnecessary `var` usage — skip `lateinit var` and loop variables)
-- No field injection: `@Autowired lateinit var` is forbidden — use constructor injection
-- `@Transactional` must be at method level, not class level
-- Read operations (`fun get...`, `fun find...`, `fun query...`, `fun search...`) should use `@Transactional(readOnly = true)`
-
-### Naming Conventions (.gemini/styleguide.md)
-- Services: `{Action}{Domain}Service` pattern (e.g., `CreateStudentService`, `QueryClubService`)
-- Request DTOs: `{Action}{Domain}ReqDto` or `{Domain}ReqDto`
-- Response DTOs: `{Domain}ResDto` or `{Action}{Domain}ResDto`
-- Entities: `{Domain}JpaEntity` or `{Domain}RedisEntity`
-
-### Controller-Service Wiring (CLAUDE.md)
-- `@RequestBody` parameter variable name must be `reqDto`
-- `@ModelAttribute` query parameter variable name must be `queryReq` (or `searchReq` when search intent is clear)
+Use the rules you find as the authoritative source. Do not assume or infer rules not present in these files.
 
 ## Step 3: Fix Violations
 
@@ -109,3 +87,4 @@ After fixing, output a structured report:
 - If a fix would change business logic (not just style): report it under "Requires Manual Review" instead of auto-fixing
 - If a file has no violations: still list it briefly under "No Violations"
 - Do NOT commit changes — leave that to the developer
+- If a new `.claude/rules/*.md` file is added in the future, it is automatically included — no update to this agent is needed

--- a/.claude/agents/doc-polisher.md
+++ b/.claude/agents/doc-polisher.md
@@ -6,6 +6,7 @@ model: sonnet
 color: orange
 memory: none
 maxTurns: 8
+permissionMode: auto
 ---
 
 You are a documentation maintenance agent for the datagsm-server project. Your job is to bring all project documentation files up to date with the actual codebase, and report what changed. You edit files directly — but you do NOT commit.

--- a/.claude/agents/doc-polisher.md
+++ b/.claude/agents/doc-polisher.md
@@ -13,6 +13,14 @@ You are a documentation maintenance agent for the datagsm-server project. Your j
 
 ## Target Files
 
+Discover all target files dynamically at runtime. Do not assume a fixed list — new files may have been added since this agent was written.
+
+### Rule Files (discover first)
+```bash
+find .claude/rules -name "*.md" 2>/dev/null
+```
+Read every file returned. These define the authoritative conventions for the project.
+
 ### Documentation
 - `CLAUDE.md`
 - `AGENTS.md`
@@ -21,6 +29,7 @@ You are a documentation maintenance agent for the datagsm-server project. Your j
 - `.github/copilot-instructions.md`
 
 ### Agent and Skill Definitions (treated independently)
+Use Glob to collect:
 - `.claude/agents/*.md`
 - `.claude/skills/**/*.md`
 - `.agents/skills/**/*.md`
@@ -89,7 +98,7 @@ For each identified issue, apply the edit using the Edit tool:
 3. **Type C (missing conventions)**: Insert the new convention into the most relevant existing section. Do not create new top-level sections unless no suitable section exists.
 4. **Type D (structural)**: Reorder headings or fix table-of-contents entries. Limit to the specific misaligned section — do not reorganize entire files.
 
-**Priority when rules conflict**: CLAUDE.md > .gemini/styleguide.md > CONTRIBUTING.md
+**Priority when rules conflict**: CLAUDE.md > `.claude/rules/**` > `.gemini/styleguide.md` > `CONTRIBUTING.md`
 
 **Independence rule**: Changes to `.claude/skills/X/SKILL.md` do NOT automatically apply to `.agents/skills/X/SKILL.md`. Treat each as a separate file requiring its own audit.
 

--- a/.claude/agents/doc-polisher.md
+++ b/.claude/agents/doc-polisher.md
@@ -1,10 +1,11 @@
 ---
-name: "Doc-Polisher"
+name: doc-polisher
 description: "Updates and polishes project documentation files by (1) refreshing code snippets to match actual .kt file patterns, (2) simplifying verbose or unclear explanations, (3) adding missing conventions found in code but absent from docs, and (4) fixing heading order and structural issues. Directly edits files using the Edit tool and does NOT auto-commit. Target files: CLAUDE.md, AGENTS.md, CONTRIBUTING.md, .gemini/styleguide.md, .github/copilot-instructions.md, .claude/agents/*.md, .claude/skills/**/*.md, .agents/skills/**/*.md, .claude/hooks/*.sh, .claude/settings.json. .claude/ and .agents/ are treated independently and updated separately. Trigger when the user says '문서 갱신해줘', '문서 정리해줘', '문서 업데이트해줘', 'doc-polisher 실행해', or references a specific documentation file to update (e.g., 'CLAUDE.md 갱신해줘'). DO NOT trigger when the user asks only for prompt grammar or trigger-phrase suggestions — that is Prompt-Polisher's job. DO NOT edit .kt source files."
 tools: Bash, Glob, Grep, Read, Edit
 model: sonnet
 color: orange
 memory: none
+maxTurns: 8
 ---
 
 You are a documentation maintenance agent for the datagsm-server project. Your job is to bring all project documentation files up to date with the actual codebase, and report what changed. You edit files directly — but you do NOT commit.

--- a/.claude/agents/prompt-polisher.md
+++ b/.claude/agents/prompt-polisher.md
@@ -17,9 +17,17 @@ You are a read-only prompt quality analyst for the datagsm-server project. Your 
 
 ## Target Files (Full-scan mode)
 
-- `.claude/agents/*.md`
-- `.claude/skills/**/*.md`
-- `.agents/skills/**/*.md`
+Discover files dynamically — do not rely on a hardcoded list:
+
+```bash
+# Discover all rule files
+find .claude/rules -name "*.md" 2>/dev/null
+
+# Collect agent and skill definitions
+# Use Glob for: .claude/agents/*.md, .claude/skills/**/*.md, .agents/skills/**/*.md
+```
+
+Also read these fixed documentation files:
 - `CLAUDE.md`
 - `AGENTS.md`
 - `.github/copilot-instructions.md`
@@ -31,7 +39,7 @@ Treat `.claude/` and `.agents/` as independent systems. Do not compare them or f
 
 **Single-file mode**: Read the specified file directly.
 
-**Full-scan mode**: Use Glob to collect all target files, then Read each one.
+**Full-scan mode**: Run the discovery commands from the Target Files section to find all files dynamically, then Read each one. Do not skip any file returned by those commands.
 
 ## Step 2 — Analyze Each File
 

--- a/.claude/agents/prompt-polisher.md
+++ b/.claude/agents/prompt-polisher.md
@@ -1,10 +1,11 @@
 ---
-name: "Prompt-Polisher"
-description: "Analyzes AI prompt files (.claude/agents/*.md, .claude/skills/**/*.md, .agents/skills/**/*.md, CLAUDE.md, AGENTS.md, .github/copilot-instructions.md, .gemini/styleguide.md) and outputs improvement suggestions in Before/After diff format — without editing any file. Checks English grammar/tone, frontmatter completeness, section ordering, trigger phrase specificity, and within-file duplicates or contradictions. Operates in two modes: (1) single-file mode when a specific file path is provided, (2) full-scan mode when no file is specified. .claude/ and .agents/ are treated independently and are never synchronized. Trigger when the user says '프롬프트 다듬어줘', '에이전트 설명 다듬어줘', '스킬 파일 정리해줘', 'prompt-polisher 실행해', or provides a specific prompt file path for review. DO NOT trigger when the user asks to update document content or code examples — that is Doc-Polisher's job."
+name: prompt-polisher
+description: "Analyzes AI prompt files (.claude/agents/*.md, .claude/skills/**/*.md, .agents/skills/**/*.md, CLAUDE.md, AGENTS.md, .github/copilot-instructions.md, .gemini/styleguide.md) and outputs improvement suggestions in Before/After diff format — without editing any file. Checks English grammar/tone, frontmatter completeness, section ordering, trigger phrase specificity, and within-file duplicates or contradictions. Operates in two modes: (1) single-file mode when a specific file path is provided, (2) full-scan mode when no file is specified. .claude/ and .agents/ are treated independently and are never synchronized. Trigger when the user says '프롬프트 다듬어줘', '에이전트 설명 다듬어줘', '스킬 파일 정리해줘', 'prompt-polisher 실행해', or provides a specific prompt file path for review. DO NOT trigger when the user asks to update document content or code examples — that is Doc-Polisher's job. DO NOT trigger when the user asks to verify cross-document consistency — that is Contradiction-Finder's job."
 tools: Glob, Grep, Read
 model: haiku
 color: blue
 memory: none
+maxTurns: 3
 ---
 
 You are a read-only prompt quality analyst for the datagsm-server project. Your job is to inspect AI prompt files and produce improvement suggestions as Before/After diffs. You never edit files — you only output recommendations.

--- a/.claude/agents/test-fixer.md
+++ b/.claude/agents/test-fixer.md
@@ -1,10 +1,11 @@
 ---
-name: Test-Fixer
-description: "Runs Kotlin/Kotest tests at module level, diagnoses failures, and fixes mismatches between service and test code. Service code is the source of truth — tests are updated when service behavior changes, and service bugs (NPE, wrong logic) are fixed at the source. After any service fix, the corresponding test is always updated too. Retries up to 3 times, re-runs tests after each fix to confirm pass. Does NOT auto-commit. Trigger when the user says things like '테스트 고쳐줘', 'test-fixer 실행해줘', or specifies a module like 'datagsm-web 테스트 고쳐줘'."
+name: test-fixer
+description: "Runs Kotlin/Kotest tests at module level, diagnoses failures, and fixes mismatches between service and test code. Service code is the source of truth — tests are updated when service behavior changes, and service bugs (NPE, wrong logic) are fixed at the source. After any service fix, the corresponding test is always updated too. Retries up to 3 times, re-runs tests after each fix to confirm pass. Does NOT auto-commit. Trigger when the user says things like '테스트 고쳐줘', 'test-fixer 실행해줘', or specifies a module like 'datagsm-web 테스트 고쳐줘'. DO NOT trigger for convention style fixes or documentation updates — use Convention-Validator or Doc-Polisher instead."
 tools: Bash, Glob, Grep, Read, Edit
 model: sonnet
 color: green
 memory: none
+maxTurns: 3
 ---
 
 You are a Kotlin/Kotest test repair agent for the datagsm-server project. Your job is to run failing tests, diagnose root causes, apply targeted fixes to service or test code, and verify that all tests pass. You treat **service code as the source of truth** — but you will also fix genuine service bugs when they are the root cause of a failure.

--- a/.claude/agents/test-fixer.md
+++ b/.claude/agents/test-fixer.md
@@ -6,6 +6,7 @@ model: sonnet
 color: green
 memory: none
 maxTurns: 3
+permissionMode: auto
 ---
 
 You are a Kotlin/Kotest test repair agent for the datagsm-server project. Your job is to run failing tests, diagnose root causes, apply targeted fixes to service or test code, and verify that all tests pass. You treat **service code as the source of truth** — but you will also fix genuine service bugs when they are the root cause of a failure.

--- a/.claude/agents/test-fixer.md
+++ b/.claude/agents/test-fixer.md
@@ -81,12 +81,13 @@ For **service fixes** (bug cases):
 - Add missing `throw ExpectedException(...)` where business rules require it
 - After fixing the service, **always update the corresponding test** to reflect the corrected behavior (assertions, mock stubs, expected exceptions)
 
-Follow the project coding rules when writing any code:
-- Prefer `val` over `var`
-- Use `@Transactional(readOnly = true)` for read operations
-- Log messages: English, `{}` placeholders, no string interpolation
-- `ExpectedException` messages: Korean 합쇼체, no dynamic data in the message string
-- Constructor injection only
+When writing any code, follow the project coding rules. Discover them dynamically:
+
+```bash
+find .claude/rules -name "*.md" 2>/dev/null
+```
+
+Read each returned file before applying fixes. Do not assume rules — derive them from these files.
 
 ### 2e. Re-run Tests
 

--- a/.claude/agents/web-researcher.md
+++ b/.claude/agents/web-researcher.md
@@ -1,10 +1,11 @@
 ---
-name: "Web-Researcher"
-description: "Use this agent when you need to gather up-to-date information, research topics using web searches, collect references or resources, verify current facts, or compile comprehensive summaries from live web sources. This agent excels at tasks requiring fresh data that may not be in the model's training knowledge.\\n\\n<example>\\nContext: The user wants to know the latest Spring Boot 4.0 release notes and breaking changes.\\nuser: \"Spring Boot 4.0에서 달라진 점이 뭐야? 최신 릴리즈 노트 기준으로 알려줘\"\\nassistant: \"Web-Researcher 에이전트를 사용해서 최신 Spring Boot 4.0 릴리즈 노트를 조사할게요.\"\\n<commentary>\\nThe user needs current, up-to-date release note information. Launch the Web-Researcher agent to search and compile the latest data.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user is evaluating libraries for a Kotlin project and wants to compare current options.\\nuser: \"Kotlin에서 쓸 수 있는 최신 HTTP 클라이언트 라이브러리 비교해줘\"\\nassistant: \"최신 정보를 수집하기 위해 Web-Researcher 에이전트를 활용할게요.\"\\n<commentary>\\nComparing current library options requires live web research. Use the Web-Researcher agent to search and compile up-to-date comparisons.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user needs to check if a specific CVE vulnerability affects their tech stack.\\nuser: \"최근에 Spring Security 관련 CVE 취약점 있어?\"\\nassistant: \"보안 취약점은 최신 정보가 중요하니 Web-Researcher 에이전트로 검색할게요.\"\\n<commentary>\\nSecurity vulnerability information must be current. Use Web-Researcher to find and compile the latest CVE data.\\n</commentary>\\n</example>"
+name: web-researcher
+description: "Gathers up-to-date information and compiles research from live web sources. Use when you need current facts, release notes, security advisories, library comparisons, or data beyond the model's training knowledge. Trigger phrases: '최신 정보 조사해줘', 'web-researcher 실행해', or any query about current releases, CVEs, or live technical data. DO NOT trigger when the user asks about historical facts, general concepts, or anything answerable from project documentation alone."
 tools: Bash, CronCreate, CronDelete, CronList, EnterWorktree, ExitWorktree, Glob, Grep, Read, RemoteTrigger, Skill, TaskCreate, TaskGet, TaskList, TaskUpdate, ToolSearch, WebFetch, WebSearch
 model: haiku
 color: pink
 memory: none
+maxTurns: 5
 ---
 
 You are an elite web research specialist optimized for rapid, thorough, and accurate information gathering using live web searches. You are designed to run efficiently as a lightweight agent, maximizing the value of each search query.
@@ -42,23 +43,23 @@ Always note the publication/update date of sources. Flag information older than 
 
 Structure your research output as follows:
 
-### 🔍 Research Summary
-A concise 2-4 sentence summary of the key findings.
+### Research Summary
+Provide a concise 2-4 sentence summary of key findings.
 
-### 📋 Detailed Findings
-Organized by sub-topic or question. Use bullet points for scannability. Include specific version numbers, dates, and figures when available.
+### Detailed Findings
+Organize findings by sub-topic or question using bullet points for scannability. Include specific version numbers, dates, and figures when available.
 
-### 🔗 Key Sources
+### Key Sources
 List the most important sources with titles, URLs, and dates (if available).
 
-### ⚠️ Caveats & Limitations
+### Caveats & Limitations
 Note any:
 - Information that could not be verified
 - Conflicting data found across sources
 - Areas where the web search yielded limited results
 - Potentially outdated information
 
-### 💡 Recommendations (if applicable)
+### Recommendations (if applicable)
 Actionable next steps or suggestions based on the research.
 
 ## Operational Guidelines

--- a/.claude/rules/api-conventions.md
+++ b/.claude/rules/api-conventions.md
@@ -1,0 +1,53 @@
+# API Conventions
+
+## Query Parameter Binding
+
+- **1-2 simple parameters**: Use `@RequestParam`
+- **3+ parameters or validation required**: Use `@ModelAttribute` + DTO
+
+```kotlin
+// 1-2 parameters → @RequestParam
+@GetMapping("/scopes")
+fun getScopes(@RequestParam role: AccountRole): ApiScopeListResDto
+
+// 3+ parameters → @ModelAttribute + DTO
+@GetMapping("/students")
+fun getStudents(@Valid @ModelAttribute queryReq: QueryStudentReqDto): StudentListResDto
+```
+
+## DTO Variable Naming
+
+- **`@RequestBody`** (Create/Update): `reqDto` → `service.execute(reqDto)`
+- **`@ModelAttribute`** (Query): `queryReq` → `service.execute(queryReq)`
+- **`@ModelAttribute`** (Search): `searchReq` (when search intent is clear)
+
+## Controller → Service Passing
+
+Pass DTO objects as-is. `@PathVariable` values can be passed individually.
+
+```kotlin
+@PostMapping
+fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDto =
+    createStudentService.execute(reqDto)
+
+@PutMapping("/{id}")
+fun updateStudent(@PathVariable id: Long, @Valid @RequestBody reqDto: UpdateStudentReqDto): StudentResDto =
+    updateStudentService.execute(id, reqDto)
+```
+
+## Transaction Rules
+
+- `@Transactional` must be at **method level** — never class level
+- Read operations: `@Transactional(readOnly = true)`
+- Write operations: `@Transactional`
+
+```kotlin
+// CORRECT
+@Transactional(readOnly = true)
+override fun execute(queryReq: QueryStudentReqDto): StudentListResDto { ... }
+
+// WRONG
+@Service
+@Transactional  // class-level is forbidden
+class StudentServiceImpl { ... }
+```

--- a/.claude/rules/commit-conventions.md
+++ b/.claude/rules/commit-conventions.md
@@ -1,0 +1,30 @@
+# Commit & PR Conventions
+
+## Commit Message Format
+
+`type(scope): description`
+
+- **Types**: `add` / `update` / `fix` / `refactor` / `ci/cd` / `docs` / `test` / `merge`
+- **Scope**: domain name (not module name)
+- **Description**: Korean, no period
+
+## Scope Rules
+
+Use **domain names** as scope, not module names:
+
+```
+// CORRECT
+fix(auth): OAuth 토큰 발급 로직 수정
+update(student): 학생 조회 필터 추가
+
+// WRONG — module names as scope
+fix(web): 버그 수정
+update(common): 엔티티 수정
+```
+
+Use module-level scope **only** for cross-cutting concerns:
+
+```
+refactor(global): 공통 예외 처리 구조 개선
+update(ci/cd): GitHub Actions 워크플로우 수정
+```

--- a/.claude/rules/dto-annotations.md
+++ b/.claude/rules/dto-annotations.md
@@ -1,0 +1,42 @@
+# DTO Annotation Rules
+
+## Jackson Serialization
+
+Always use `@field:` target — never `@param:`:
+
+```kotlin
+// CORRECT
+@field:JsonProperty("user_name")
+@field:JsonAlias("userName")
+val userName: String
+
+// WRONG
+@param:JsonProperty("user_name")  // Jackson ignores this
+val userName: String
+```
+
+## Swagger / OpenAPI
+
+- **Request DTOs** (`*ReqDto`): use `@param:Schema`
+- **Response DTOs** (`*ResDto`): use `@field:Schema`
+
+```kotlin
+// Request DTO
+data class CreateStudentReqDto(
+    @param:Schema(description = "Student name")
+    @field:JsonProperty("student_name")
+    val studentName: String
+)
+
+// Response DTO
+data class StudentResDto(
+    @field:Schema(description = "Student ID")
+    @field:JsonProperty("student_id")
+    val studentId: Long
+)
+```
+
+## Common Mistakes
+
+- WRONG: `@param:JsonProperty` → CORRECT: `@field:JsonProperty`
+- WRONG: Response DTO with `@param:Schema` → CORRECT: `@field:Schema`

--- a/.claude/rules/exception.md
+++ b/.claude/rules/exception.md
@@ -1,0 +1,29 @@
+# Exception Handling Rules
+
+## ExpectedException Usage
+
+Use `ExpectedException` directly — do not subclass it:
+
+```kotlin
+// CORRECT
+val student = studentRepository.findById(id).orElseThrow {
+    ExpectedException("학생을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+}
+
+// WRONG — subclassing is forbidden
+class StudentNotFoundException : ExpectedException(...)
+```
+
+## Message Format
+
+- Korean (합쇼체) + period — displayed directly to end users as toast/alert
+- No dynamic data (IDs, names, variables) in the message string
+
+```kotlin
+// CORRECT
+ExpectedException("학생을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+ExpectedException("이미 존재하는 이메일입니다.", HttpStatus.CONFLICT)
+
+// WRONG — dynamic data in message
+ExpectedException("학생을 찾을 수 없습니다. ID: $id", HttpStatus.NOT_FOUND)
+```

--- a/.claude/rules/kotlin-style.md
+++ b/.claude/rules/kotlin-style.md
@@ -1,0 +1,49 @@
+# Kotlin Style Rules
+
+## Immutability
+
+Prefer `val` over `var`. Use `var` only when reassignment is strictly required (loop accumulators, Logback-injected properties).
+
+```kotlin
+// CORRECT
+val student = studentRepository.findById(id).orElseThrow()
+
+// WRONG
+var student = studentRepository.findById(id).orElseThrow()
+```
+
+## Dependency Injection
+
+Always use constructor injection — never field injection:
+
+```kotlin
+// CORRECT
+@Service
+class StudentService(
+    private val studentRepository: StudentJpaRepository,
+    private val clubRepository: ClubJpaRepository
+)
+
+// WRONG
+@Service
+class StudentService {
+    @Autowired
+    lateinit var studentRepository: StudentJpaRepository
+}
+```
+
+## Comments
+
+Do NOT add excessive comments. Only add comments where the logic is not self-evident.
+
+## Null Safety
+
+Use Kotlin null-safety features instead of unchecked access:
+
+```kotlin
+// CORRECT
+val name = student?.name ?: "Unknown"
+
+// WRONG
+val name = student!!.name
+```

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -1,0 +1,26 @@
+# Logging Rules
+
+## Style
+
+- **Language**: English only — verb-led sentences
+- **Format**: SLF4J `{}` placeholder only — no Kotlin string interpolation
+- **Pattern**: `"<Verb> <subject/context> {}"`, value — no colon separators
+
+```kotlin
+// CORRECT
+logger().info("Deleted {} expired API keys", deletedCount)
+logger().error("Failed to issue OAuth token for scopeStr {}", scopeStr)
+logger().warn("ExpectedException occurred with message {}", ex.message)
+
+// WRONG
+logger().error("에러 발생: $message")             // Korean + interpolation
+logger().error("Failed to process: {}", message)  // colon separator
+logger().error("Error occurred: ${ex.message}")   // string interpolation
+```
+
+## Common Mistakes
+
+- WRONG: `logger().error("에러 발생: $message")` → CORRECT: `logger().error("Failed to process {}", message)`
+- No colon separators between subject and `{}`
+- No Korean characters in log messages
+- Never use `println()` — use SLF4J Logger only

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,9 +43,11 @@
       }
     ]
   },
-  "language": "korean",
-  "effortLevel": "medium",
   "enabledPlugins": {
-    "claude-hud@claude-hud": true
-  }
+    "claude-hud@claude-hud": true,
+    "github@claude-plugins-official": true,
+    "context7@claude-plugins-official": true
+  },
+  "language": "korean",
+  "effortLevel": "medium"
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,16 @@
   "permissions": {
     "allow": [
       "WebSearch",
-      "WebFetch"
+      "WebFetch",
+      "Bash(./gradlew *)",
+      "Bash(git diff*)",
+      "Bash(git status)",
+      "Bash(git log*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(git branch*)",
+      "Bash(git checkout*)",
+      "Bash(git rev-parse*)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,24 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+  "includeGitInstructions": false,
+  "permissions": {
+    "allow": [
+      "WebSearch",
+      "WebFetch",
+      "Bash(./gradlew *)",
+      "Bash(git diff*)",
+      "Bash(git status)",
+      "Bash(git log*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(git branch*)",
+      "Bash(git checkout*)",
+      "Bash(git rev-parse*)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {
@@ -25,24 +45,7 @@
   },
   "language": "korean",
   "effortLevel": "medium",
-  "attribution": {
-    "commit": "",
-    "pr": ""
-  },
-  "includeGitInstructions": false,
-  "permissions": {
-    "allow": [
-      "WebSearch",
-      "WebFetch",
-      "Bash(./gradlew *)",
-      "Bash(git diff*)",
-      "Bash(git status)",
-      "Bash(git log*)",
-      "Bash(git add*)",
-      "Bash(git commit*)",
-      "Bash(git branch*)",
-      "Bash(git checkout*)",
-      "Bash(git rev-parse*)"
-    ]
+  "enabledPlugins": {
+    "claude-hud@claude-hud": true
   }
 }

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -5,14 +5,26 @@ description: Run a structured checklist over changed files — DTO annotations, 
 
 # Code Review Guide
 
-Analyze changed files and verify the following items.
+Analyze changed files and verify against project conventions.
 
-## Check Changes
+## Step 1 — Load Rules
+
+Discover all rule files dynamically:
+
+```bash
+find .claude/rules -name "*.md" 2>/dev/null
+```
+
+Read each returned file in full. These define the authoritative rules for this review.
+
+## Step 2 — Check Changes
 
 1. Run `git diff` or `git diff develop...HEAD` to see changed files
-2. Read each file with Read tool for detailed analysis
+2. Read each changed file with the Read tool for detailed analysis
 
-## Checklist
+## Step 3 — Review Checklist
+
+Use the rules loaded in Step 1 as the authoritative source. Common areas to verify:
 
 ### DTO
 - [ ] Using `@field:JsonProperty`? (not `@param:`)
@@ -26,12 +38,21 @@ Analyze changed files and verify the following items.
 
 ### JPA/Database
 - [ ] Applied `@Transactional(readOnly = true)` for read operations?
+- [ ] `@Transactional` at method level only (not class level)?
 - [ ] No N+1 problem? (Need Fetch Join?)
-- [ ] Using QueryDSL correctly?
+
+### Logging
+- [ ] English only, SLF4J `{}` placeholders?
+- [ ] No Korean characters or string interpolation in log messages?
+- [ ] No colon separators before `{}`?
+
+### Exception
+- [ ] Using `ExpectedException` directly (no subclassing)?
+- [ ] Message is Korean 합쇼체 + period, no dynamic data?
 
 ### Test
 - [ ] Test code written?
-- [ ] Following Given-When-Then pattern?
+- [ ] Following Given-When-Then pattern with `DescribeSpec`?
 - [ ] Using MockK verify appropriately?
 
 ### Commit

--- a/.claude/skills/kotest-guide/SKILL.md
+++ b/.claude/skills/kotest-guide/SKILL.md
@@ -19,8 +19,8 @@ class CreateApiKeyServiceTest : DescribeSpec({
         service = CreateApiKeyServiceImpl(repository)
     }
 
-    describe("CreateApiKeyService") {
-        describe("execute") {
+    describe("CreateApiKeyService 클래스의") {
+        describe("execute 메서드는") {
             context("유효한 요청인 경우") {
                 it("API 키를 생성하고 반환한다") {
                     // Given

--- a/.claude/skills/kotest-guide/SKILL.md
+++ b/.claude/skills/kotest-guide/SKILL.md
@@ -7,23 +7,39 @@ description: Kotest + MockK testing patterns for this project — Given/When/The
 
 ## Given-When-Then Pattern
 
+Use Kotest `DescribeSpec` with `describe` / `context` / `it` blocks.
+
 ```kotlin
-@Test
-fun `create API key successfully`() = runTest {
-    // Given
-    val reqDto = CreateApiKeyReqDto(clientId = "test-client")
-    val apiKey = ApiKey(id = 1L, key = "generated-key")
+class CreateApiKeyServiceTest : DescribeSpec({
+    lateinit var repository: ApiKeyRepository
+    lateinit var service: CreateApiKeyService
 
-    every { repository.save(any()) } returns apiKey
+    beforeEach {
+        repository = mockk()
+        service = CreateApiKeyServiceImpl(repository)
+    }
 
-    // When
-    val result = service.execute(reqDto)
+    describe("CreateApiKeyService") {
+        describe("execute") {
+            context("유효한 요청인 경우") {
+                it("API 키를 생성하고 반환한다") {
+                    // Given
+                    val reqDto = CreateApiKeyReqDto(clientId = "test-client")
+                    val apiKey = ApiKey(id = 1L, key = "generated-key")
+                    every { repository.save(any()) } returns apiKey
 
-    // Then
-    result shouldNotBe null
-    result.apiKey shouldBe "generated-key"
-    verify(exactly = 1) { repository.save(any()) }
-}
+                    // When
+                    val result = service.execute(reqDto)
+
+                    // Then
+                    result shouldNotBe null
+                    result.apiKey shouldBe "generated-key"
+                    verify(exactly = 1) { repository.save(any()) }
+                }
+            }
+        }
+    }
+})
 ```
 
 ## MockK Patterns
@@ -72,33 +88,35 @@ slot.captured.key shouldBe "expected-key"
 ## Coroutine Testing
 
 ```kotlin
-@Test
-fun `test async operation`() = runTest {
-    // Given
-    coEvery { repository.findById(1L) } coAnswers {
-        delay(100)
-        Optional.of(apiKey)
+context("비동기 처리가 필요한 경우") {
+    it("결과를 정상적으로 반환한다") {
+        // Given
+        coEvery { repository.findById(1L) } coAnswers {
+            delay(100)
+            Optional.of(apiKey)
+        }
+
+        // When
+        val result = service.execute(1L)
+
+        // Then
+        result shouldNotBe null
     }
-
-    // When
-    val result = service.execute(1L)
-
-    // Then
-    result shouldNotBe null
 }
 ```
 
 ## Exception Testing
 
 ```kotlin
-@Test
-fun `throw exception when API key not found`() = runTest {
-    // Given
-    every { repository.findById(1L) } returns Optional.empty()
+context("API 키가 존재하지 않는 경우") {
+    it("ExpectedException을 던진다") {
+        // Given
+        every { repository.findById(1L) } returns Optional.empty()
 
-    // When & Then
-    shouldThrow<ApiKeyNotFoundException> {
-        service.execute(1L)
+        // When & Then
+        shouldThrow<ExpectedException> {
+            service.execute(1L)
+        }
     }
 }
 ```

--- a/.claude/skills/kotlin-spring-arch/SKILL.md
+++ b/.claude/skills/kotlin-spring-arch/SKILL.md
@@ -51,13 +51,14 @@ fun findAllWithRelated(): List<Entity>
 
 ## Exception Handling
 
-### Custom Exception
+### Use ExpectedException Directly
 ```kotlin
-class ApiKeyNotFoundException : ExpectedException(
-    status = HttpStatus.NOT_FOUND,
-    message = "API key not found"
-)
+val apiKey = repository.findById(id).orElseThrow {
+    ExpectedException("API key를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+}
 ```
+
+Do not create custom exception subclasses extending `ExpectedException`.
 
 ### Global Handler
 See `datagsm-common/.../global/common/error/GlobalExceptionHandler.kt`

--- a/.claude/skills/pr-draft/SKILL.md
+++ b/.claude/skills/pr-draft/SKILL.md
@@ -28,22 +28,23 @@ Read `${CLAUDE_SKILL_DIR}/references/labels.md` and select 1–2 appropriate lab
 **Title** — Generate 3 options in the format `[scope] description`:
 - Scope: domain name (`[student]`, `[auth]`, `[application]`, `[club]`, etc.) or `[global]` / `[ci/cd]` for cross-cutting changes
 - Description: Korean, concise, no emojis, max 50 characters total
-- Mark the best option with `← 추천`
+- Wrap class names, method names, annotations, file names, and technical terms in backticks (e.g., `@Transactional`, `QueryProjectServiceImpl`, `SKILL.md`)
 
 **Body** — Follow the `.github/PULL_REQUEST_TEMPLATE.md` structure:
 - Korean 합쇼체: `~하였습니다`, `~되었습니다`, `~추가하였습니다`
 - No emojis
 - Max 2500 characters
+- Wrap all proper nouns and technical identifiers in backticks: class names, method names, annotations, file names, field names, config keys, module names, agent names, etc.
 
 ## Step 4 — Write Body & Show Preview
 
 Write the body to `PR_BODY.md`, then display:
 
 ```
-## 추천 PR 제목
+## PR 제목 후보
 1. [title1]
 2. [title2]
-3. [title3] ← 추천
+3. [title3]
 
 ## 선택된 라벨
 - label1, label2
@@ -52,7 +53,7 @@ Write the body to `PR_BODY.md`, then display:
 [body content]
 ```
 
-Ask the user to confirm which title to use. If no answer is given, proceed with the recommended (marked) title.
+Use AskUserQuestion to ask the user which title to use (present options 1/2/3). Wait for the answer before proceeding.
 
 ## Step 5 — Create PR
 

--- a/.claude/skills/pr-draft/SKILL.md
+++ b/.claude/skills/pr-draft/SKILL.md
@@ -26,7 +26,7 @@ Read `${CLAUDE_SKILL_DIR}/references/labels.md` and select 1–2 appropriate lab
 ## Step 3 — Generate PR Content
 
 **Title** — Generate 3 options in the format `[scope] description`:
-- Scope: domain name (`[student]`, `[auth]`, `[application]`, `[club]`, etc.) or `[global]` / `[ci/cd]` for cross-cutting changes
+- Scope: domain name (`[account]`, `[application]`, `[auth]`, `[client]`, `[club]`, `[neis]`, `[oauth]`, `[project]`, `[student]`, `[utility]`) or `[global]` / `[ci/cd]` for cross-cutting changes
 - Description: Korean, concise, no emojis, max 50 characters total
 - Wrap class names, method names, annotations, file names, and technical terms in backticks (e.g., `@Transactional`, `QueryProjectServiceImpl`, `SKILL.md`)
 
@@ -34,7 +34,7 @@ Read `${CLAUDE_SKILL_DIR}/references/labels.md` and select 1–2 appropriate lab
 - Korean 합쇼체: `~하였습니다`, `~되었습니다`, `~추가하였습니다`
 - No emojis
 - Max 2500 characters
-- Wrap all proper nouns and technical identifiers in backticks: class names, method names, annotations, file names, field names, config keys, module names, agent names, etc.
+- Wrap all proper nouns and technical identifiers in backticks: class names, method names, annotations, file names, field names, config keys, module names, and agent names.
 
 ## Step 4 — Write Body & Show Preview
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -24,13 +24,23 @@ gh repo view --json nameWithOwner -q .nameWithOwner
 gh pr view --json number,baseRefName -q '{number: .number, base: .baseRefName}'
 ```
 
-## Step 2 — Assess Each Comment
+## Step 2 — Load Rules and Assess Each Comment
+
+Before assessing any comment, discover and read all project convention files:
+
+```bash
+find .claude/rules -name "*.md" 2>/dev/null
+```
+
+Read each returned file in full. These are the authoritative rules for judging each review comment.
+
+**Rule priority**: `CLAUDE.md` > `.claude/rules/**` > `.gemini/styleguide.md` > `CONTRIBUTING.md`
 
 For each comment in `pr_comments.json`, apply the following **layered judgment criteria**:
 
 ### Judgment criteria (priority order)
 
-1. **Project conventions** (primary): cross-reference CLAUDE.md and CONTRIBUTING.md
+1. **Project conventions** (primary): apply rules discovered above
    - DTO annotation rules, commit scope, logging style, exception message format, etc.
 2. **Language/framework best practices** (secondary): Kotlin official guide, Spring Boot recommendations
    - Apply only when no matching project rule exists

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -400,7 +400,7 @@ fun execute(reqDto: CreateStudentReqDto) {
 
 - **Language**: English only — verb-led sentences
 - **Format**: SLF4J `{}` placeholder, not string interpolation
-- **Pattern**: `"<Verb> <subject/context>: {}"`, value
+- **Pattern**: `"<Verb> <subject/context> {}"`, value
 
 ```kotlin
 // CORRECT

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,13 +116,6 @@ fun updateStudent(@PathVariable id: Long, @Valid @RequestBody reqDto: UpdateStud
   - CORRECT: `ExpectedException("학생을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)`
   - WRONG: `ExpectedException("학생을 찾을 수 없습니다. ID: $id", HttpStatus.NOT_FOUND)`
 
-## Custom Commands
-
-Use the following slash commands for common tasks:
-- `/pr-draft` - Generate PR title suggestions and body
-- `/format` - Run KtLint formatting
-- `/commit` - Create Git commits by splitting changes into logical units
-- `/review-pr` - Assess PR review comments against conventions, auto-apply valid ones, refute invalid ones
 ## Notes
 
 - This project uses Java 25 for Gradle builds

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,67 +32,26 @@ Each module follows: `controller/`, `service/`, `repository/`, `entity/`, `dto/`
 - Build: `./gradlew build`
 - Test: `./gradlew test`
 - Format: `./gradlew ktlintFormat`
-- Run: `./gradlew :<module>:bootRun` (modules: `datagsm-oauth-authorization`, `datagsm-openapi`, `datagsm-oauth-userinfo`, `datagsm-web`)
+- Run: `./gradlew :<module>:bootRun`
 
 ## Coding Conventions
 
-### Kotlin Style
-- Use Kotlin idioms: `val` over `var`, null safety, extension functions
-- Naming: PascalCase (classes), camelCase (functions/variables)
-- DTO naming: Request/Response suffix (e.g., `UserReqDto`, `UserResDto`)
-- Follow KtLint rules
+@.claude/rules/kotlin-style.md
 
-### Architecture Pattern
-- **Layer Structure**: Controller → Service (interface + impl) → Repository
-- **Dependency Injection**: Always use constructor injection
-- **Entity vs DTO**: Separate Entity and DTO clearly
-- **Comments**: Do NOT add excessive comments - only where logic is not self-evident
+@.claude/rules/dto-annotations.md
 
-### DTO Annotations
-- **Jackson**: Always use `@field:JsonProperty`, `@field:JsonAlias` (not `@param:`)
-- **Swagger**: Request DTO uses `@param:Schema`, Response DTO uses `@field:Schema`
-- See CONTRIBUTING.md for detailed examples
+@.claude/rules/api-conventions.md
 
-### Query Parameter Binding (@RequestParam vs @ModelAttribute)
+@.claude/rules/logging.md
 
-- **1-2 simple parameters**: Use `@RequestParam`
-- **3+ parameters or validation required**: Use `@ModelAttribute` + DTO
+@.claude/rules/exception.md
 
-```kotlin
-// 1-2 parameters → @RequestParam
-@GetMapping("/scopes")
-fun getScopes(@RequestParam role: AccountRole): ApiScopeListResDto
-
-// 3+ parameters → @ModelAttribute + DTO
-@GetMapping("/students")
-fun getStudents(@Valid @ModelAttribute queryReq: QueryStudentReqDto): StudentListResDto
-```
-
-### DTO Variable Naming
-
-- **@RequestBody (Create/Update)**: Use `reqDto` → `service.execute(reqDto)`
-- **@ModelAttribute (Query)**: Use `queryReq` → `service.execute(queryReq)`
-- **@ModelAttribute (Search)**: Use `searchReq` (검색 의미가 명확한 경우)
-
-### Controller-Service Value Passing
-
-Pass DTO objects to service layer as-is. PathVariable can be passed individually.
-
-```kotlin
-@PostMapping
-fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDto =
-    createStudentService.execute(reqDto)
-
-@PutMapping("/{id}")
-fun updateStudent(@PathVariable id: Long, @Valid @RequestBody reqDto: UpdateStudentReqDto): StudentResDto =
-    updateStudentService.execute(id, reqDto)
-```
+@.claude/rules/commit-conventions.md
 
 ## Key Practices
 
 ### Security
 - No hardcoded secrets
-- Use SLF4J Logger with Logback (not println())
 - Validate JWT/API keys properly
 
 ### JPA
@@ -105,16 +64,9 @@ fun updateStudent(@PathVariable id: Long, @Valid @RequestBody reqDto: UpdateStud
 
 ### Testing
 - Write Kotest tests for business logic
-- Use Given-When-Then pattern
+- Use Given-When-Then pattern with `DescribeSpec`
 - Use MockK for mocking
-
-### Exception Handling
-- Use `ExpectedException` for custom exceptions
-- Map to appropriate HTTP status codes
-- Exception Handler: `datagsm-common/.../global/common/error/`
-- **Message format**: Korean (합쇼체) + period, no dynamic data — messages are displayed directly to end users
-  - CORRECT: `ExpectedException("학생을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)`
-  - WRONG: `ExpectedException("학생을 찾을 수 없습니다. ID: $id", HttpStatus.NOT_FOUND)`
+- Test names in Korean: `describe("클래스명 클래스의")`, `describe("메서드명 메서드는")`
 
 ## Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,72 +25,18 @@ Kotlin, Spring Boot 4.0, Spring Data JPA, QueryDSL, Redis, MySQL
 
 ## Coding Rules
 
-- Prefer `val` over `var`, use null safety
 - Controller → Service → Repository pattern
-- DTO suffix: ReqDto, ResDto
 - Use constructor injection
 - Test: Kotest + MockK (Given-When-Then)
 - Do NOT add excessive comments - only add comments where logic is not self-evident
 
-### DTO Annotations
-
-- **Jackson**: Always `@field:JsonProperty`, `@field:JsonAlias` (not `@param:`)
-- **Swagger**: Request DTO → `@param:Schema`, Response DTO → `@field:Schema`
-- See CONTRIBUTING.md for examples
-
-### Query Parameter Binding (@RequestParam vs @ModelAttribute)
-
-- **1-2 simple parameters**: Use `@RequestParam`
-- **3+ parameters or validation required**: Use `@ModelAttribute` + DTO
-
-```kotlin
-// 1-2 parameters → @RequestParam
-@GetMapping("/scopes")
-fun getScopes(@RequestParam role: AccountRole): ApiScopeListResDto
-
-// 3+ parameters → @ModelAttribute + DTO
-@GetMapping("/students")
-fun getStudents(@Valid @ModelAttribute queryReq: QueryStudentReqDto): StudentListResDto
-```
-
-### DTO Variable Naming
-
-- **@RequestBody (Create/Update)**: Use `reqDto` → `service.execute(reqDto)`
-- **@ModelAttribute (Query)**: Use `queryReq` → `service.execute(queryReq)`
-- **@ModelAttribute (Search)**: Use `searchReq` (If search meaning is clear)
-
-### Controller-Service Value Passing
-
-Pass DTO objects to service layer as-is. PathVariable can be passed individually.
-
-```kotlin
-@PostMapping
-fun createStudent(@Valid @RequestBody reqDto: CreateStudentReqDto): StudentResDto =
-    createStudentService.execute(reqDto)
-
-@PutMapping("/{id}")
-fun updateStudent(@PathVariable id: Long, @Valid @RequestBody reqDto: UpdateStudentReqDto): StudentResDto =
-    updateStudentService.execute(id, reqDto)
-```
-
-## Common Mistakes
-
-### DTO Annotations
-- WRONG: `@param:JsonProperty` → CORRECT: `@field:JsonProperty`
-- WRONG: Response DTO with `@param:Schema` → CORRECT: `@field:Schema`
-
-### Commit Scope
-- WRONG: `fix(web):` (module name) → CORRECT: `fix(auth):` (domain name)
-- WRONG: `update(common):` → CORRECT: `update(student):`
-- Only use module names for cross-cutting concerns: `refactor(global):`, `update(ci/cd):`
-
-### Logging Style
-- WRONG: `logger().error("에러 발생: $message")` → CORRECT: `logger().error("Failed to process {}", message)`
-- English verb-led sentences, SLF4J `{}` placeholders only (no string interpolation, no colon separators)
-
-### Exception Messages (ExpectedException)
-- WRONG: `ExpectedException("학생을 찾을 수 없습니다. ID: $id", ...)` → CORRECT: `ExpectedException("학생을 찾을 수 없습니다.", ...)`
-- Korean 합쇼체 + period, no dynamic data — message is shown directly to users as toast/alert
+Detailed rules are split into `.claude/rules/`:
+- `dto-annotations.md` — `@field:` vs `@param:` rules for Jackson and Swagger
+- `logging.md` — English-only, SLF4J `{}` placeholders, no colon separators
+- `exception.md` — `ExpectedException` usage and message format
+- `kotlin-style.md` — `val/var`, constructor injection, null safety
+- `api-conventions.md` — `@RequestParam` vs `@ModelAttribute`, DTO naming, `@Transactional` placement
+- `commit-conventions.md` — commit type/scope rules
 
 ## Context Compaction Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,14 +102,6 @@ Priority order when compressing conversation history:
 5. Tech Stack
 6. Reduce: Commands, Key Paths
 
-## Detailed Guides (Skills)
-
-For more details, execute the corresponding skill:
-- **kotlin-spring-arch**: Detailed layer structure, transaction strategy, exception handling patterns
-- **kotest-guide**: Kotest + MockK Given-When-Then pattern, coroutine testing
-- **code-review**: Checklist-based automatic validation
-- **security-checklist**: Hardcoded secrets, SQL Injection, JWT validation checks
-
 ## Key Paths
 
 - Common Entity: `datagsm-common/src/main/kotlin/.../domain/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -747,7 +747,7 @@ throw ExpectedException("이미 존재하는 이메일입니다", HttpStatus.CON
 ```kotlin
 // Good
 logger().info("Deleted {} expired API keys", deletedCount)
-logger().error("Failed to issue OAuth token: scopeStr={}", scopeStr)
+logger().error("Failed to issue OAuth token for scopeStr {}", scopeStr)
 logger().warn("ExpectedException occurred with message {}", ex.message)
 
 // Bad

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/QueryProjectServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/QueryProjectServiceImpl.kt
@@ -12,10 +12,10 @@ import team.themoment.datagsm.common.domain.student.dto.internal.ParticipantInfo
 import team.themoment.datagsm.openapi.domain.project.service.QueryProjectService
 
 @Service
-@Transactional(readOnly = true)
 class QueryProjectServiceImpl(
     private val projectJpaRepository: ProjectJpaRepository,
 ) : QueryProjectService {
+    @Transactional(readOnly = true)
     override fun execute(queryReq: QueryProjectReqDto): ProjectListResDto {
         val projectPage =
             projectJpaRepository.searchProjectWithPaging(


### PR DESCRIPTION
## 개요

문서-코드 불일치 사항을 수정하는 데서 출발하여, Claude 프롬프트/스킬 시스템 전반의 규칙 관리 방식을 정리하였습니다. `@Transactional` 위치 위반을 수정하고, 프로젝트 컨벤션을 `.claude/rules/` 하위 문서로 분리한 뒤 에이전트·스킬·상위 문서가 해당 규칙을 동적으로 참조하도록 일관성을 확보하였습니다.

## 본문

### 코드 및 문서 불일치 수정

- `QueryProjectServiceImpl`의 `@Transactional(readOnly = true)`를 클래스 레벨에서 `execute()` 메서드 레벨로 이동하였습니다.
- `CONTRIBUTING.md`, `.gemini/styleguide.md`의 로그 예시를 현재 규칙에 맞게 정리하였습니다.
- `kotlin-spring-arch/SKILL.md`의 `ExpectedException` 예시를 직접 `throw ExpectedException(...)` 패턴으로 교체하였습니다.
- `kotest-guide/SKILL.md`의 테스트 예시를 Kotest `DescribeSpec`과 한국어 테스트명 규칙에 맞게 보완하였습니다.

### 규칙 문서 분리 및 참조 구조 정리

- DTO 어노테이션, API 설계, 로깅, 예외, Kotlin 스타일, 커밋 규칙을 `.claude/rules/` 하위 문서로 분리하였습니다.
- `AGENTS.md`, `CLAUDE.md`에서 중복 규칙 서술을 줄이고, 세부 규칙을 `.claude/rules/` 문서로 위임하도록 재구성하였습니다.
- 중복된 커스텀 명령어/스킬 안내를 제거하여 최상위 문서의 역할을 간결하게 정리하였습니다.

### 에이전트 및 스킬 품질 개선

- 6개 에이전트 파일의 `name`을 kebab-case로 통일하고, `maxTurns`, `permissionMode`, `DO NOT trigger` 경계 조건을 추가하였습니다.
- `contradiction-finder`, `convention-validator`, `doc-polisher`, `prompt-polisher`, `test-fixer`, `code-review`, `review-pr`가 규칙 파일을 하드코딩하지 않고 동적으로 탐색하도록 변경하였습니다.
- `pr-draft` 스킬에 제목 scope 목록 명시, `etc.` 제거, 기술 식별자 백틱 사용 규칙을 반영하였습니다.

### Claude 설정 정비

- `.claude/settings.json`에 Git/Bash 허용 범위를 보강하였습니다.
- `claude-hud`, `github`, `context7` 플러그인을 활성화하였습니다.
