### PR TITLE
[global] 신규 모듈 구조에 맞춘 `.gitignore` 프로필 파일 경로 현행화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,14 +44,8 @@ out/
 .kotlin
 
 ### Profile Files ###
-/datagsm-oauth-authorization/src/main/resources/application-stage.yml
-/datagsm-oauth-authorization/src/main/resources/application-prod.yml
-/datagsm-oauth-userinfo/src/main/resources/application-stage.yml
-/datagsm-oauth-userinfo/src/main/resources/application-prod.yml
-/datagsm-openapi/src/main/resources/application-stage.yml
-/datagsm-openapi/src/main/resources/application-prod.yml
-/datagsm-web/src/main/resources/application-stage.yml
-/datagsm-web/src/main/resources/application-prod.yml
+**/src/main/resources/application-stage.yml
+**/src/main/resources/application-prod.yml
 
 ### LLM Outputs ###
 PR_BODY.md

--- a/.gitignore
+++ b/.gitignore
@@ -44,10 +44,12 @@ out/
 .kotlin
 
 ### Profile Files ###
-/datagsm-authorization/src/main/resources/application-stage.yml
-/datagsm-authorization/src/main/resources/application-prod.yml
-/datagsm-resource/src/main/resources/application-stage.yml
-/datagsm-resource/src/main/resources/application-prod.yml
+/datagsm-oauth-authorization/src/main/resources/application-stage.yml
+/datagsm-oauth-authorization/src/main/resources/application-prod.yml
+/datagsm-oauth-userinfo/src/main/resources/application-stage.yml
+/datagsm-oauth-userinfo/src/main/resources/application-prod.yml
+/datagsm-openapi/src/main/resources/application-stage.yml
+/datagsm-openapi/src/main/resources/application-prod.yml
 /datagsm-web/src/main/resources/application-stage.yml
 /datagsm-web/src/main/resources/application-prod.yml
 


### PR DESCRIPTION
## 개요

최근 진행된 모듈 명칭 변경 작업에 맞춰 .gitignore 파일에 정의된 stage 및 prod 프로필 설정 파일의 경로를 수정하였습니다.

## 본문

프로필 설정 파일이 Git에 의도치 않게 포함되지 않도록 .gitignore 내의 경로를 새로운 모듈 구조에 맞게 업데이트하였습니다.

- **datagsm-authorization** -> `datagsm-oauth-authorization`
- **datagsm-resource** -> `datagsm-oauth-userinfo`, `datagsm-openapi`

기존 모듈이 용도에 따라 세분화됨에 따라 각각의 새로운 경로를 명시하여 보안 관련 설정 파일이 노출되지 않도록 조치하였습니다.
