### PR TITLE
[global] 사용자 노출 예외 메시지에서 동적 데이터 제거

### DIFF
--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/CreateClubServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/CreateClubServiceImpl.kt
@@ -55,7 +55,7 @@ class CreateClubServiceImpl(
                 studentJpaRepository
                     .findByIdOrNull(leaderId)
                     ?: throw ExpectedException(
-                        "부장으로 지정한 학생을 찾을 수 없습니다. studentId: $leaderId",
+                        "부장으로 지정한 학생을 찾을 수 없습니다.",
                         HttpStatus.NOT_FOUND,
                     )
             clubEntity.leader = leader

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/ModifyClubServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/ModifyClubServiceImpl.kt
@@ -60,7 +60,7 @@ class ModifyClubServiceImpl(
                 studentJpaRepository
                     .findByIdOrNull(leaderId)
                     ?: throw ExpectedException(
-                        "부장으로 지정한 학생을 찾을 수 없습니다. studentId: $leaderId",
+                        "부장으로 지정한 학생을 찾을 수 없습니다.",
                         HttpStatus.NOT_FOUND,
                     )
             club.leader = newLeader

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentExcelServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentExcelServiceImpl.kt
@@ -54,7 +54,7 @@ class ModifyStudentExcelServiceImpl(
                 .keys
         if (duplicatesStudentNumber.isNotEmpty()) {
             throw ExpectedException(
-                "엑셀 파일에 다음 학번이 중복으로 존재합니다: $duplicatesStudentNumber",
+                "엑셀 파일에 중복된 학번이 존재합니다.",
                 HttpStatus.BAD_REQUEST,
             )
         }
@@ -67,7 +67,7 @@ class ModifyStudentExcelServiceImpl(
                 .keys
         if (duplicatesEmail.isNotEmpty()) {
             throw ExpectedException(
-                "엑셀 파일에 다음 이메일이 중복으로 존재합니다: $duplicatesEmail",
+                "엑셀 파일에 중복된 이메일이 존재합니다.",
                 HttpStatus.BAD_REQUEST,
             )
         }
@@ -84,14 +84,14 @@ class ModifyStudentExcelServiceImpl(
         val missingInDb = excelStudentNumbers - dbStudentNumbers
         if (missingInDb.isNotEmpty()) {
             throw ExpectedException(
-                "DB에 존재하지 않는 학번이 엑셀 파일에 존재합니다: $missingInDb",
+                "데이터베이스에 존재하지 않는 학번이 포함되어 있습니다.",
                 HttpStatus.BAD_REQUEST,
             )
         }
         val extraInDb = dbStudentNumbers - excelStudentNumbers
         if (extraInDb.isNotEmpty()) {
             throw ExpectedException(
-                "엑셀에 존재하지 않는 학번이 데이터베이스에 존재합니다: $extraInDb",
+                "엑셀 파일에 존재하지 않는 학번이 있습니다.",
                 HttpStatus.BAD_REQUEST,
             )
         }
@@ -192,7 +192,7 @@ class ModifyStudentExcelServiceImpl(
                                 major =
                                     Major.fromMajor(getRequiredString(row, 3, "학과"))
                                         ?: throw ExpectedException(
-                                            "${row.rowNum + 1}행: 학과는 'SW개발과', '스마트IoT과', '인공지능과'여야 합니다.",
+                                            "올바르지 않은 학과 값이 존재합니다.",
                                             HttpStatus.BAD_REQUEST,
                                         ),
                                 majorClub = getOptionalString(row, 4),
@@ -201,13 +201,13 @@ class ModifyStudentExcelServiceImpl(
                                 role =
                                     StudentRole.fromRole(getRequiredString(row, 7, "소속"))
                                         ?: throw ExpectedException(
-                                            "${row.rowNum + 1}행: 소속은 '일반학생', '기숙사자치위원회', '학생회'여야 합니다.",
+                                            "올바르지 않은 소속 값이 존재합니다.",
                                             HttpStatus.BAD_REQUEST,
                                         ),
                                 sex =
                                     Sex.fromSex(getRequiredString(row, 8, "성별"))
                                         ?: throw ExpectedException(
-                                            "${row.rowNum + 1}행: 성별은 '남자' 또는 '여자'여야 합니다.",
+                                            "올바르지 않은 성별 값이 존재합니다.",
                                             HttpStatus.BAD_REQUEST,
                                         ),
                             )
@@ -235,7 +235,7 @@ class ModifyStudentExcelServiceImpl(
         getCellValue(row, columnIndex)
             .takeIf { it.isNotBlank() }
             ?: throw ExpectedException(
-                "${row.rowNum + 1}행 ${fieldName}이(가) 비어있습니다.",
+                "필수 항목이 비어있습니다.",
                 HttpStatus.BAD_REQUEST,
             )
 
@@ -253,7 +253,7 @@ class ModifyStudentExcelServiceImpl(
     ): Int =
         getCellValue(row, columnIndex).toIntOrNull()
             ?: throw ExpectedException(
-                "${row.rowNum + 1}행 ${fieldName}이(가) 비어있습니다.",
+                "필수 항목이 비어있습니다.",
                 HttpStatus.BAD_REQUEST,
             )
 

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentExcelServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentExcelServiceTest.kt
@@ -3,7 +3,6 @@ package team.themoment.datagsm.web.domain.student.service
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -219,7 +218,7 @@ class ModifyStudentExcelServiceTest :
                                 modifyStudentExcelService.execute(file)
                             }
 
-                        exception.message shouldContain "엑셀 파일에 다음 학번이 중복으로 존재합니다"
+                        exception.message shouldBe "엑셀 파일에 중복된 학번이 존재합니다."
                         exception.statusCode shouldBe HttpStatus.BAD_REQUEST
                     }
                 }
@@ -280,7 +279,7 @@ class ModifyStudentExcelServiceTest :
                                 modifyStudentExcelService.execute(file)
                             }
 
-                        exception.message shouldContain "엑셀 파일에 다음 이메일이 중복으로 존재합니다"
+                        exception.message shouldBe "엑셀 파일에 중복된 이메일이 존재합니다."
                         exception.statusCode shouldBe HttpStatus.BAD_REQUEST
                     }
                 }
@@ -411,7 +410,7 @@ class ModifyStudentExcelServiceTest :
                                 modifyStudentExcelService.execute(file)
                             }
 
-                        exception.message shouldContain "DB에 존재하지 않는 학번이 엑셀 파일에 존재합니다"
+                        exception.message shouldBe "데이터베이스에 존재하지 않는 학번이 포함되어 있습니다."
                         exception.statusCode shouldBe HttpStatus.BAD_REQUEST
                     }
                 }
@@ -446,7 +445,7 @@ class ModifyStudentExcelServiceTest :
                                 modifyStudentExcelService.execute(file)
                             }
 
-                        exception.message shouldContain "엑셀에 존재하지 않는 학번이 데이터베이스에 존재합니다"
+                        exception.message shouldBe "엑셀 파일에 존재하지 않는 학번이 있습니다."
                         exception.statusCode shouldBe HttpStatus.BAD_REQUEST
                     }
                 }
@@ -532,7 +531,7 @@ class ModifyStudentExcelServiceTest :
                                 modifyStudentExcelService.execute(file)
                             }
 
-                        exception.message shouldContain "학과는 'SW개발과', '스마트IoT과', '인공지능과'여야 합니다"
+                        exception.message shouldBe "올바르지 않은 학과 값이 존재합니다."
                         exception.statusCode shouldBe HttpStatus.BAD_REQUEST
                     }
                 }
@@ -585,7 +584,7 @@ class ModifyStudentExcelServiceTest :
                                 modifyStudentExcelService.execute(file)
                             }
 
-                        exception.message shouldContain "소속은 '일반학생', '기숙사자치위원회', '학생회'여야 합니다"
+                        exception.message shouldBe "올바르지 않은 소속 값이 존재합니다."
                         exception.statusCode shouldBe HttpStatus.BAD_REQUEST
                     }
                 }
@@ -637,7 +636,7 @@ class ModifyStudentExcelServiceTest :
                                 modifyStudentExcelService.execute(file)
                             }
 
-                        exception.message shouldContain "성별은 '남자' 또는 '여자'여야 합니다"
+                        exception.message shouldBe "올바르지 않은 성별 값이 존재합니다."
                         exception.statusCode shouldBe HttpStatus.BAD_REQUEST
                     }
                 }


### PR DESCRIPTION
## 개요

`ExpectedException` 메시지에 포함된 동적 데이터(변수 보간)를 제거하고 정적 한국어 합쇼체 문장으로 교체하였습니다.
해당 메시지는 사용자에게 toast/alert로 직접 노출되므로, 정적 문장이어야 한다는 규칙을 적용하였습니다.

## 본문

### 수정 파일

**`CreateClubServiceImpl`, `ModifyClubServiceImpl`**
- `"부장으로 지정한 학생을 찾을 수 없습니다. studentId: $leaderId"` → `"부장으로 지정한 학생을 찾을 수 없습니다."`

**`ModifyStudentExcelServiceImpl`** (9곳)
- `$duplicatesStudentNumber`, `$duplicatesEmail` 중복 목록 제거 → `"엑셀 파일에 중복된 학번이 존재합니다."`, `"엑셀 파일에 중복된 이메일이 존재합니다."`
- `$missingInDb`, `$extraInDb` 누락 목록 제거 → `"데이터베이스에 존재하지 않는 학번이 포함되어 있습니다."`, `"엑셀 파일에 존재하지 않는 학번이 있습니다."`
- `${row.rowNum + 1}행` 행 번호 접두어 제거 → `"올바르지 않은 학과/소속/성별 값이 존재합니다."`
- `${fieldName}이(가) 비어있습니다.` → `"필수 항목이 비어있습니다."`

**`ModifyStudentExcelServiceTest`** (7곳)
- 동적 메시지 일부를 `shouldContain`으로 검증하던 코드를 `shouldBe`로 변경하고 새 정적 메시지에 맞게 수정하였습니다.

Closes #291
