### PR TITLE
[global] Claude 훅 구조 개선 및 에이전트 설정 업데이트

### DIFF
--- a/.claude/agents/test-fixer.md
+++ b/.claude/agents/test-fixer.md
@@ -1,6 +1,6 @@
 ---
 name: test-fixer
-description: "Runs Kotlin/Kotest tests at module level, diagnoses failures, and fixes mismatches between service and test code. Service code is the source of truth — tests are updated when service behavior changes, and service bugs (NPE, wrong logic) are fixed at the source. After any service fix, the corresponding test is always updated too. Retries up to 3 times, re-runs tests after each fix to confirm pass. Does NOT auto-commit. Trigger when the user says things like '테스트 고쳐줘', 'test-fixer 실행해줘', or specifies a module like 'datagsm-web 테스트 고쳐줘'. DO NOT trigger for convention style fixes or documentation updates — use Convention-Validator or Doc-Polisher instead."
+description: "Runs Kotlin/Kotest tests at module level, diagnoses failures, and fixes mismatches between service and test code. Service code is the source of truth — tests are updated when service behavior changes, and service bugs (NPE, wrong logic) are fixed at the source. After any service fix, the corresponding test is always updated too. Retries up to 3 times, re-runs tests after each fix to confirm pass. Does NOT auto-commit. Trigger when the user says things like '테스트 고쳐줘', 'test-fixer 실행해줘', or specifies a module like 'datagsm-web 테스트 고쳐줘'. Also trigger when the user modifies service code (files matching *ServiceImpl.kt or *Service.kt) and asks to verify or run tests, or after completing a service-level feature/fix and the user asks to check if tests still pass. DO NOT trigger for convention style fixes or documentation updates — use Convention-Validator or Doc-Polisher instead."
 tools: Bash, Glob, Grep, Read, Edit
 model: sonnet
 color: green
@@ -55,14 +55,14 @@ For each failing test class `FooServiceTest`:
 
 Use the following decision table:
 
-| Failure Pattern | Root Cause | Fix Target |
-|----------------|-----------|-----------|
-| `UnsatisfiedMockKStubbing` / `no answer for` | Service method signature changed | Update test mock setup |
-| `shouldBe` / `shouldNotBe` assertion mismatch (value differs) | Service logic changed or has a bug | Inspect service first, then decide |
-| `NullPointerException` inside service implementation | Service null-safety issue | Fix service |
-| `shouldThrow<ExpectedException>` but no exception thrown | Service missing throw, or test scenario is wrong | Inspect service logic to decide |
-| Compilation error in test (unresolved reference, type mismatch) | Service API changed (method renamed/removed/signature changed) | Update test to match new API |
-| `ClassCastException` or wrong type returned | Service return type or DTO mapping changed | Inspect service, fix accordingly |
+| Failure Pattern                                                 | Root Cause                                                     | Fix Target                         |
+|-----------------------------------------------------------------|----------------------------------------------------------------|------------------------------------|
+| `UnsatisfiedMockKStubbing` / `no answer for`                    | Service method signature changed                               | Update test mock setup             |
+| `shouldBe` / `shouldNotBe` assertion mismatch (value differs)   | Service logic changed or has a bug                             | Inspect service first, then decide |
+| `NullPointerException` inside service implementation            | Service null-safety issue                                      | Fix service                        |
+| `shouldThrow<ExpectedException>` but no exception thrown        | Service missing throw, or test scenario is wrong               | Inspect service logic to decide    |
+| Compilation error in test (unresolved reference, type mismatch) | Service API changed (method renamed/removed/signature changed) | Update test to match new API       |
+| `ClassCastException` or wrong type returned                     | Service return type or DTO mapping changed                     | Inspect service, fix accordingly   |
 
 **Default bias**: Service code is correct. Only fix service code when there is clear evidence of a bug (NPE, wrong condition, missing null check, logic error).
 

--- a/.claude/hooks/postToolUse.sh
+++ b/.claude/hooks/postToolUse.sh
@@ -20,8 +20,9 @@ if [[ "$TOOL_NAME" == "Edit" ]] || [[ "$TOOL_NAME" == "Write" ]]; then
             RELATIVE="${FILE_PATH#$CWD/}"
             MODULE=$(echo "$RELATIVE" | cut -d'/' -f1)
             if [[ -n "$MODULE" ]] && [[ -d "$CWD/$MODULE/src/test" ]]; then
-                echo "[Hook] Running tests for $MODULE after $FILE_NAME edit..." >&2
-                TEST_OUTPUT=$(./gradlew ":${MODULE}:test" 2>&1)
+                TEST_CLASS="${FILE_NAME%Impl.kt}Test"
+                echo "[Hook] Running test $TEST_CLASS in $MODULE..." >&2
+                TEST_OUTPUT=$(./gradlew ":${MODULE}:test" --tests "$TEST_CLASS" 2>&1)
                 TEST_EXIT=$?
                 TAIL=$(echo "$TEST_OUTPUT" | tail -5)
                 if [[ $TEST_EXIT -ne 0 ]]; then

--- a/.claude/hooks/postToolUse.sh
+++ b/.claude/hooks/postToolUse.sh
@@ -1,20 +1,40 @@
 #!/bin/bash
-# .claude/hooks/postToolUse.sh
-# Run ktlintFormat after Edit or Write tool if the file is a Kotlin file
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name')
 
 if [[ "$TOOL_NAME" == "Edit" ]] || [[ "$TOOL_NAME" == "Write" ]]; then
-    FILE_PATH="${TOOL_PARAMS_FILE_PATH:-$TOOL_RESULT_FILE_PATH}"
+    FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+    CWD=$(echo "$INPUT" | jq -r '.cwd')
+
     if [[ "$FILE_PATH" == *.kt ]]; then
-        echo "[Hook] Running ktlintFormat for $FILE_PATH"
-        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-        PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-        cd "$PROJECT_ROOT"
-        ./gradlew ktlintFormat -q
-        if [ $? -eq 0 ]; then
-            echo "[Hook] ✓ Format successful"
+        echo "[Hook] Running ktlintFormat for $(basename "$FILE_PATH")" >&2
+        cd "$CWD"
+        if ./gradlew ktlintFormat -q 2>&1; then
+            echo "[Hook] Format OK" >&2
         else
-            echo "[Hook] ✗ Format failed"
-            exit 1
+            echo "[Hook] Format failed" >&2
+        fi
+        FILE_NAME=$(basename "$FILE_PATH")
+        if [[ "$FILE_NAME" == *ServiceImpl.kt ]] && [[ "$FILE_PATH" != */test/* ]]; then
+            RELATIVE="${FILE_PATH#$CWD/}"
+            MODULE=$(echo "$RELATIVE" | cut -d'/' -f1)
+            if [[ -n "$MODULE" ]] && [[ -d "$CWD/$MODULE/src/test" ]]; then
+                echo "[Hook] Running tests for $MODULE after $FILE_NAME edit..." >&2
+                TEST_OUTPUT=$(./gradlew ":${MODULE}:test" 2>&1)
+                TEST_EXIT=$?
+                TAIL=$(echo "$TEST_OUTPUT" | tail -5)
+                if [[ $TEST_EXIT -ne 0 ]]; then
+                    echo "[Hook] Test FAILED in $MODULE. Last 5 lines:"
+                    echo "$TAIL"
+                    echo "Tests failed after editing $FILE_NAME. Consider running test-fixer agent."
+                else
+                    echo "[Hook] Tests passed in $MODULE. Last 5 lines:"
+                    echo "$TAIL"
+                fi
+            fi
         fi
     fi
 fi
+
+exit 0

--- a/.claude/hooks/preToolUse.sh
+++ b/.claude/hooks/preToolUse.sh
@@ -11,7 +11,7 @@ if [[ "$TOOL_NAME" == "Bash" ]]; then
     mkdir -p "$(dirname "$LOG_FILE")"
     echo "[$TIMESTAMP] $COMMAND" >> "$LOG_FILE"
     BLOCKED_PATTERNS=(
-        "rm -rf /"
+        "rm -rf[[:space:]]*/[[:space:]]*$"
         "sudo rm"
         "> /dev/"
         "dd if="

--- a/.claude/hooks/preToolUse.sh
+++ b/.claude/hooks/preToolUse.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
-# .claude/hooks/preToolUse.sh
-# Block dangerous commands before execution
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name')
 
 if [[ "$TOOL_NAME" == "Bash" ]]; then
-    COMMAND="$TOOL_PARAMS_COMMAND"
+    COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+    CWD=$(echo "$INPUT" | jq -r '.cwd')
+    TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+    LOG_FILE="$HOME/.claude/command.log"
+    mkdir -p "$(dirname "$LOG_FILE")"
+    echo "[$TIMESTAMP] $COMMAND" >> "$LOG_FILE"
     BLOCKED_PATTERNS=(
         "rm -rf /"
         "sudo rm"
@@ -15,9 +21,10 @@ if [[ "$TOOL_NAME" == "Bash" ]]; then
     )
     for pattern in "${BLOCKED_PATTERNS[@]}"; do
         if [[ "$COMMAND" =~ $pattern ]]; then
-            echo "[Hook] ✗ Blocked dangerous command: $COMMAND"
-            echo "This command is not allowed for safety reasons."
+            echo "[Hook] Blocked dangerous command: $COMMAND" >&2
             exit 2
         fi
     done
 fi
+
+exit 0

--- a/.claude/hooks/preToolUse.sh
+++ b/.claude/hooks/preToolUse.sh
@@ -7,7 +7,7 @@ if [[ "$TOOL_NAME" == "Bash" ]]; then
     COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
     CWD=$(echo "$INPUT" | jq -r '.cwd')
     TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
-    LOG_FILE="$HOME/.claude/command.log"
+    LOG_FILE="$CWD/.claude/command.log"
     mkdir -p "$(dirname "$LOG_FILE")"
     echo "[$TIMESTAMP] $COMMAND" >> "$LOG_FILE"
     BLOCKED_PATTERNS=(

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ out/
 ### LLM Outputs ###
 PR_BODY.md
 .pr-tmp/
+/.claude/command.log

--- a/.idea/icon.svg
+++ b/.idea/icon.svg
@@ -1,6 +1,14 @@
-<svg width="38" height="14" viewBox="0 0 38 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M11.0137 0.00292969C14.8268 0.0772199 17.8954 3.18059 17.8955 7C17.8955 10.8195 14.8269 13.9218 11.0137 13.9961V14H0V10.1572H11.0127V10.1533C12.6967 10.0805 14.0399 8.69776 14.04 7.00098C14.04 5.30405 12.6968 3.91948 11.0127 3.84668V3.84375H4.60742L4.6084 3.84277H0V0H11.0137V0.00292969Z" fill="black" style="fill:black;fill-opacity:1;"/>
-    <path d="M26.9863 0.00292969C23.1723 0.0761944 20.1026 3.17993 20.1025 7C20.1025 10.8201 23.1722 13.9228 26.9863 13.9961V14H38V10.1572H26.9854V10.1533C25.3004 10.0815 23.9562 8.69842 23.9561 7.00098C23.9561 5.30339 25.3003 3.91848 26.9854 3.84668V3.84375H33.3906L33.3896 3.84277H38V0H26.9863V0.00292969Z" fill="black" style="fill:black;fill-opacity:1;"/>
-    <path d="M33.5931 5.07861H37.9987V8.92185H29.7383L31.6657 7.00023L33.5931 5.07861Z" fill="black" style="fill:black;fill-opacity:1;"/>
-    <path d="M0 5.07861H4.40554V8.92185H0V5.07861Z" fill="black" style="fill:black;fill-opacity:1;"/>
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="10" height="2" fill="black"/>
+  <rect x="0" y="2" width="4" height="2" fill="black"/>
+  <rect x="8" y="2" width="4" height="2" fill="black"/>
+  <rect x="0" y="4" width="4" height="2" fill="black"/>
+  <rect x="10" y="4" width="4" height="2" fill="black"/>
+  <rect x="0" y="6" width="4" height="2" fill="black"/>
+  <rect x="10" y="6" width="4" height="2" fill="black"/>
+  <rect x="0" y="8" width="4" height="2" fill="black"/>
+  <rect x="10" y="8" width="4" height="2" fill="black"/>
+  <rect x="0" y="10" width="4" height="2" fill="black"/>
+  <rect x="8" y="10" width="4" height="2" fill="black"/>
+  <rect x="0" y="12" width="10" height="2" fill="black"/>
 </svg>


### PR DESCRIPTION
## 개요
Claude Desktop 사용 환경에서의 훅(Hooks) 구조를 개선하고 에이전트 설정을 업데이트하였습니다.

## 본문
- `preToolUse.sh`, `postToolUse.sh`를 `jq` 기반으로 재작성하여 도구 실행 전후 처리를 더 안정적으로 개선하였습니다.
- 서비스 코드(`*ServiceImpl.kt`) 수정 시 자동으로 관련 모듈의 테스트를 실행하고 결과를 요약하여 출력하는 기능을 추가하였습니다.
- `test-fixer` 에이전트의 트리거 조건과 오류 패턴 분석 테이블을 개선하여 문제 해결 성능을 높였습니다.
- `.claude/command.log`를 생성하여 실행된 명령어 이력을 관리하며, 이를 `.gitignore`에 추가하였습니다.