### PR TITLE
[client] tb_client.scopes 정규화 및 삭제 정합성 보장

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/ClientJpaEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/ClientJpaEntity.kt
@@ -45,7 +45,7 @@ class ClientJpaEntity {
     )
     @OnDelete(action = OnDeleteAction.CASCADE)
     @Column(name = "scope")
-    var scopes: MutableSet<String> = mutableSetOf()
+    val scopes: MutableSet<String> = mutableSetOf()
 
     @Column(name = "client_name")
     lateinit var clientName: String

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/ClientJpaEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/ClientJpaEntity.kt
@@ -1,13 +1,18 @@
 package team.themoment.datagsm.common.domain.client.entity
 
+import jakarta.persistence.CollectionTable
 import jakarta.persistence.Column
 import jakarta.persistence.Convert
+import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.global.converter.StringSetConverter
 
@@ -33,9 +38,14 @@ class ClientJpaEntity {
     @Column(columnDefinition = "text")
     lateinit var redirectUrls: Set<String>
 
-    @Convert(converter = StringSetConverter::class)
-    @Column(columnDefinition = "text")
-    lateinit var scopes: Set<String>
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name = "tb_client_scope",
+        joinColumns = [JoinColumn(name = "client_id")],
+    )
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @Column(name = "scope")
+    var scopes: MutableSet<String> = mutableSetOf()
 
     @Column(name = "client_name")
     lateinit var clientName: String

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/repository/ClientJpaRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/repository/ClientJpaRepository.kt
@@ -1,6 +1,9 @@
 package team.themoment.datagsm.common.domain.client.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.client.entity.ClientJpaEntity
 import team.themoment.datagsm.common.domain.client.repository.custom.ClientJpaCustomRepository
@@ -9,4 +12,12 @@ interface ClientJpaRepository :
     JpaRepository<ClientJpaEntity, String>,
     ClientJpaCustomRepository {
     fun deleteAllByAccount(account: AccountJpaEntity)
+
+    @Modifying
+    @Query("DELETE FROM tb_client_scope WHERE scope = :scope", nativeQuery = true)
+    fun removeScopeFromClients(@Param("scope") scope: String)
+
+    @Modifying
+    @Query("DELETE FROM tb_client_scope WHERE scope LIKE CONCAT(:prefix, '%')", nativeQuery = true)
+    fun removeScopesByApplicationId(@Param("prefix") prefix: String)
 }

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/repository/ClientJpaRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/repository/ClientJpaRepository.kt
@@ -15,9 +15,13 @@ interface ClientJpaRepository :
 
     @Modifying
     @Query("DELETE FROM tb_client_scope WHERE scope = :scope", nativeQuery = true)
-    fun removeScopeFromClients(@Param("scope") scope: String)
+    fun removeScopeFromClients(
+        @Param("scope") scope: String,
+    )
 
     @Modifying
     @Query("DELETE FROM tb_client_scope WHERE scope LIKE CONCAT(:prefix, '%')", nativeQuery = true)
-    fun removeScopesByApplicationId(@Param("prefix") prefix: String)
+    fun removeScopesByApplicationId(
+        @Param("prefix") prefix: String,
+    )
 }

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/repository/custom/impl/ClientJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/repository/custom/impl/ClientJpaCustomRepositoryImpl.kt
@@ -31,11 +31,13 @@ class ClientJpaCustomRepositoryImpl(
                 .limit(pageable.pageSize.toLong())
                 .fetch()
 
-        // 2쿼리: ID IN절로 account fetchJoin
+        // 2쿼리: ID IN절로 account, scopes fetchJoin
         val content =
             jpaQueryFactory
                 .selectFrom(clientJpaEntity)
                 .leftJoin(clientJpaEntity.account)
+                .fetchJoin()
+                .leftJoin(clientJpaEntity.scopes)
                 .fetchJoin()
                 .where(clientJpaEntity.id.`in`(clientIds))
                 .fetch()
@@ -66,7 +68,7 @@ class ClientJpaCustomRepositoryImpl(
                 .limit(pageable.pageSize.toLong())
                 .fetch()
 
-        // 2쿼리: ID IN절로 account fetchJoin
+        // 2쿼리: ID IN절로 account, scopes fetchJoin
         val content =
             if (clientIds.isEmpty()) {
                 emptyList()
@@ -74,6 +76,8 @@ class ClientJpaCustomRepositoryImpl(
                 jpaQueryFactory
                     .selectFrom(clientJpaEntity)
                     .leftJoin(clientJpaEntity.account)
+                    .fetchJoin()
+                    .leftJoin(clientJpaEntity.scopes)
                     .fetchJoin()
                     .where(clientJpaEntity.id.`in`(clientIds))
                     .fetch()

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOauthSessionServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOauthSessionServiceTest.kt
@@ -54,7 +54,7 @@ class QueryOauthSessionServiceTest :
                         id = testClientId
                         secret = "encodedSecret"
                         redirectUrls = setOf("https://example.com/callback")
-                        scopes = mutableSetOf("self:read")
+                        scopes.add("self:read")
                         clientName = "Test Client"
                         serviceName = "Test Service"
                     }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOauthSessionServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOauthSessionServiceTest.kt
@@ -54,7 +54,7 @@ class QueryOauthSessionServiceTest :
                         id = testClientId
                         secret = "encodedSecret"
                         redirectUrls = setOf("https://example.com/callback")
-                        scopes = setOf("self:read")
+                        scopes = mutableSetOf("self:read")
                         clientName = "Test Client"
                         serviceName = "Test Service"
                     }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -54,7 +54,7 @@ class StartOauthAuthorizeFlowServiceTest :
                         id = testClientId
                         secret = "encodedSecret"
                         redirectUrls = setOf(testRedirectUri)
-                        scopes = mutableSetOf("self:read")
+                        scopes.add("self:read")
                         clientName = "Test Client"
                         serviceName = "Test Service"
                     }
@@ -151,7 +151,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             id = testClientId
                             secret = "encodedSecret"
                             redirectUrls = setOf(testRedirectUri)
-                            scopes = mutableSetOf("self:read", "profile:read")
+                            scopes.addAll(setOf("self:read", "profile:read"))
                             clientName = "Test Client"
                             serviceName = "Test Service"
                         }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -54,7 +54,7 @@ class StartOauthAuthorizeFlowServiceTest :
                         id = testClientId
                         secret = "encodedSecret"
                         redirectUrls = setOf(testRedirectUri)
-                        scopes = setOf("self:read")
+                        scopes = mutableSetOf("self:read")
                         clientName = "Test Client"
                         serviceName = "Test Service"
                     }
@@ -151,7 +151,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             id = testClientId
                             secret = "encodedSecret"
                             redirectUrls = setOf(testRedirectUri)
-                            scopes = setOf("self:read", "profile:read")
+                            scopes = mutableSetOf("self:read", "profile:read")
                             clientName = "Test Client"
                             serviceName = "Test Service"
                         }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
@@ -108,7 +108,7 @@ class Oauth2TokenServiceImplTest :
                             id = "test-client"
                             secret = "hashed-secret"
                             redirectUrls = setOf("https://example.com/callback")
-                            scopes = mutableSetOf("self:read")
+                            scopes.add("self:read")
                         }
 
                     val account =
@@ -164,7 +164,7 @@ class Oauth2TokenServiceImplTest :
                             id = "test-client"
                             secret = "hashed-secret"
                             redirectUrls = setOf("https://example.com/callback")
-                            scopes = mutableSetOf("self:read")
+                            scopes.add("self:read")
                         }
 
                     val account =
@@ -300,7 +300,7 @@ class Oauth2TokenServiceImplTest :
                         ClientJpaEntity().apply {
                             id = "test-client"
                             secret = "hashed-secret"
-                            scopes = mutableSetOf("self:read")
+                            scopes.add("self:read")
                         }
 
                     val account =
@@ -360,7 +360,7 @@ class Oauth2TokenServiceImplTest :
                             ClientJpaEntity().apply {
                                 id = "test-client"
                                 secret = "hashed-secret"
-                                scopes = mutableSetOf("admin:write") // storedToken.scopes와 다름
+                                scopes.add("admin:write") // storedToken.scopes와 다름
                             }
                         every { mockClientJpaRepository.findById("test-client") } returns Optional.of(clientWithDifferentScopes)
 
@@ -440,7 +440,7 @@ class Oauth2TokenServiceImplTest :
                         ClientJpaEntity().apply {
                             id = "test-client"
                             secret = "hashed-secret"
-                            scopes = mutableSetOf("self:read")
+                            scopes.add("self:read")
                         }
 
                     beforeEach {

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
@@ -108,7 +108,7 @@ class Oauth2TokenServiceImplTest :
                             id = "test-client"
                             secret = "hashed-secret"
                             redirectUrls = setOf("https://example.com/callback")
-                            scopes = setOf("self:read")
+                            scopes = mutableSetOf("self:read")
                         }
 
                     val account =
@@ -164,7 +164,7 @@ class Oauth2TokenServiceImplTest :
                             id = "test-client"
                             secret = "hashed-secret"
                             redirectUrls = setOf("https://example.com/callback")
-                            scopes = setOf("self:read")
+                            scopes = mutableSetOf("self:read")
                         }
 
                     val account =
@@ -300,7 +300,7 @@ class Oauth2TokenServiceImplTest :
                         ClientJpaEntity().apply {
                             id = "test-client"
                             secret = "hashed-secret"
-                            scopes = setOf("self:read")
+                            scopes = mutableSetOf("self:read")
                         }
 
                     val account =
@@ -360,7 +360,7 @@ class Oauth2TokenServiceImplTest :
                             ClientJpaEntity().apply {
                                 id = "test-client"
                                 secret = "hashed-secret"
-                                scopes = setOf("admin:write") // storedToken.scopes와 다름
+                                scopes = mutableSetOf("admin:write") // storedToken.scopes와 다름
                             }
                         every { mockClientJpaRepository.findById("test-client") } returns Optional.of(clientWithDifferentScopes)
 
@@ -440,7 +440,7 @@ class Oauth2TokenServiceImplTest :
                         ClientJpaEntity().apply {
                             id = "test-client"
                             secret = "hashed-secret"
-                            scopes = setOf("self:read")
+                            scopes = mutableSetOf("self:read")
                         }
 
                     beforeEach {

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/application/service/impl/DeleteApplicationServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/application/service/impl/DeleteApplicationServiceImpl.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
 import team.themoment.datagsm.common.domain.application.repository.ApplicationJpaRepository
+import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.web.domain.application.service.DeleteApplicationService
 import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
@@ -12,6 +13,7 @@ import team.themoment.sdk.exception.ExpectedException
 @Service
 class DeleteApplicationServiceImpl(
     private val applicationJpaRepository: ApplicationJpaRepository,
+    private val clientJpaRepository: ClientJpaRepository,
     private val currentUserProvider: CurrentUserProvider,
 ) : DeleteApplicationService {
     @Transactional
@@ -28,6 +30,7 @@ class DeleteApplicationServiceImpl(
             throw ExpectedException("Application 삭제 권한이 없습니다.", HttpStatus.FORBIDDEN)
         }
 
+        clientJpaRepository.removeScopesByApplicationId("${application.id}:")
         applicationJpaRepository.delete(application)
     }
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/application/service/impl/DeleteOAuthScopeServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/application/service/impl/DeleteOAuthScopeServiceImpl.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
 import team.themoment.datagsm.common.domain.application.repository.OAuthScopeJpaRepository
+import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.web.domain.application.service.DeleteOAuthScopeService
 import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
@@ -12,6 +13,7 @@ import team.themoment.sdk.exception.ExpectedException
 @Service
 class DeleteOAuthScopeServiceImpl(
     private val oauthScopeJpaRepository: OAuthScopeJpaRepository,
+    private val clientJpaRepository: ClientJpaRepository,
     private val currentUserProvider: CurrentUserProvider,
 ) : DeleteOAuthScopeService {
     @Transactional
@@ -35,6 +37,7 @@ class DeleteOAuthScopeServiceImpl(
             throw ExpectedException("OAuth 권한 범위 삭제 권한이 없습니다.", HttpStatus.FORBIDDEN)
         }
 
+        clientJpaRepository.removeScopeFromClients("${scope.application.id}:${scope.scopeName}")
         oauthScopeJpaRepository.delete(scope)
     }
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/client/service/impl/CreateClientServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/client/service/impl/CreateClientServiceImpl.kt
@@ -46,7 +46,7 @@ class CreateClientServiceImpl(
                 serviceName = reqDto.serviceName
                 account = currentAccount
                 redirectUrls = reqDto.redirectUrls
-                scopes = reqDto.scopes.toMutableSet()
+                scopes.addAll(reqDto.scopes)
             }
         clientJpaRepository.save(client)
 

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/client/service/impl/CreateClientServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/client/service/impl/CreateClientServiceImpl.kt
@@ -46,7 +46,7 @@ class CreateClientServiceImpl(
                 serviceName = reqDto.serviceName
                 account = currentAccount
                 redirectUrls = reqDto.redirectUrls
-                scopes = reqDto.scopes
+                scopes = reqDto.scopes.toMutableSet()
             }
         clientJpaRepository.save(client)
 

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/application/service/DeleteApplicationServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/application/service/DeleteApplicationServiceTest.kt
@@ -12,6 +12,7 @@ import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
 import team.themoment.datagsm.common.domain.application.entity.ApplicationJpaEntity
 import team.themoment.datagsm.common.domain.application.repository.ApplicationJpaRepository
+import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.web.domain.application.service.impl.DeleteApplicationServiceImpl
 import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
@@ -21,11 +22,13 @@ class DeleteApplicationServiceTest :
     DescribeSpec({
 
         val mockApplicationJpaRepository = mockk<ApplicationJpaRepository>()
+        val mockClientJpaRepository = mockk<ClientJpaRepository>()
         val mockCurrentUserProvider = mockk<CurrentUserProvider>()
 
         val service =
             DeleteApplicationServiceImpl(
                 mockApplicationJpaRepository,
+                mockClientJpaRepository,
                 mockCurrentUserProvider,
             )
 
@@ -56,6 +59,7 @@ class DeleteApplicationServiceTest :
                     beforeEach {
                         every { mockApplicationJpaRepository.findById(applicationId) } returns Optional.of(existingApplication)
                         every { mockCurrentUserProvider.getCurrentAccount() } returns ownerAccount
+                        every { mockClientJpaRepository.removeScopesByApplicationId("$applicationId:") } returns Unit
                         every { mockApplicationJpaRepository.delete(existingApplication) } returns Unit
                     }
 
@@ -64,6 +68,7 @@ class DeleteApplicationServiceTest :
 
                         verify(exactly = 1) { mockApplicationJpaRepository.findById(applicationId) }
                         verify(exactly = 1) { mockCurrentUserProvider.getCurrentAccount() }
+                        verify(exactly = 1) { mockClientJpaRepository.removeScopesByApplicationId("$applicationId:") }
                         verify(exactly = 1) { mockApplicationJpaRepository.delete(existingApplication) }
                     }
                 }
@@ -79,12 +84,14 @@ class DeleteApplicationServiceTest :
                     beforeEach {
                         every { mockApplicationJpaRepository.findById(applicationId) } returns Optional.of(existingApplication)
                         every { mockCurrentUserProvider.getCurrentAccount() } returns adminAccount
+                        every { mockClientJpaRepository.removeScopesByApplicationId("$applicationId:") } returns Unit
                         every { mockApplicationJpaRepository.delete(existingApplication) } returns Unit
                     }
 
                     it("성공적으로 삭제되어야 한다") {
                         service.execute(applicationId)
 
+                        verify(exactly = 1) { mockClientJpaRepository.removeScopesByApplicationId("$applicationId:") }
                         verify(exactly = 1) { mockApplicationJpaRepository.delete(existingApplication) }
                     }
                 }
@@ -100,12 +107,14 @@ class DeleteApplicationServiceTest :
                     beforeEach {
                         every { mockApplicationJpaRepository.findById(applicationId) } returns Optional.of(existingApplication)
                         every { mockCurrentUserProvider.getCurrentAccount() } returns rootAccount
+                        every { mockClientJpaRepository.removeScopesByApplicationId("$applicationId:") } returns Unit
                         every { mockApplicationJpaRepository.delete(existingApplication) } returns Unit
                     }
 
                     it("성공적으로 삭제되어야 한다") {
                         service.execute(applicationId)
 
+                        verify(exactly = 1) { mockClientJpaRepository.removeScopesByApplicationId("$applicationId:") }
                         verify(exactly = 1) { mockApplicationJpaRepository.delete(existingApplication) }
                     }
                 }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/application/service/DeleteOAuthScopeServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/application/service/DeleteOAuthScopeServiceTest.kt
@@ -13,6 +13,7 @@ import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
 import team.themoment.datagsm.common.domain.application.entity.ApplicationJpaEntity
 import team.themoment.datagsm.common.domain.application.entity.OAuthScopeJpaEntity
 import team.themoment.datagsm.common.domain.application.repository.OAuthScopeJpaRepository
+import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.web.domain.application.service.impl.DeleteOAuthScopeServiceImpl
 import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
@@ -22,11 +23,13 @@ class DeleteOAuthScopeServiceTest :
     DescribeSpec({
 
         val mockOauthScopeJpaRepository = mockk<OAuthScopeJpaRepository>()
+        val mockClientJpaRepository = mockk<ClientJpaRepository>()
         val mockCurrentUserProvider = mockk<CurrentUserProvider>()
 
         val service =
             DeleteOAuthScopeServiceImpl(
                 mockOauthScopeJpaRepository,
+                mockClientJpaRepository,
                 mockCurrentUserProvider,
             )
 
@@ -66,6 +69,7 @@ class DeleteOAuthScopeServiceTest :
                     beforeEach {
                         every { mockOauthScopeJpaRepository.findById(scopeId) } returns Optional.of(scope)
                         every { mockCurrentUserProvider.getCurrentAccount() } returns ownerAccount
+                        every { mockClientJpaRepository.removeScopeFromClients("$applicationId:profile") } returns Unit
                         every { mockOauthScopeJpaRepository.delete(scope) } returns Unit
                     }
 
@@ -74,6 +78,7 @@ class DeleteOAuthScopeServiceTest :
 
                         verify(exactly = 1) { mockOauthScopeJpaRepository.findById(scopeId) }
                         verify(exactly = 1) { mockCurrentUserProvider.getCurrentAccount() }
+                        verify(exactly = 1) { mockClientJpaRepository.removeScopeFromClients("$applicationId:profile") }
                         verify(exactly = 1) { mockOauthScopeJpaRepository.delete(scope) }
                     }
                 }
@@ -89,12 +94,14 @@ class DeleteOAuthScopeServiceTest :
                     beforeEach {
                         every { mockOauthScopeJpaRepository.findById(scopeId) } returns Optional.of(scope)
                         every { mockCurrentUserProvider.getCurrentAccount() } returns adminAccount
+                        every { mockClientJpaRepository.removeScopeFromClients("$applicationId:profile") } returns Unit
                         every { mockOauthScopeJpaRepository.delete(scope) } returns Unit
                     }
 
                     it("성공적으로 삭제되어야 한다") {
                         service.execute(applicationId, scopeId)
 
+                        verify(exactly = 1) { mockClientJpaRepository.removeScopeFromClients("$applicationId:profile") }
                         verify(exactly = 1) { mockOauthScopeJpaRepository.delete(scope) }
                     }
                 }
@@ -110,12 +117,14 @@ class DeleteOAuthScopeServiceTest :
                     beforeEach {
                         every { mockOauthScopeJpaRepository.findById(scopeId) } returns Optional.of(scope)
                         every { mockCurrentUserProvider.getCurrentAccount() } returns rootAccount
+                        every { mockClientJpaRepository.removeScopeFromClients("$applicationId:profile") } returns Unit
                         every { mockOauthScopeJpaRepository.delete(scope) } returns Unit
                     }
 
                     it("성공적으로 삭제되어야 한다") {
                         service.execute(applicationId, scopeId)
 
+                        verify(exactly = 1) { mockClientJpaRepository.removeScopeFromClients("$applicationId:profile") }
                         verify(exactly = 1) { mockOauthScopeJpaRepository.delete(scope) }
                     }
                 }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/ModifyClientServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/ModifyClientServiceTest.kt
@@ -56,7 +56,7 @@ class ModifyClientServiceTest :
                             serviceName = "기존 서비스"
                             account = ownerAccount
                             redirectUrls = setOf("https://example.com")
-                            scopes = setOf("self:read")
+                            scopes = mutableSetOf("self:read")
                         }
                 }
 

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/ModifyClientServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/ModifyClientServiceTest.kt
@@ -56,7 +56,7 @@ class ModifyClientServiceTest :
                             serviceName = "기존 서비스"
                             account = ownerAccount
                             redirectUrls = setOf("https://example.com")
-                            scopes = mutableSetOf("self:read")
+                            scopes.add("self:read")
                         }
                 }
 

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/QueryMyClientServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/QueryMyClientServiceTest.kt
@@ -46,7 +46,7 @@ class QueryMyClientServiceTest :
                             serviceName = "나의 서비스"
                             account = currentAccount
                             redirectUrls = setOf("https://example.com")
-                            scopes = mutableSetOf("self:read")
+                            scopes.add("self:read")
                         }
 
                     beforeEach {
@@ -91,7 +91,7 @@ class QueryMyClientServiceTest :
                                 serviceName = "서비스$index"
                                 account = currentAccount
                                 redirectUrls = setOf("https://example$index.com")
-                                scopes = mutableSetOf("self:read")
+                                scopes.add("self:read")
                             }
                         }
 
@@ -153,7 +153,7 @@ class QueryMyClientServiceTest :
                             serviceName = "멀티 리다이렉트 서비스"
                             account = currentAccount
                             redirectUrls = setOf("https://url1.com", "https://url2.com", "https://url3.com")
-                            scopes = mutableSetOf("self:read")
+                            scopes.add("self:read")
                         }
 
                     val client2 =
@@ -164,7 +164,7 @@ class QueryMyClientServiceTest :
                             serviceName = "단일 리다이렉트 서비스"
                             account = currentAccount
                             redirectUrls = setOf("https://single.com")
-                            scopes = mutableSetOf("self:read")
+                            scopes.add("self:read")
                         }
 
                     val client3 =
@@ -175,7 +175,7 @@ class QueryMyClientServiceTest :
                             serviceName = "리다이렉트 없는 서비스"
                             account = currentAccount
                             redirectUrls = emptySet()
-                            scopes = mutableSetOf("self:read")
+                            scopes.add("self:read")
                         }
 
                     beforeEach {
@@ -215,7 +215,7 @@ class QueryMyClientServiceTest :
                             serviceName = "관리자 서비스"
                             account = adminAccount
                             redirectUrls = emptySet()
-                            scopes = mutableSetOf("self:read")
+                            scopes.add("self:read")
                         }
 
                     beforeEach {
@@ -249,7 +249,7 @@ class QueryMyClientServiceTest :
                                 serviceName = "서비스$index"
                                 account = currentAccount
                                 redirectUrls = setOf("https://example$index.com")
-                                scopes = mutableSetOf("self:read")
+                                scopes.add("self:read")
                             }
                         }
 

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/QueryMyClientServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/QueryMyClientServiceTest.kt
@@ -46,7 +46,7 @@ class QueryMyClientServiceTest :
                             serviceName = "나의 서비스"
                             account = currentAccount
                             redirectUrls = setOf("https://example.com")
-                            scopes = setOf("self:read")
+                            scopes = mutableSetOf("self:read")
                         }
 
                     beforeEach {
@@ -91,7 +91,7 @@ class QueryMyClientServiceTest :
                                 serviceName = "서비스$index"
                                 account = currentAccount
                                 redirectUrls = setOf("https://example$index.com")
-                                scopes = setOf("self:read")
+                                scopes = mutableSetOf("self:read")
                             }
                         }
 
@@ -153,7 +153,7 @@ class QueryMyClientServiceTest :
                             serviceName = "멀티 리다이렉트 서비스"
                             account = currentAccount
                             redirectUrls = setOf("https://url1.com", "https://url2.com", "https://url3.com")
-                            scopes = setOf("self:read")
+                            scopes = mutableSetOf("self:read")
                         }
 
                     val client2 =
@@ -164,7 +164,7 @@ class QueryMyClientServiceTest :
                             serviceName = "단일 리다이렉트 서비스"
                             account = currentAccount
                             redirectUrls = setOf("https://single.com")
-                            scopes = setOf("self:read")
+                            scopes = mutableSetOf("self:read")
                         }
 
                     val client3 =
@@ -175,7 +175,7 @@ class QueryMyClientServiceTest :
                             serviceName = "리다이렉트 없는 서비스"
                             account = currentAccount
                             redirectUrls = emptySet()
-                            scopes = setOf("self:read")
+                            scopes = mutableSetOf("self:read")
                         }
 
                     beforeEach {
@@ -215,7 +215,7 @@ class QueryMyClientServiceTest :
                             serviceName = "관리자 서비스"
                             account = adminAccount
                             redirectUrls = emptySet()
-                            scopes = setOf("self:read")
+                            scopes = mutableSetOf("self:read")
                         }
 
                     beforeEach {
@@ -249,7 +249,7 @@ class QueryMyClientServiceTest :
                                 serviceName = "서비스$index"
                                 account = currentAccount
                                 redirectUrls = setOf("https://example$index.com")
-                                scopes = setOf("self:read")
+                                scopes = mutableSetOf("self:read")
                             }
                         }
 

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/SearchClientServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/SearchClientServiceTest.kt
@@ -44,7 +44,7 @@ class SearchClientServiceTest :
                         serviceName = "테스트 서비스"
                         account = testAccount
                         redirectUrls = setOf("https://test.com")
-                        scopes = mutableSetOf("self:read")
+                        scopes.add("self:read")
                     }
 
                 context("클라이언트 이름으로 검색할 때") {
@@ -97,7 +97,7 @@ class SearchClientServiceTest :
                                 serviceName = "서비스$index"
                                 account = testAccount
                                 redirectUrls = setOf("https://example$index.com")
-                                scopes = mutableSetOf("self:read")
+                                scopes.add("self:read")
                             }
                         }
 
@@ -166,7 +166,7 @@ class SearchClientServiceTest :
                                 serviceName = "서비스$index"
                                 account = testAccount
                                 redirectUrls = emptySet()
-                                scopes = mutableSetOf("self:read")
+                                scopes.add("self:read")
                             }
                         }
 
@@ -209,7 +209,7 @@ class SearchClientServiceTest :
                                 serviceName = "서비스$index"
                                 account = testAccount
                                 redirectUrls = emptySet()
-                                scopes = mutableSetOf("self:read")
+                                scopes.add("self:read")
                             }
                         }
 
@@ -252,7 +252,7 @@ class SearchClientServiceTest :
                                 serviceName = "API 서비스1"
                                 account = testAccount
                                 redirectUrls = emptySet()
-                                scopes = mutableSetOf("self:read")
+                                scopes.add("self:read")
                             },
                             ClientJpaEntity().apply {
                                 id = "client-2"
@@ -261,7 +261,7 @@ class SearchClientServiceTest :
                                 serviceName = "API 서비스2"
                                 account = testAccount
                                 redirectUrls = emptySet()
-                                scopes = mutableSetOf("self:read")
+                                scopes.add("self:read")
                             },
                         )
 
@@ -302,7 +302,7 @@ class SearchClientServiceTest :
                                 serviceName = "서비스$index"
                                 account = testAccount
                                 redirectUrls = emptySet()
-                                scopes = mutableSetOf("self:read")
+                                scopes.add("self:read")
                             }
                         }
 

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/SearchClientServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/SearchClientServiceTest.kt
@@ -44,7 +44,7 @@ class SearchClientServiceTest :
                         serviceName = "테스트 서비스"
                         account = testAccount
                         redirectUrls = setOf("https://test.com")
-                        scopes = setOf("self:read")
+                        scopes = mutableSetOf("self:read")
                     }
 
                 context("클라이언트 이름으로 검색할 때") {
@@ -97,7 +97,7 @@ class SearchClientServiceTest :
                                 serviceName = "서비스$index"
                                 account = testAccount
                                 redirectUrls = setOf("https://example$index.com")
-                                scopes = setOf("self:read")
+                                scopes = mutableSetOf("self:read")
                             }
                         }
 
@@ -166,7 +166,7 @@ class SearchClientServiceTest :
                                 serviceName = "서비스$index"
                                 account = testAccount
                                 redirectUrls = emptySet()
-                                scopes = setOf("self:read")
+                                scopes = mutableSetOf("self:read")
                             }
                         }
 
@@ -209,7 +209,7 @@ class SearchClientServiceTest :
                                 serviceName = "서비스$index"
                                 account = testAccount
                                 redirectUrls = emptySet()
-                                scopes = setOf("self:read")
+                                scopes = mutableSetOf("self:read")
                             }
                         }
 
@@ -252,7 +252,7 @@ class SearchClientServiceTest :
                                 serviceName = "API 서비스1"
                                 account = testAccount
                                 redirectUrls = emptySet()
-                                scopes = setOf("self:read")
+                                scopes = mutableSetOf("self:read")
                             },
                             ClientJpaEntity().apply {
                                 id = "client-2"
@@ -261,7 +261,7 @@ class SearchClientServiceTest :
                                 serviceName = "API 서비스2"
                                 account = testAccount
                                 redirectUrls = emptySet()
-                                scopes = setOf("self:read")
+                                scopes = mutableSetOf("self:read")
                             },
                         )
 
@@ -302,7 +302,7 @@ class SearchClientServiceTest :
                                 serviceName = "서비스$index"
                                 account = testAccount
                                 redirectUrls = emptySet()
-                                scopes = setOf("self:read")
+                                scopes = mutableSetOf("self:read")
                             }
                         }
 


### PR DESCRIPTION
## 개요

`tb_client.scopes` JSON 텍스트 컬럼을 `tb_client_scope` 조인 테이블로 정규화하고, `Application` 및 `OAuthScope` 삭제 시 Client의 scope 참조가 정리되지 않던 문제를 해결하였습니다.

## 본문

### 문제

`ClientJpaEntity.scopes`가 `StringSetConverter`를 통해 JSON 배열 텍스트(`["appId:scopeName", ...]`)로 저장되어 있어 다음 문제가 발생하였습니다:

- `OAuthScope` 삭제 시 `tb_client`에 삭제된 scope 문자열이 잔존
- `Application` 삭제 시 해당 application의 모든 scope 문자열이 잔존
- Client Credentials 토큰 발급 시 `Oauth2TokenServiceImpl.stringsToScopes()`에서 삭제된 scope를 만나면 **500 에러** 발생
- 기존 배열 텍스트로 정합성을 유지하기 위해선 LIKE 문 사용이 불가피하여 full table search가 발생할 우려가 있음

### 변경 내용

**정규화**

- `ClientJpaEntity.scopes`를 `@ElementCollection` + `@CollectionTable("tb_client_scope")`로 변경하였습니다.
- `@OnDelete(action = OnDeleteAction.CASCADE)`를 적용하여 Client 삭제 시 DB 레벨에서 scope 행이 자동 삭제됩니다.
- `FetchType.EAGER`를 설정하여 Client 조회 시 scopes가 항상 함께 로딩됩니다.

**삭제 정합성**

- `DeleteOAuthScopeServiceImpl`에서 scope 삭제 전 `removeScopeFromClients()`를 호출하여 해당 scope를 참조하는 Client를 정리합니다.
- `DeleteApplicationServiceImpl`에서 Application 삭제 전 `removeScopesByApplicationId()`를 호출하여 관련 scope를 일괄 정리합니다.
- 두 메서드 모두 `tb_client_scope.scope` 인덱스를 활용하는 네이티브 쿼리로 구현하였습니다.

**QueryDSL fetch join**

- `ClientJpaCustomRepositoryImpl`의 목록 조회 쿼리에 `leftJoin(clientJpaEntity.scopes).fetchJoin()`을 추가하여 추가 SELECT 없이 한 번의 쿼리로 scopes를 로딩합니다.

### DB 마이그레이션
 `tb_client_scope` 테이블을 추가해야합니다. 기존 `tb_client.scopes` 컬럼의 데이터를 새 테이블로 이관해야 합니다.

### 추가 리뷰 요청
삭제시 정합성 유지를 위해 full table search가 불가피하여 이러한 변경을 하게 되었는데, client 도메인은 읽기가 훨씬 더 자주 일어나다보니 적합한 trade off 인지 고민입니다. 다른 방법이 있다면 생각 공유해주시길 바랍니다. ex) json을 지원하는 다른 db 사용
