### PR TITLE
[project] 프로젝트 운영 상태 관리 및 시작/종료 연도 필드 추가

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/request/EndProjectReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/request/EndProjectReqDto.kt
@@ -1,0 +1,10 @@
+package team.themoment.datagsm.common.domain.project.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Positive
+
+data class EndProjectReqDto(
+    @field:Positive
+    @param:Schema(description = "프로젝트 종료 연도", example = "2025")
+    val endYear: Int,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/request/ProjectReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/request/ProjectReqDto.kt
@@ -2,6 +2,7 @@ package team.themoment.datagsm.common.domain.project.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.Size
 
 data class ProjectReqDto(
@@ -13,6 +14,9 @@ data class ProjectReqDto(
     @field:Size(max = 500)
     @param:Schema(description = "프로젝트 설명", example = "학교 데이터를 제공하는 API 서비스", maxLength = 500)
     val description: String,
+    @field:Positive
+    @param:Schema(description = "프로젝트 시작 연도", example = "2024")
+    val startYear: Int,
     @param:Schema(description = "프로젝트 소유 동아리 ID", example = "1")
     val clubId: Long?,
     @param:Schema(description = "프로젝트 참가자 학생 ID 목록", example = "[1, 2, 3]")

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/request/ProjectReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/request/ProjectReqDto.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.Size
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 
 data class ProjectReqDto(
     @field:NotBlank
@@ -21,4 +22,9 @@ data class ProjectReqDto(
     val clubId: Long?,
     @param:Schema(description = "프로젝트 참가자 학생 ID 목록", example = "[1, 2, 3]")
     val participantIds: List<Long>,
+    @param:Schema(description = "프로젝트 운영 상태", example = "ACTIVE")
+    val status: ProjectStatus = ProjectStatus.ACTIVE,
+    @field:Positive
+    @param:Schema(description = "프로젝트 종료 연도 (ENDED 시 설정)", example = "2025")
+    val endYear: Int? = null,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/request/QueryProjectReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/request/QueryProjectReqDto.kt
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.Positive
 import team.themoment.datagsm.common.domain.project.entity.constant.ProjectSortBy
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.global.constant.SortDirection
 
 data class QueryProjectReqDto(
@@ -16,6 +17,8 @@ data class QueryProjectReqDto(
     @field:Positive
     @param:Schema(description = "동아리 ID")
     val clubId: Long? = null,
+    @param:Schema(description = "프로젝트 운영 상태 (ACTIVE, ENDED, 미입력 시 ACTIVE만 조회)", defaultValue = "ACTIVE")
+    val status: ProjectStatus? = ProjectStatus.ACTIVE,
     @field:Min(0)
     @param:Schema(description = "페이지 번호", defaultValue = "0", minimum = "0")
     val page: Int = 0,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/response/ProjectResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/response/ProjectResDto.kt
@@ -2,6 +2,7 @@ package team.themoment.datagsm.common.domain.project.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.student.dto.internal.ParticipantInfoDto
 
 data class ProjectResDto(
@@ -11,6 +12,12 @@ data class ProjectResDto(
     val name: String,
     @field:Schema(description = "프로젝트 설명", example = "학교 데이터를 제공하는 API 서비스")
     val description: String,
+    @field:Schema(description = "프로젝트 시작 연도", example = "2024")
+    val startYear: Int,
+    @field:Schema(description = "프로젝트 종료 연도", example = "2025")
+    val endYear: Int?,
+    @field:Schema(description = "프로젝트 운영 상태")
+    val status: ProjectStatus,
     @field:Schema(description = "프로젝트 소유 동아리 정보")
     val club: ClubSummaryDto?,
     @field:Schema(description = "프로젝트 참가자 목록")

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/entity/ProjectJpaEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/entity/ProjectJpaEntity.kt
@@ -2,6 +2,8 @@ package team.themoment.datagsm.common.domain.project.entity
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -12,6 +14,7 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.DynamicUpdate
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 
 @Table(name = "tb_project")
@@ -28,6 +31,16 @@ class ProjectJpaEntity {
 
     @field:Column(name = "description", nullable = false, length = 500, columnDefinition = "TEXT")
     lateinit var description: String
+
+    @field:Column(name = "start_year", nullable = false)
+    var startYear: Int = 0
+
+    @field:Column(name = "end_year", nullable = true)
+    var endYear: Int? = null
+
+    @field:Column(name = "status", nullable = false)
+    @field:Enumerated(EnumType.STRING)
+    lateinit var status: ProjectStatus
 
     @field:ManyToOne(optional = true)
     @field:JoinColumn(name = "club_id", nullable = true, referencedColumnName = "id")

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/entity/constant/ProjectStatus.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/entity/constant/ProjectStatus.kt
@@ -1,0 +1,8 @@
+package team.themoment.datagsm.common.domain.project.entity.constant
+
+enum class ProjectStatus(
+    val value: String,
+) {
+    ACTIVE("운영 중"),
+    ENDED("종료"),
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/ProjectJpaCustomRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/ProjectJpaCustomRepository.kt
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
 import team.themoment.datagsm.common.domain.project.entity.constant.ProjectSortBy
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.global.constant.SortDirection
 
 interface ProjectJpaCustomRepository {
@@ -11,6 +12,7 @@ interface ProjectJpaCustomRepository {
         id: Long?,
         name: String?,
         clubId: Long?,
+        status: ProjectStatus?,
         pageable: Pageable,
         sortBy: ProjectSortBy?,
         sortDirection: SortDirection,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/impl/ProjectJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/impl/ProjectJpaCustomRepositoryImpl.kt
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
 import team.themoment.datagsm.common.domain.project.entity.QProjectJpaEntity.Companion.projectJpaEntity
 import team.themoment.datagsm.common.domain.project.entity.constant.ProjectSortBy
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.project.repository.custom.ProjectJpaCustomRepository
 import team.themoment.datagsm.common.global.constant.SortDirection
 
@@ -20,13 +21,14 @@ class ProjectJpaCustomRepositoryImpl(
         id: Long?,
         name: String?,
         clubId: Long?,
+        status: ProjectStatus?,
         pageable: Pageable,
         sortBy: ProjectSortBy?,
         sortDirection: SortDirection,
     ): Page<ProjectJpaEntity> {
-        var searchResult = searchProjectWithCondition(id, name, clubId, pageable, sortBy, sortDirection, useStartsWith = true)
+        var searchResult = searchProjectWithCondition(id, name, clubId, status, pageable, sortBy, sortDirection, useStartsWith = true)
         if (searchResult.content.isEmpty() && name != null) {
-            searchResult = searchProjectWithCondition(id, name, clubId, pageable, sortBy, sortDirection, useStartsWith = false)
+            searchResult = searchProjectWithCondition(id, name, clubId, status, pageable, sortBy, sortDirection, useStartsWith = false)
         }
         return searchResult
     }
@@ -35,6 +37,7 @@ class ProjectJpaCustomRepositoryImpl(
         projectId: Long?,
         projectName: String?,
         clubId: Long?,
+        status: ProjectStatus?,
         pageable: Pageable,
         sortBy: ProjectSortBy?,
         sortDirection: SortDirection,
@@ -53,6 +56,7 @@ class ProjectJpaCustomRepositoryImpl(
                         if (useStartsWith) projectJpaEntity.name.startsWith(it) else projectJpaEntity.name.contains(it)
                     },
                     clubId?.let { projectJpaEntity.club.id.eq(it) },
+                    status?.let { projectJpaEntity.status.eq(it) },
                 ).apply {
                     orderSpecifier?.let { orderBy(it) }
                 }.offset(pageable.offset)
@@ -86,6 +90,7 @@ class ProjectJpaCustomRepositoryImpl(
                         if (useStartsWith) projectJpaEntity.name.startsWith(it) else projectJpaEntity.name.contains(it)
                     },
                     clubId?.let { projectJpaEntity.club.id.eq(it) },
+                    status?.let { projectJpaEntity.status.eq(it) },
                 )
 
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/controller/ProjectController.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/controller/ProjectController.kt
@@ -17,14 +17,17 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import team.themoment.datagsm.common.domain.auth.entity.constant.ApiKeyScope
+import team.themoment.datagsm.common.domain.project.dto.request.EndProjectReqDto
 import team.themoment.datagsm.common.domain.project.dto.request.ProjectReqDto
 import team.themoment.datagsm.common.domain.project.dto.request.QueryProjectReqDto
 import team.themoment.datagsm.common.domain.project.dto.response.ProjectListResDto
 import team.themoment.datagsm.common.domain.project.dto.response.ProjectResDto
 import team.themoment.datagsm.openapi.domain.project.service.CreateProjectService
 import team.themoment.datagsm.openapi.domain.project.service.DeleteProjectService
+import team.themoment.datagsm.openapi.domain.project.service.EndProjectService
 import team.themoment.datagsm.openapi.domain.project.service.ModifyProjectService
 import team.themoment.datagsm.openapi.domain.project.service.QueryProjectService
+import team.themoment.datagsm.openapi.domain.project.service.ReactivateProjectService
 import team.themoment.datagsm.openapi.global.security.annotation.RequireScope
 
 @Tag(name = "Project", description = "프로젝트 관련 API")
@@ -35,6 +38,8 @@ class ProjectController(
     private val createProjectService: CreateProjectService,
     private val modifyProjectService: ModifyProjectService,
     private val deleteProjectService: DeleteProjectService,
+    private val endProjectService: EndProjectService,
+    private val reactivateProjectService: ReactivateProjectService,
 ) {
     @Operation(summary = "프로젝트 정보 조회", description = "필터 조건에 맞는 프로젝트 정보를 조회합니다.")
     @ApiResponses(
@@ -79,6 +84,34 @@ class ProjectController(
         @Parameter(description = "프로젝트 ID") @PathVariable projectId: Long,
         @RequestBody @Valid reqDto: ProjectReqDto,
     ): ProjectResDto = modifyProjectService.execute(projectId, reqDto)
+
+    @Operation(summary = "프로젝트 종료", description = "운영 중인 프로젝트를 종료 처리합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "종료 처리 성공"),
+            ApiResponse(responseCode = "400", description = "잘못된 요청 (검증 실패 또는 종료 연도 오류)", content = [Content()]),
+            ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음", content = [Content()]),
+        ],
+    )
+    @RequireScope(ApiKeyScope.PROJECT_WRITE)
+    @PostMapping("/{projectId}/end")
+    fun endProject(
+        @Parameter(description = "프로젝트 ID") @PathVariable projectId: Long,
+        @RequestBody @Valid reqDto: EndProjectReqDto,
+    ) = endProjectService.execute(projectId, reqDto)
+
+    @Operation(summary = "프로젝트 운영 재개", description = "종료된 프로젝트를 다시 운영 중 상태로 변경합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "운영 재개 성공"),
+            ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음", content = [Content()]),
+        ],
+    )
+    @RequireScope(ApiKeyScope.PROJECT_WRITE)
+    @PostMapping("/{projectId}/reactivate")
+    fun reactivateProject(
+        @Parameter(description = "프로젝트 ID") @PathVariable projectId: Long,
+    ) = reactivateProjectService.execute(projectId)
 
     @Operation(summary = "프로젝트 삭제", description = "기존 프로젝트를 삭제합니다.")
     @ApiResponses(

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/EndProjectService.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/EndProjectService.kt
@@ -1,0 +1,10 @@
+package team.themoment.datagsm.openapi.domain.project.service
+
+import team.themoment.datagsm.common.domain.project.dto.request.EndProjectReqDto
+
+interface EndProjectService {
+    fun execute(
+        projectId: Long,
+        reqDto: EndProjectReqDto,
+    )
+}

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/ReactivateProjectService.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/ReactivateProjectService.kt
@@ -1,0 +1,5 @@
+package team.themoment.datagsm.openapi.domain.project.service
+
+interface ReactivateProjectService {
+    fun execute(projectId: Long)
+}

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/CreateProjectServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/CreateProjectServiceImpl.kt
@@ -9,6 +9,7 @@ import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
 import team.themoment.datagsm.common.domain.project.dto.request.ProjectReqDto
 import team.themoment.datagsm.common.domain.project.dto.response.ProjectResDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
 import team.themoment.datagsm.common.domain.student.dto.internal.ParticipantInfoDto
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
@@ -56,6 +57,8 @@ class CreateProjectServiceImpl(
             ProjectJpaEntity().apply {
                 name = projectReqDto.name
                 description = projectReqDto.description
+                startYear = projectReqDto.startYear
+                status = ProjectStatus.ACTIVE
                 this.club = ownerClub
                 this.participants = participants
             }
@@ -65,6 +68,9 @@ class CreateProjectServiceImpl(
             id = savedProjectEntity.id!!,
             name = savedProjectEntity.name,
             description = savedProjectEntity.description,
+            startYear = savedProjectEntity.startYear,
+            endYear = savedProjectEntity.endYear,
+            status = savedProjectEntity.status,
             club = ownerClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
             participants =
                 savedProjectEntity.participants.map { student ->

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/CreateProjectServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/CreateProjectServiceImpl.kt
@@ -53,12 +53,22 @@ class CreateProjectServiceImpl(
                 mutableSetOf()
             }
 
+        if (projectReqDto.status == ProjectStatus.ENDED) {
+            val endYear =
+                projectReqDto.endYear
+                    ?: throw ExpectedException("종료 연도를 입력해주세요.", HttpStatus.BAD_REQUEST)
+            if (endYear < projectReqDto.startYear) {
+                throw ExpectedException("종료 연도는 시작 연도보다 크거나 같아야 합니다.", HttpStatus.BAD_REQUEST)
+            }
+        }
+
         val projectEntity =
             ProjectJpaEntity().apply {
                 name = projectReqDto.name
                 description = projectReqDto.description
                 startYear = projectReqDto.startYear
-                status = ProjectStatus.ACTIVE
+                status = projectReqDto.status
+                endYear = projectReqDto.endYear
                 this.club = ownerClub
                 this.participants = participants
             }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/EndProjectServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/EndProjectServiceImpl.kt
@@ -1,0 +1,31 @@
+package team.themoment.datagsm.openapi.domain.project.service.impl
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.project.dto.request.EndProjectReqDto
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
+import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
+import team.themoment.datagsm.openapi.domain.project.service.EndProjectService
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class EndProjectServiceImpl(
+    private val projectJpaRepository: ProjectJpaRepository,
+) : EndProjectService {
+    @Transactional
+    override fun execute(
+        projectId: Long,
+        reqDto: EndProjectReqDto,
+    ) {
+        val project =
+            projectJpaRepository.findByIdOrNull(projectId)
+                ?: throw ExpectedException("프로젝트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+        if (reqDto.endYear < project.startYear) {
+            throw ExpectedException("종료 연도는 시작 연도보다 크거나 같아야 합니다.", HttpStatus.BAD_REQUEST)
+        }
+        project.status = ProjectStatus.ENDED
+        project.endYear = reqDto.endYear
+    }
+}

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/ModifyProjectServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/ModifyProjectServiceImpl.kt
@@ -60,6 +60,7 @@ class ModifyProjectServiceImpl(
 
         project.name = reqDto.name
         project.description = reqDto.description
+        project.startYear = reqDto.startYear
         project.club = ownerClub
         project.participants = newParticipants
 
@@ -67,6 +68,9 @@ class ModifyProjectServiceImpl(
             id = project.id!!,
             name = project.name,
             description = project.description,
+            startYear = project.startYear,
+            endYear = project.endYear,
+            status = project.status,
             club = project.club?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
             participants =
                 project.participants.map { student ->

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/QueryProjectServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/QueryProjectServiceImpl.kt
@@ -22,6 +22,7 @@ class QueryProjectServiceImpl(
                 id = queryReq.projectId,
                 name = queryReq.projectName,
                 clubId = queryReq.clubId,
+                status = queryReq.status,
                 pageable = PageRequest.of(queryReq.page, queryReq.size),
                 sortBy = queryReq.sortBy,
                 sortDirection = queryReq.sortDirection,
@@ -36,6 +37,9 @@ class QueryProjectServiceImpl(
                         id = project.id!!,
                         name = project.name,
                         description = project.description,
+                        startYear = project.startYear,
+                        endYear = project.endYear,
+                        status = project.status,
                         club = project.club?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
                         participants =
                             project.participants.map { student ->

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/ReactivateProjectServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/ReactivateProjectServiceImpl.kt
@@ -1,0 +1,24 @@
+package team.themoment.datagsm.openapi.domain.project.service.impl
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
+import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
+import team.themoment.datagsm.openapi.domain.project.service.ReactivateProjectService
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class ReactivateProjectServiceImpl(
+    private val projectJpaRepository: ProjectJpaRepository,
+) : ReactivateProjectService {
+    @Transactional
+    override fun execute(projectId: Long) {
+        val project =
+            projectJpaRepository.findByIdOrNull(projectId)
+                ?: throw ExpectedException("프로젝트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+        project.status = ProjectStatus.ACTIVE
+        project.endYear = null
+    }
+}

--- a/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/CreateProjectServiceTest.kt
+++ b/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/CreateProjectServiceTest.kt
@@ -236,6 +236,70 @@ class CreateProjectServiceTest :
                         verify(exactly = 0) { mockProjectRepository.save(any()) }
                     }
                 }
+
+                context("ENDED 상태로 프로젝트를 생성할 때") {
+                    val createRequest =
+                        ProjectReqDto(
+                            name = "종료된 프로젝트",
+                            description = "이미 종료된 프로젝트입니다",
+                            startYear = 2022,
+                            clubId = null,
+                            participantIds = emptyList(),
+                            status = ProjectStatus.ENDED,
+                            endYear = 2023,
+                        )
+
+                    val savedProject =
+                        ProjectJpaEntity().apply {
+                            id = 3L
+                            name = createRequest.name
+                            description = createRequest.description
+                            startYear = createRequest.startYear
+                            status = ProjectStatus.ENDED
+                            endYear = 2023
+                        }
+
+                    beforeEach {
+                        every { mockProjectRepository.existsByName(createRequest.name) } returns false
+                        every { mockProjectRepository.save(any()) } returns savedProject
+                    }
+
+                    it("ENDED 상태와 endYear가 설정된 프로젝트가 생성되어야 한다") {
+                        val result = createProjectService.execute(createRequest)
+
+                        result.status shouldBe ProjectStatus.ENDED
+                        result.endYear shouldBe 2023
+
+                        verify(exactly = 1) { mockProjectRepository.save(any()) }
+                    }
+                }
+
+                context("ENDED 상태이지만 endYear 없이 생성 요청할 때") {
+                    val createRequest =
+                        ProjectReqDto(
+                            name = "종료연도없는프로젝트",
+                            description = "종료 연도가 없는 프로젝트입니다",
+                            startYear = 2022,
+                            clubId = null,
+                            participantIds = emptyList(),
+                            status = ProjectStatus.ENDED,
+                        )
+
+                    beforeEach {
+                        every { mockProjectRepository.existsByName(createRequest.name) } returns false
+                    }
+
+                    it("ExpectedException이 발생해야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                createProjectService.execute(createRequest)
+                            }
+
+                        exception.message shouldBe "종료 연도를 입력해주세요."
+
+                        verify(exactly = 0) { mockProjectRepository.save(any()) }
+                    }
+                }
             }
         }
     })

--- a/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/CreateProjectServiceTest.kt
+++ b/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/CreateProjectServiceTest.kt
@@ -12,6 +12,7 @@ import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
 import team.themoment.datagsm.common.domain.project.dto.request.ProjectReqDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
@@ -40,6 +41,7 @@ class CreateProjectServiceTest :
                         ProjectReqDto(
                             name = "DataGSM 프로젝트",
                             description = "학교 데이터를 제공하는 API 서비스",
+                            startYear = 2024,
                             clubId = 1L,
                             participantIds = emptyList(),
                         )
@@ -56,6 +58,8 @@ class CreateProjectServiceTest :
                             id = 1L
                             name = createRequest.name
                             description = createRequest.description
+                            startYear = createRequest.startYear
+                            status = ProjectStatus.ACTIVE
                             this.club = ownerClub
                         }
 
@@ -71,6 +75,9 @@ class CreateProjectServiceTest :
                         result.id shouldBe 1L
                         result.name shouldBe "DataGSM 프로젝트"
                         result.description shouldBe "학교 데이터를 제공하는 API 서비스"
+                        result.startYear shouldBe 2024
+                        result.endYear shouldBe null
+                        result.status shouldBe ProjectStatus.ACTIVE
                         result.club?.id shouldBe 1L
                         result.club?.name shouldBe "SW개발동아리"
                         result.club?.type shouldBe ClubType.MAJOR_CLUB
@@ -87,6 +94,7 @@ class CreateProjectServiceTest :
                         ProjectReqDto(
                             name = "중복프로젝트",
                             description = "중복된 프로젝트입니다",
+                            startYear = 2024,
                             clubId = 1L,
                             participantIds = emptyList(),
                         )
@@ -114,6 +122,7 @@ class CreateProjectServiceTest :
                         ProjectReqDto(
                             name = "신규프로젝트",
                             description = "신규 프로젝트입니다",
+                            startYear = 2024,
                             clubId = 999L,
                             participantIds = emptyList(),
                         )
@@ -150,6 +159,7 @@ class CreateProjectServiceTest :
                         ProjectReqDto(
                             name = "참여자 있는 프로젝트",
                             description = "참여자가 있는 프로젝트입니다",
+                            startYear = 2024,
                             clubId = 1L,
                             participantIds = listOf(1L),
                         )
@@ -166,6 +176,8 @@ class CreateProjectServiceTest :
                             id = 2L
                             name = createRequest.name
                             description = createRequest.description
+                            startYear = createRequest.startYear
+                            status = ProjectStatus.ACTIVE
                             this.club = ownerClub
                             this.participants = mutableSetOf(participant)
                         }
@@ -189,46 +201,12 @@ class CreateProjectServiceTest :
                     }
                 }
 
-                context("동아리 없이 프로젝트를 생성할 때") {
-                    val createRequest =
-                        ProjectReqDto(
-                            name = "동아리없는프로젝트",
-                            description = "동아리가 없는 프로젝트입니다",
-                            clubId = null,
-                            participantIds = emptyList(),
-                        )
-
-                    val savedProject =
-                        ProjectJpaEntity().apply {
-                            id = 3L
-                            name = createRequest.name
-                            description = createRequest.description
-                            this.club = null
-                        }
-
-                    beforeEach {
-                        every { mockProjectRepository.existsByName(createRequest.name) } returns false
-                        every { mockProjectRepository.save(any()) } returns savedProject
-                    }
-
-                    it("동아리 없이 프로젝트가 생성되어야 한다") {
-                        val result = createProjectService.execute(createRequest)
-
-                        result.id shouldBe 3L
-                        result.name shouldBe "동아리없는프로젝트"
-                        result.club shouldBe null
-
-                        verify(exactly = 1) { mockProjectRepository.existsByName(createRequest.name) }
-                        verify(exactly = 0) { mockClubRepository.findById(any()) }
-                        verify(exactly = 1) { mockProjectRepository.save(any()) }
-                    }
-                }
-
                 context("존재하지 않는 참여자 ID로 생성 요청할 때") {
                     val createRequest =
                         ProjectReqDto(
                             name = "잘못된 참여자 프로젝트",
                             description = "존재하지 않는 참여자를 포함한 프로젝트입니다",
+                            startYear = 2024,
                             clubId = 1L,
                             participantIds = listOf(999L),
                         )

--- a/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/EndProjectServiceTest.kt
+++ b/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/EndProjectServiceTest.kt
@@ -1,0 +1,124 @@
+package team.themoment.datagsm.openapi.domain.project.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import team.themoment.datagsm.common.domain.project.dto.request.EndProjectReqDto
+import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
+import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
+import team.themoment.datagsm.openapi.domain.project.service.impl.EndProjectServiceImpl
+import team.themoment.sdk.exception.ExpectedException
+
+class EndProjectServiceTest :
+    DescribeSpec({
+
+        val mockProjectRepository = mockk<ProjectJpaRepository>()
+
+        val endProjectService = EndProjectServiceImpl(mockProjectRepository)
+
+        describe("EndProjectService 클래스의") {
+            describe("execute 메서드는") {
+
+                context("운영 중인 프로젝트를 종료 처리할 때") {
+                    val project =
+                        ProjectJpaEntity().apply {
+                            id = 1L
+                            name = "DataGSM 프로젝트"
+                            description = "학교 데이터 API"
+                            startYear = 2023
+                            status = ProjectStatus.ACTIVE
+                        }
+
+                    val reqDto = EndProjectReqDto(endYear = 2025)
+
+                    beforeEach {
+                        every { mockProjectRepository.findById(1L) } returns java.util.Optional.of(project)
+                    }
+
+                    it("status가 ENDED로 변경되고 endYear가 설정되어야 한다") {
+                        endProjectService.execute(1L, reqDto)
+
+                        project.status shouldBe ProjectStatus.ENDED
+                        project.endYear shouldBe 2025
+
+                        verify(exactly = 1) { mockProjectRepository.findById(1L) }
+                    }
+                }
+
+                context("종료 연도가 시작 연도와 같을 때") {
+                    val project =
+                        ProjectJpaEntity().apply {
+                            id = 2L
+                            name = "단기 프로젝트"
+                            description = "1년 프로젝트"
+                            startYear = 2024
+                            status = ProjectStatus.ACTIVE
+                        }
+
+                    val reqDto = EndProjectReqDto(endYear = 2024)
+
+                    beforeEach {
+                        every { mockProjectRepository.findById(2L) } returns java.util.Optional.of(project)
+                    }
+
+                    it("정상적으로 종료 처리되어야 한다") {
+                        endProjectService.execute(2L, reqDto)
+
+                        project.status shouldBe ProjectStatus.ENDED
+                        project.endYear shouldBe 2024
+                    }
+                }
+
+                context("종료 연도가 시작 연도보다 작을 때") {
+                    val project =
+                        ProjectJpaEntity().apply {
+                            id = 3L
+                            name = "DataGSM 프로젝트"
+                            description = "학교 데이터 API"
+                            startYear = 2025
+                            status = ProjectStatus.ACTIVE
+                        }
+
+                    val reqDto = EndProjectReqDto(endYear = 2024)
+
+                    beforeEach {
+                        every { mockProjectRepository.findById(3L) } returns java.util.Optional.of(project)
+                    }
+
+                    it("ExpectedException이 발생해야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                endProjectService.execute(3L, reqDto)
+                            }
+
+                        exception.message shouldBe "종료 연도는 시작 연도보다 크거나 같아야 합니다."
+
+                        verify(exactly = 1) { mockProjectRepository.findById(3L) }
+                    }
+                }
+
+                context("존재하지 않는 프로젝트를 종료 처리할 때") {
+                    val reqDto = EndProjectReqDto(endYear = 2025)
+
+                    beforeEach {
+                        every { mockProjectRepository.findById(999L) } returns java.util.Optional.empty()
+                    }
+
+                    it("ExpectedException이 발생해야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                endProjectService.execute(999L, reqDto)
+                            }
+
+                        exception.message shouldBe "프로젝트를 찾을 수 없습니다."
+
+                        verify(exactly = 1) { mockProjectRepository.findById(999L) }
+                    }
+                }
+            }
+        }
+    })

--- a/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/ModifyProjectServiceTest.kt
+++ b/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/ModifyProjectServiceTest.kt
@@ -11,6 +11,7 @@ import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
 import team.themoment.datagsm.common.domain.project.dto.request.ProjectReqDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
@@ -54,6 +55,8 @@ class ModifyProjectServiceTest :
                             this.id = projectId
                             name = "기존프로젝트"
                             description = "기존 설명"
+                            startYear = 2023
+                            status = ProjectStatus.ACTIVE
                             this.club = ownerClub
                         }
                 }
@@ -63,6 +66,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "수정된프로젝트",
                             description = "기존 설명",
+                            startYear = 2023,
                             clubId = 1L,
                             participantIds = emptyList(),
                         )
@@ -84,6 +88,7 @@ class ModifyProjectServiceTest :
                         result.id shouldBe projectId
                         result.name shouldBe "수정된프로젝트"
                         result.description shouldBe "기존 설명"
+                        result.startYear shouldBe 2023
                         result.participants shouldBe emptyList()
 
                         verify(exactly = 1) { mockProjectRepository.findById(projectId) }
@@ -102,6 +107,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "수정프로젝트",
                             description = "설명",
+                            startYear = 2024,
                             clubId = 1L,
                             participantIds = emptyList(),
                         )
@@ -136,6 +142,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "기존프로젝트",
                             description = "기존 설명",
+                            startYear = 2023,
                             clubId = 1L,
                             participantIds = listOf(1L),
                         )
@@ -168,6 +175,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "기존프로젝트",
                             description = "기존 설명",
+                            startYear = 2023,
                             clubId = null,
                             participantIds = emptyList(),
                         )
@@ -196,6 +204,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "기존프로젝트",
                             description = "기존 설명",
+                            startYear = 2023,
                             clubId = 1L,
                             participantIds = listOf(999L),
                         )

--- a/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/QueryProjectServiceTest.kt
+++ b/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/QueryProjectServiceTest.kt
@@ -12,6 +12,7 @@ import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.project.dto.request.QueryProjectReqDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentNumber
@@ -44,6 +45,8 @@ class QueryProjectServiceTest :
                         id = 1L
                         name = "DataGSM 프로젝트"
                         description = "학교 데이터를 제공하는 API 서비스"
+                        startYear = 2024
+                        status = ProjectStatus.ACTIVE
                         club = testClub
                     }
 
@@ -54,6 +57,7 @@ class QueryProjectServiceTest :
                                 id = 1L,
                                 name = null,
                                 clubId = null,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 100),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -73,6 +77,9 @@ class QueryProjectServiceTest :
                         project.id shouldBe 1L
                         project.name shouldBe "DataGSM 프로젝트"
                         project.description shouldBe "학교 데이터를 제공하는 API 서비스"
+                        project.startYear shouldBe 2024
+                        project.endYear shouldBe null
+                        project.status shouldBe ProjectStatus.ACTIVE
                         project.club?.id shouldBe 1L
                         project.club?.name shouldBe "SW개발동아리"
                         project.club?.type shouldBe ClubType.MAJOR_CLUB
@@ -83,6 +90,7 @@ class QueryProjectServiceTest :
                                 id = 1L,
                                 name = null,
                                 clubId = null,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 100),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -98,6 +106,7 @@ class QueryProjectServiceTest :
                                 id = null,
                                 name = "DataGSM",
                                 clubId = null,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 100),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -121,6 +130,7 @@ class QueryProjectServiceTest :
                                 id = null,
                                 name = null,
                                 clubId = 1L,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 100),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -135,6 +145,41 @@ class QueryProjectServiceTest :
                         result.totalElements shouldBe 1L
                         result.projects[0].club?.id shouldBe 1L
                         result.projects[0].club?.name shouldBe "SW개발동아리"
+                    }
+                }
+
+                context("status=ENDED 필터로 종료된 프로젝트를 검색할 때") {
+                    val endedProject =
+                        ProjectJpaEntity().apply {
+                            id = 5L
+                            name = "종료된 프로젝트"
+                            description = "운영이 종료된 프로젝트"
+                            startYear = 2022
+                            endYear = 2023
+                            status = ProjectStatus.ENDED
+                        }
+
+                    beforeEach {
+                        every {
+                            mockProjectRepository.searchProjectWithPaging(
+                                id = null,
+                                name = null,
+                                clubId = null,
+                                status = ProjectStatus.ENDED,
+                                pageable = PageRequest.of(0, 100),
+                                sortBy = any(),
+                                sortDirection = any(),
+                            )
+                        } returns PageImpl(listOf(endedProject), PageRequest.of(0, 100), 1L)
+                    }
+
+                    it("종료된 프로젝트가 반환되어야 한다") {
+                        val queryReq = QueryProjectReqDto(status = ProjectStatus.ENDED)
+                        val result = queryProjectService.execute(queryReq)
+
+                        result.totalElements shouldBe 1L
+                        result.projects[0].status shouldBe ProjectStatus.ENDED
+                        result.projects[0].endYear shouldBe 2023
                     }
                 }
 
@@ -153,6 +198,8 @@ class QueryProjectServiceTest :
                             id = 2L
                             name = "참여자있는프로젝트"
                             description = "학생들이 참여하는 프로젝트"
+                            startYear = 2024
+                            status = ProjectStatus.ACTIVE
                             club = testClub
                             participants = mutableSetOf(student)
                         }
@@ -163,6 +210,7 @@ class QueryProjectServiceTest :
                                 id = 2L,
                                 name = null,
                                 clubId = null,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 100),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -192,6 +240,7 @@ class QueryProjectServiceTest :
                                 id = 999L,
                                 name = null,
                                 clubId = null,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 100),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -215,6 +264,8 @@ class QueryProjectServiceTest :
                             id = 3L
                             name = "독립프로젝트"
                             description = "동아리에 속하지 않은 프로젝트"
+                            startYear = 2024
+                            status = ProjectStatus.ACTIVE
                             club = null
                         }
 
@@ -224,6 +275,7 @@ class QueryProjectServiceTest :
                                 id = 3L,
                                 name = null,
                                 clubId = null,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 100),
                                 sortBy = any(),
                                 sortDirection = any(),

--- a/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/ReactivateProjectServiceTest.kt
+++ b/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/ReactivateProjectServiceTest.kt
@@ -1,0 +1,90 @@
+package team.themoment.datagsm.openapi.domain.project.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
+import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
+import team.themoment.datagsm.openapi.domain.project.service.impl.ReactivateProjectServiceImpl
+import team.themoment.sdk.exception.ExpectedException
+
+class ReactivateProjectServiceTest :
+    DescribeSpec({
+
+        val mockProjectRepository = mockk<ProjectJpaRepository>()
+
+        val reactivateProjectService = ReactivateProjectServiceImpl(mockProjectRepository)
+
+        describe("ReactivateProjectService 클래스의") {
+            describe("execute 메서드는") {
+
+                context("종료된 프로젝트를 운영 재개할 때") {
+                    val project =
+                        ProjectJpaEntity().apply {
+                            id = 1L
+                            name = "DataGSM 프로젝트"
+                            description = "학교 데이터 API"
+                            startYear = 2023
+                            endYear = 2024
+                            status = ProjectStatus.ENDED
+                        }
+
+                    beforeEach {
+                        every { mockProjectRepository.findById(1L) } returns java.util.Optional.of(project)
+                    }
+
+                    it("status가 ACTIVE로 변경되고 endYear가 null로 초기화되어야 한다") {
+                        reactivateProjectService.execute(1L)
+
+                        project.status shouldBe ProjectStatus.ACTIVE
+                        project.endYear shouldBe null
+
+                        verify(exactly = 1) { mockProjectRepository.findById(1L) }
+                    }
+                }
+
+                context("이미 운영 중인 프로젝트를 운영 재개 요청할 때") {
+                    val project =
+                        ProjectJpaEntity().apply {
+                            id = 2L
+                            name = "운영중 프로젝트"
+                            description = "이미 운영 중인 프로젝트"
+                            startYear = 2024
+                            status = ProjectStatus.ACTIVE
+                        }
+
+                    beforeEach {
+                        every { mockProjectRepository.findById(2L) } returns java.util.Optional.of(project)
+                    }
+
+                    it("status는 ACTIVE로 유지되고 endYear는 null로 설정되어야 한다") {
+                        reactivateProjectService.execute(2L)
+
+                        project.status shouldBe ProjectStatus.ACTIVE
+                        project.endYear shouldBe null
+                    }
+                }
+
+                context("존재하지 않는 프로젝트를 운영 재개 요청할 때") {
+                    beforeEach {
+                        every { mockProjectRepository.findById(999L) } returns java.util.Optional.empty()
+                    }
+
+                    it("ExpectedException이 발생해야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                reactivateProjectService.execute(999L)
+                            }
+
+                        exception.message shouldBe "프로젝트를 찾을 수 없습니다."
+
+                        verify(exactly = 1) { mockProjectRepository.findById(999L) }
+                    }
+                }
+            }
+        }
+    })

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/controller/ProjectController.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/controller/ProjectController.kt
@@ -16,14 +16,17 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import team.themoment.datagsm.common.domain.project.dto.request.EndProjectReqDto
 import team.themoment.datagsm.common.domain.project.dto.request.ProjectReqDto
 import team.themoment.datagsm.common.domain.project.dto.request.QueryProjectReqDto
 import team.themoment.datagsm.common.domain.project.dto.response.ProjectListResDto
 import team.themoment.datagsm.common.domain.project.dto.response.ProjectResDto
 import team.themoment.datagsm.web.domain.project.service.CreateProjectService
 import team.themoment.datagsm.web.domain.project.service.DeleteProjectService
+import team.themoment.datagsm.web.domain.project.service.EndProjectService
 import team.themoment.datagsm.web.domain.project.service.ModifyProjectService
 import team.themoment.datagsm.web.domain.project.service.QueryProjectService
+import team.themoment.datagsm.web.domain.project.service.ReactivateProjectService
 
 @Tag(name = "Project", description = "프로젝트 관련 API")
 @RestController
@@ -33,6 +36,8 @@ class ProjectController(
     private val createProjectService: CreateProjectService,
     private val modifyProjectService: ModifyProjectService,
     private val deleteProjectService: DeleteProjectService,
+    private val endProjectService: EndProjectService,
+    private val reactivateProjectService: ReactivateProjectService,
 ) {
     @Operation(summary = "프로젝트 정보 조회", description = "필터 조건에 맞는 프로젝트 정보를 조회합니다.")
     @ApiResponses(
@@ -74,6 +79,32 @@ class ProjectController(
         @Parameter(description = "프로젝트 ID") @PathVariable projectId: Long,
         @RequestBody @Valid reqDto: ProjectReqDto,
     ): ProjectResDto = modifyProjectService.execute(projectId, reqDto)
+
+    @Operation(summary = "프로젝트 종료", description = "운영 중인 프로젝트를 종료 처리합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "종료 처리 성공"),
+            ApiResponse(responseCode = "400", description = "잘못된 요청 (검증 실패 또는 종료 연도 오류)", content = [Content()]),
+            ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음", content = [Content()]),
+        ],
+    )
+    @PostMapping("/{projectId}/end")
+    fun endProject(
+        @Parameter(description = "프로젝트 ID") @PathVariable projectId: Long,
+        @RequestBody @Valid reqDto: EndProjectReqDto,
+    ) = endProjectService.execute(projectId, reqDto)
+
+    @Operation(summary = "프로젝트 운영 재개", description = "종료된 프로젝트를 다시 운영 중 상태로 변경합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "운영 재개 성공"),
+            ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음", content = [Content()]),
+        ],
+    )
+    @PostMapping("/{projectId}/reactivate")
+    fun reactivateProject(
+        @Parameter(description = "프로젝트 ID") @PathVariable projectId: Long,
+    ) = reactivateProjectService.execute(projectId)
 
     @Operation(summary = "프로젝트 삭제", description = "기존 프로젝트를 삭제합니다.")
     @ApiResponses(

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/EndProjectService.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/EndProjectService.kt
@@ -1,0 +1,10 @@
+package team.themoment.datagsm.web.domain.project.service
+
+import team.themoment.datagsm.common.domain.project.dto.request.EndProjectReqDto
+
+interface EndProjectService {
+    fun execute(
+        projectId: Long,
+        reqDto: EndProjectReqDto,
+    )
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/ReactivateProjectService.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/ReactivateProjectService.kt
@@ -1,0 +1,5 @@
+package team.themoment.datagsm.web.domain.project.service
+
+interface ReactivateProjectService {
+    fun execute(projectId: Long)
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/CreateProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/CreateProjectServiceImpl.kt
@@ -8,6 +8,7 @@ import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
 import team.themoment.datagsm.common.domain.project.dto.request.ProjectReqDto
 import team.themoment.datagsm.common.domain.project.dto.response.ProjectResDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
 import team.themoment.datagsm.common.domain.student.dto.internal.ParticipantInfoDto
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
@@ -58,6 +59,8 @@ class CreateProjectServiceImpl(
             ProjectJpaEntity().apply {
                 name = projectReqDto.name
                 description = projectReqDto.description
+                startYear = projectReqDto.startYear
+                status = ProjectStatus.ACTIVE
                 this.club = ownerClub
                 this.participants = participants
             }
@@ -67,6 +70,9 @@ class CreateProjectServiceImpl(
             id = savedProjectEntity.id!!,
             name = savedProjectEntity.name,
             description = savedProjectEntity.description,
+            startYear = savedProjectEntity.startYear,
+            endYear = savedProjectEntity.endYear,
+            status = savedProjectEntity.status,
             club = ownerClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
             participants =
                 savedProjectEntity.participants.map { student ->

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/CreateProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/CreateProjectServiceImpl.kt
@@ -55,12 +55,22 @@ class CreateProjectServiceImpl(
                 mutableSetOf()
             }
 
+        if (projectReqDto.status == ProjectStatus.ENDED) {
+            val endYear =
+                projectReqDto.endYear
+                    ?: throw ExpectedException("종료 연도를 입력해주세요.", HttpStatus.BAD_REQUEST)
+            if (endYear < projectReqDto.startYear) {
+                throw ExpectedException("종료 연도는 시작 연도보다 크거나 같아야 합니다.", HttpStatus.BAD_REQUEST)
+            }
+        }
+
         val projectEntity =
             ProjectJpaEntity().apply {
                 name = projectReqDto.name
                 description = projectReqDto.description
                 startYear = projectReqDto.startYear
-                status = ProjectStatus.ACTIVE
+                status = projectReqDto.status
+                endYear = projectReqDto.endYear
                 this.club = ownerClub
                 this.participants = participants
             }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/EndProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/EndProjectServiceImpl.kt
@@ -1,0 +1,31 @@
+package team.themoment.datagsm.web.domain.project.service.impl
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.project.dto.request.EndProjectReqDto
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
+import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
+import team.themoment.datagsm.web.domain.project.service.EndProjectService
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class EndProjectServiceImpl(
+    private val projectJpaRepository: ProjectJpaRepository,
+) : EndProjectService {
+    @Transactional
+    override fun execute(
+        projectId: Long,
+        reqDto: EndProjectReqDto,
+    ) {
+        val project =
+            projectJpaRepository
+                .findById(projectId)
+                .orElseThrow { ExpectedException("프로젝트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
+        if (reqDto.endYear < project.startYear) {
+            throw ExpectedException("종료 연도는 시작 연도보다 크거나 같아야 합니다.", HttpStatus.BAD_REQUEST)
+        }
+        project.status = ProjectStatus.ENDED
+        project.endYear = reqDto.endYear
+    }
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/EndProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/EndProjectServiceImpl.kt
@@ -1,5 +1,6 @@
 package team.themoment.datagsm.web.domain.project.service.impl
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -19,9 +20,8 @@ class EndProjectServiceImpl(
         reqDto: EndProjectReqDto,
     ) {
         val project =
-            projectJpaRepository
-                .findById(projectId)
-                .orElseThrow { ExpectedException("프로젝트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
+            projectJpaRepository.findByIdOrNull(projectId)
+                ?: throw ExpectedException("프로젝트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
         if (reqDto.endYear < project.startYear) {
             throw ExpectedException("종료 연도는 시작 연도보다 크거나 같아야 합니다.", HttpStatus.BAD_REQUEST)
         }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ModifyProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ModifyProjectServiceImpl.kt
@@ -62,6 +62,7 @@ class ModifyProjectServiceImpl(
 
         project.name = reqDto.name
         project.description = reqDto.description
+        project.startYear = reqDto.startYear
         project.club = ownerClub
         project.participants = newParticipants
 
@@ -69,6 +70,9 @@ class ModifyProjectServiceImpl(
             id = project.id!!,
             name = project.name,
             description = project.description,
+            startYear = project.startYear,
+            endYear = project.endYear,
+            status = project.status,
             club = project.club?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
             participants =
                 project.participants.map { student ->

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/QueryProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/QueryProjectServiceImpl.kt
@@ -22,6 +22,7 @@ class QueryProjectServiceImpl(
                 id = queryReq.projectId,
                 name = queryReq.projectName,
                 clubId = queryReq.clubId,
+                status = queryReq.status,
                 pageable = PageRequest.of(queryReq.page, queryReq.size),
                 sortBy = queryReq.sortBy,
                 sortDirection = queryReq.sortDirection,
@@ -36,6 +37,9 @@ class QueryProjectServiceImpl(
                         id = project.id!!,
                         name = project.name,
                         description = project.description,
+                        startYear = project.startYear,
+                        endYear = project.endYear,
+                        status = project.status,
                         club = project.club?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
                         participants =
                             project.participants.map { student ->

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ReactivateProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ReactivateProjectServiceImpl.kt
@@ -1,0 +1,24 @@
+package team.themoment.datagsm.web.domain.project.service.impl
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
+import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
+import team.themoment.datagsm.web.domain.project.service.ReactivateProjectService
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class ReactivateProjectServiceImpl(
+    private val projectJpaRepository: ProjectJpaRepository,
+) : ReactivateProjectService {
+    @Transactional
+    override fun execute(projectId: Long) {
+        val project =
+            projectJpaRepository
+                .findById(projectId)
+                .orElseThrow { ExpectedException("프로젝트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
+        project.status = ProjectStatus.ACTIVE
+        project.endYear = null
+    }
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ReactivateProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ReactivateProjectServiceImpl.kt
@@ -1,5 +1,6 @@
 package team.themoment.datagsm.web.domain.project.service.impl
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,9 +16,8 @@ class ReactivateProjectServiceImpl(
     @Transactional
     override fun execute(projectId: Long) {
         val project =
-            projectJpaRepository
-                .findById(projectId)
-                .orElseThrow { ExpectedException("프로젝트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
+            projectJpaRepository.findByIdOrNull(projectId)
+                ?: throw ExpectedException("프로젝트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
         project.status = ProjectStatus.ACTIVE
         project.endYear = null
     }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/CreateProjectServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/CreateProjectServiceTest.kt
@@ -12,6 +12,7 @@ import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
 import team.themoment.datagsm.common.domain.project.dto.request.ProjectReqDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
@@ -40,6 +41,7 @@ class CreateProjectServiceTest :
                         ProjectReqDto(
                             name = "DataGSM 프로젝트",
                             description = "학교 데이터를 제공하는 API 서비스",
+                            startYear = 2024,
                             clubId = 1L,
                             participantIds = emptyList(),
                         )
@@ -56,6 +58,8 @@ class CreateProjectServiceTest :
                             id = 1L
                             name = createRequest.name
                             description = createRequest.description
+                            startYear = createRequest.startYear
+                            status = ProjectStatus.ACTIVE
                             this.club = ownerClub
                         }
 
@@ -71,6 +75,9 @@ class CreateProjectServiceTest :
                         result.id shouldBe 1L
                         result.name shouldBe "DataGSM 프로젝트"
                         result.description shouldBe "학교 데이터를 제공하는 API 서비스"
+                        result.startYear shouldBe 2024
+                        result.endYear shouldBe null
+                        result.status shouldBe ProjectStatus.ACTIVE
                         result.club?.id shouldBe 1L
                         result.club?.name shouldBe "SW개발동아리"
                         result.club?.type shouldBe ClubType.MAJOR_CLUB
@@ -87,6 +94,7 @@ class CreateProjectServiceTest :
                         ProjectReqDto(
                             name = "중복프로젝트",
                             description = "중복된 프로젝트입니다",
+                            startYear = 2024,
                             clubId = 1L,
                             participantIds = emptyList(),
                         )
@@ -114,6 +122,7 @@ class CreateProjectServiceTest :
                         ProjectReqDto(
                             name = "신규프로젝트",
                             description = "신규 프로젝트입니다",
+                            startYear = 2024,
                             clubId = 999L,
                             participantIds = emptyList(),
                         )
@@ -142,6 +151,7 @@ class CreateProjectServiceTest :
                         ProjectReqDto(
                             name = "자율동아리 프로젝트",
                             description = "자율동아리 프로젝트입니다",
+                            startYear = 2024,
                             clubId = 2L,
                             participantIds = emptyList(),
                         )
@@ -158,6 +168,8 @@ class CreateProjectServiceTest :
                             id = 2L
                             name = createRequest.name
                             description = createRequest.description
+                            startYear = createRequest.startYear
+                            status = ProjectStatus.ACTIVE
                             this.club = ownerClub
                         }
 
@@ -189,6 +201,7 @@ class CreateProjectServiceTest :
                         ProjectReqDto(
                             name = "참여자 있는 프로젝트",
                             description = "참여자가 있는 프로젝트입니다",
+                            startYear = 2024,
                             clubId = 1L,
                             participantIds = listOf(1L),
                         )
@@ -205,6 +218,8 @@ class CreateProjectServiceTest :
                             id = 3L
                             name = createRequest.name
                             description = createRequest.description
+                            startYear = createRequest.startYear
+                            status = ProjectStatus.ACTIVE
                             this.club = ownerClub
                             this.participants = mutableSetOf(participant)
                         }
@@ -233,6 +248,7 @@ class CreateProjectServiceTest :
                         ProjectReqDto(
                             name = "동아리없는프로젝트",
                             description = "동아리가 없는 프로젝트입니다",
+                            startYear = 2024,
                             clubId = null,
                             participantIds = emptyList(),
                         )
@@ -242,6 +258,8 @@ class CreateProjectServiceTest :
                             id = 4L
                             name = createRequest.name
                             description = createRequest.description
+                            startYear = createRequest.startYear
+                            status = ProjectStatus.ACTIVE
                             this.club = null
                         }
 
@@ -268,6 +286,7 @@ class CreateProjectServiceTest :
                         ProjectReqDto(
                             name = "잘못된 참여자 프로젝트",
                             description = "존재하지 않는 참여자를 포함한 프로젝트입니다",
+                            startYear = 2024,
                             clubId = 1L,
                             participantIds = listOf(999L),
                         )

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/CreateProjectServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/CreateProjectServiceTest.kt
@@ -316,6 +316,70 @@ class CreateProjectServiceTest :
                         verify(exactly = 0) { mockProjectRepository.save(any()) }
                     }
                 }
+
+                context("ENDED 상태로 프로젝트를 생성할 때") {
+                    val createRequest =
+                        ProjectReqDto(
+                            name = "종료된 프로젝트",
+                            description = "이미 종료된 프로젝트입니다",
+                            startYear = 2022,
+                            clubId = null,
+                            participantIds = emptyList(),
+                            status = ProjectStatus.ENDED,
+                            endYear = 2023,
+                        )
+
+                    val savedProject =
+                        ProjectJpaEntity().apply {
+                            id = 5L
+                            name = createRequest.name
+                            description = createRequest.description
+                            startYear = createRequest.startYear
+                            status = ProjectStatus.ENDED
+                            endYear = 2023
+                        }
+
+                    beforeEach {
+                        every { mockProjectRepository.existsByName(createRequest.name) } returns false
+                        every { mockProjectRepository.save(any()) } returns savedProject
+                    }
+
+                    it("ENDED 상태와 endYear가 설정된 프로젝트가 생성되어야 한다") {
+                        val result = createProjectService.execute(createRequest)
+
+                        result.status shouldBe ProjectStatus.ENDED
+                        result.endYear shouldBe 2023
+
+                        verify(exactly = 1) { mockProjectRepository.save(any()) }
+                    }
+                }
+
+                context("ENDED 상태이지만 endYear 없이 생성 요청할 때") {
+                    val createRequest =
+                        ProjectReqDto(
+                            name = "종료연도없는프로젝트",
+                            description = "종료 연도가 없는 프로젝트입니다",
+                            startYear = 2022,
+                            clubId = null,
+                            participantIds = emptyList(),
+                            status = ProjectStatus.ENDED,
+                        )
+
+                    beforeEach {
+                        every { mockProjectRepository.existsByName(createRequest.name) } returns false
+                    }
+
+                    it("ExpectedException이 발생해야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                createProjectService.execute(createRequest)
+                            }
+
+                        exception.message shouldBe "종료 연도를 입력해주세요."
+
+                        verify(exactly = 0) { mockProjectRepository.save(any()) }
+                    }
+                }
             }
         }
     })

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/EndProjectServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/EndProjectServiceTest.kt
@@ -1,0 +1,125 @@
+package team.themoment.datagsm.web.domain.project.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import team.themoment.datagsm.common.domain.project.dto.request.EndProjectReqDto
+import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
+import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
+import team.themoment.datagsm.web.domain.project.service.impl.EndProjectServiceImpl
+import team.themoment.sdk.exception.ExpectedException
+import java.util.Optional
+
+class EndProjectServiceTest :
+    DescribeSpec({
+
+        val mockProjectRepository = mockk<ProjectJpaRepository>()
+
+        val endProjectService = EndProjectServiceImpl(mockProjectRepository)
+
+        describe("EndProjectService 클래스의") {
+            describe("execute 메서드는") {
+
+                context("운영 중인 프로젝트를 종료 처리할 때") {
+                    val project =
+                        ProjectJpaEntity().apply {
+                            id = 1L
+                            name = "DataGSM 프로젝트"
+                            description = "학교 데이터 API"
+                            startYear = 2023
+                            status = ProjectStatus.ACTIVE
+                        }
+
+                    val reqDto = EndProjectReqDto(endYear = 2025)
+
+                    beforeEach {
+                        every { mockProjectRepository.findById(1L) } returns Optional.of(project)
+                    }
+
+                    it("status가 ENDED로 변경되고 endYear가 설정되어야 한다") {
+                        endProjectService.execute(1L, reqDto)
+
+                        project.status shouldBe ProjectStatus.ENDED
+                        project.endYear shouldBe 2025
+
+                        verify(exactly = 1) { mockProjectRepository.findById(1L) }
+                    }
+                }
+
+                context("종료 연도가 시작 연도와 같을 때") {
+                    val project =
+                        ProjectJpaEntity().apply {
+                            id = 2L
+                            name = "단기 프로젝트"
+                            description = "1년 프로젝트"
+                            startYear = 2024
+                            status = ProjectStatus.ACTIVE
+                        }
+
+                    val reqDto = EndProjectReqDto(endYear = 2024)
+
+                    beforeEach {
+                        every { mockProjectRepository.findById(2L) } returns Optional.of(project)
+                    }
+
+                    it("정상적으로 종료 처리되어야 한다") {
+                        endProjectService.execute(2L, reqDto)
+
+                        project.status shouldBe ProjectStatus.ENDED
+                        project.endYear shouldBe 2024
+                    }
+                }
+
+                context("종료 연도가 시작 연도보다 작을 때") {
+                    val project =
+                        ProjectJpaEntity().apply {
+                            id = 3L
+                            name = "DataGSM 프로젝트"
+                            description = "학교 데이터 API"
+                            startYear = 2025
+                            status = ProjectStatus.ACTIVE
+                        }
+
+                    val reqDto = EndProjectReqDto(endYear = 2024)
+
+                    beforeEach {
+                        every { mockProjectRepository.findById(3L) } returns Optional.of(project)
+                    }
+
+                    it("ExpectedException이 발생해야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                endProjectService.execute(3L, reqDto)
+                            }
+
+                        exception.message shouldBe "종료 연도는 시작 연도보다 크거나 같아야 합니다."
+
+                        verify(exactly = 1) { mockProjectRepository.findById(3L) }
+                    }
+                }
+
+                context("존재하지 않는 프로젝트를 종료 처리할 때") {
+                    val reqDto = EndProjectReqDto(endYear = 2025)
+
+                    beforeEach {
+                        every { mockProjectRepository.findById(999L) } returns Optional.empty()
+                    }
+
+                    it("ExpectedException이 발생해야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                endProjectService.execute(999L, reqDto)
+                            }
+
+                        exception.message shouldBe "프로젝트를 찾을 수 없습니다."
+
+                        verify(exactly = 1) { mockProjectRepository.findById(999L) }
+                    }
+                }
+            }
+        }
+    })

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/ModifyProjectServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/ModifyProjectServiceTest.kt
@@ -11,6 +11,7 @@ import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
 import team.themoment.datagsm.common.domain.project.dto.request.ProjectReqDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
@@ -54,6 +55,8 @@ class ModifyProjectServiceTest :
                             this.id = projectId
                             name = "기존프로젝트"
                             description = "기존 설명"
+                            startYear = 2023
+                            status = ProjectStatus.ACTIVE
                             this.club = ownerClub
                         }
                 }
@@ -63,6 +66,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "수정된프로젝트",
                             description = "기존 설명",
+                            startYear = 2023,
                             clubId = 1L,
                             participantIds = emptyList(),
                         )
@@ -84,6 +88,7 @@ class ModifyProjectServiceTest :
                         result.id shouldBe projectId
                         result.name shouldBe "수정된프로젝트"
                         result.description shouldBe "기존 설명"
+                        result.startYear shouldBe 2023
                         result.participants shouldBe emptyList()
 
                         verify(exactly = 1) { mockProjectRepository.findById(projectId) }
@@ -102,6 +107,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "기존프로젝트",
                             description = "새로운 설명입니다",
+                            startYear = 2023,
                             clubId = 1L,
                             participantIds = emptyList(),
                         )
@@ -135,6 +141,34 @@ class ModifyProjectServiceTest :
                     }
                 }
 
+                context("프로젝트의 시작 연도를 변경할 때") {
+                    val updateRequest =
+                        ProjectReqDto(
+                            name = "기존프로젝트",
+                            description = "기존 설명",
+                            startYear = 2022,
+                            clubId = 1L,
+                            participantIds = emptyList(),
+                        )
+
+                    beforeEach {
+                        every { mockProjectRepository.findById(projectId) } returns Optional.of(existingProject)
+                        every {
+                            mockProjectRepository.existsByNameAndIdNot(
+                                updateRequest.name,
+                                projectId,
+                            )
+                        } returns false
+                        every { mockClubRepository.findById(1L) } returns Optional.of(ownerClub)
+                    }
+
+                    it("프로젝트 시작 연도가 변경되어야 한다") {
+                        val result = modifyProjectService.execute(projectId, updateRequest)
+
+                        result.startYear shouldBe 2022
+                    }
+                }
+
                 context("프로젝트의 소유 동아리를 변경할 때") {
                     val newClub =
                         ClubJpaEntity().apply {
@@ -147,6 +181,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "기존프로젝트",
                             description = "기존 설명",
+                            startYear = 2023,
                             clubId = 2L,
                             participantIds = emptyList(),
                         )
@@ -192,6 +227,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "완전새로운프로젝트",
                             description = "완전 새로운 설명",
+                            startYear = 2025,
                             clubId = 3L,
                             participantIds = emptyList(),
                         )
@@ -212,6 +248,7 @@ class ModifyProjectServiceTest :
 
                         result.name shouldBe "완전새로운프로젝트"
                         result.description shouldBe "완전 새로운 설명"
+                        result.startYear shouldBe 2025
                         result.club?.id shouldBe 3L
                         result.club?.name shouldBe "완전새로운동아리"
                         result.club?.type shouldBe ClubType.AUTONOMOUS_CLUB
@@ -231,6 +268,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "수정프로젝트",
                             description = "설명",
+                            startYear = 2024,
                             clubId = 1L,
                             participantIds = emptyList(),
                         )
@@ -257,6 +295,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "중복프로젝트",
                             description = "기존 설명",
+                            startYear = 2023,
                             clubId = 1L,
                             participantIds = emptyList(),
                         )
@@ -293,6 +332,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "기존프로젝트",
                             description = "기존 설명",
+                            startYear = 2023,
                             clubId = 999L,
                             participantIds = emptyList(),
                         )
@@ -339,6 +379,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "기존프로젝트",
                             description = "기존 설명",
+                            startYear = 2023,
                             clubId = 1L,
                             participantIds = listOf(1L),
                         )
@@ -371,6 +412,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "기존프로젝트",
                             description = "기존 설명",
+                            startYear = 2023,
                             clubId = null,
                             participantIds = emptyList(),
                         )
@@ -399,6 +441,7 @@ class ModifyProjectServiceTest :
                         ProjectReqDto(
                             name = "기존프로젝트",
                             description = "기존 설명",
+                            startYear = 2023,
                             clubId = 1L,
                             participantIds = listOf(999L),
                         )

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/QueryProjectServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/QueryProjectServiceTest.kt
@@ -12,6 +12,7 @@ import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.project.dto.request.QueryProjectReqDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
 import team.themoment.datagsm.web.domain.project.service.impl.QueryProjectServiceImpl
 
@@ -41,6 +42,8 @@ class QueryProjectServiceTest :
                         id = 1L
                         name = "DataGSM 프로젝트"
                         description = "학교 데이터를 제공하는 API 서비스"
+                        startYear = 2024
+                        status = ProjectStatus.ACTIVE
                         club = testClub
                     }
 
@@ -51,6 +54,7 @@ class QueryProjectServiceTest :
                                 id = 1L,
                                 name = null,
                                 clubId = null,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 20),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -75,6 +79,9 @@ class QueryProjectServiceTest :
                         project.id shouldBe 1L
                         project.name shouldBe "DataGSM 프로젝트"
                         project.description shouldBe "학교 데이터를 제공하는 API 서비스"
+                        project.startYear shouldBe 2024
+                        project.endYear shouldBe null
+                        project.status shouldBe ProjectStatus.ACTIVE
                         project.club?.id shouldBe 1L
                         project.club?.name shouldBe "SW개발동아리"
                         project.club?.type shouldBe ClubType.MAJOR_CLUB
@@ -85,6 +92,7 @@ class QueryProjectServiceTest :
                                 id = 1L,
                                 name = null,
                                 clubId = null,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 20),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -100,6 +108,7 @@ class QueryProjectServiceTest :
                                 id = null,
                                 name = "DataGSM",
                                 clubId = null,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 20),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -128,6 +137,7 @@ class QueryProjectServiceTest :
                                 id = null,
                                 name = null,
                                 clubId = 1L,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 20),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -150,6 +160,46 @@ class QueryProjectServiceTest :
                     }
                 }
 
+                context("status=ENDED 필터로 종료된 프로젝트를 검색할 때") {
+                    val endedProject =
+                        ProjectJpaEntity().apply {
+                            id = 2L
+                            name = "종료된 프로젝트"
+                            description = "운영이 종료된 프로젝트"
+                            startYear = 2022
+                            endYear = 2023
+                            status = ProjectStatus.ENDED
+                        }
+
+                    beforeEach {
+                        every {
+                            mockProjectRepository.searchProjectWithPaging(
+                                id = null,
+                                name = null,
+                                clubId = null,
+                                status = ProjectStatus.ENDED,
+                                pageable = PageRequest.of(0, 20),
+                                sortBy = any(),
+                                sortDirection = any(),
+                            )
+                        } returns PageImpl(listOf(endedProject), PageRequest.of(0, 20), 1L)
+                    }
+
+                    it("종료된 프로젝트가 반환되어야 한다") {
+                        val queryReq =
+                            QueryProjectReqDto(
+                                status = ProjectStatus.ENDED,
+                                page = 0,
+                                size = 20,
+                            )
+                        val result = queryProjectService.execute(queryReq)
+
+                        result.totalElements shouldBe 1L
+                        result.projects[0].status shouldBe ProjectStatus.ENDED
+                        result.projects[0].endYear shouldBe 2023
+                    }
+                }
+
                 context("프로젝트 이름과 동아리 ID로 다중 조건 검색할 때") {
                     beforeEach {
                         every {
@@ -157,6 +207,7 @@ class QueryProjectServiceTest :
                                 id = null,
                                 name = "DataGSM",
                                 clubId = 1L,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 20),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -187,6 +238,7 @@ class QueryProjectServiceTest :
                                 id = 999L,
                                 name = null,
                                 clubId = null,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 20),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -222,6 +274,8 @@ class QueryProjectServiceTest :
                             id = 2L
                             name = "모바일앱 프로젝트"
                             description = "학생 편의 모바일 앱"
+                            startYear = 2025
+                            status = ProjectStatus.ACTIVE
                             club = club2
                         }
 
@@ -231,6 +285,7 @@ class QueryProjectServiceTest :
                                 id = null,
                                 name = null,
                                 clubId = null,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 10),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -257,6 +312,7 @@ class QueryProjectServiceTest :
                                 id = null,
                                 name = null,
                                 clubId = null,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 10),
                                 sortBy = any(),
                                 sortDirection = any(),
@@ -278,6 +334,8 @@ class QueryProjectServiceTest :
                             id = 3L
                             name = "취업 포트폴리오"
                             description = "전공 동아리 프로젝트"
+                            startYear = 2024
+                            status = ProjectStatus.ACTIVE
                             club = majorClub
                         }
 
@@ -287,6 +345,7 @@ class QueryProjectServiceTest :
                                 id = null,
                                 name = null,
                                 clubId = 3L,
+                                status = ProjectStatus.ACTIVE,
                                 pageable = PageRequest.of(0, 20),
                                 sortBy = any(),
                                 sortDirection = any(),

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/ReactivateProjectServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/ReactivateProjectServiceTest.kt
@@ -1,0 +1,91 @@
+package team.themoment.datagsm.web.domain.project.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
+import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
+import team.themoment.datagsm.web.domain.project.service.impl.ReactivateProjectServiceImpl
+import team.themoment.sdk.exception.ExpectedException
+import java.util.Optional
+
+class ReactivateProjectServiceTest :
+    DescribeSpec({
+
+        val mockProjectRepository = mockk<ProjectJpaRepository>()
+
+        val reactivateProjectService = ReactivateProjectServiceImpl(mockProjectRepository)
+
+        describe("ReactivateProjectService 클래스의") {
+            describe("execute 메서드는") {
+
+                context("종료된 프로젝트를 운영 재개할 때") {
+                    val project =
+                        ProjectJpaEntity().apply {
+                            id = 1L
+                            name = "DataGSM 프로젝트"
+                            description = "학교 데이터 API"
+                            startYear = 2023
+                            endYear = 2024
+                            status = ProjectStatus.ENDED
+                        }
+
+                    beforeEach {
+                        every { mockProjectRepository.findById(1L) } returns Optional.of(project)
+                    }
+
+                    it("status가 ACTIVE로 변경되고 endYear가 null로 초기화되어야 한다") {
+                        reactivateProjectService.execute(1L)
+
+                        project.status shouldBe ProjectStatus.ACTIVE
+                        project.endYear shouldBe null
+
+                        verify(exactly = 1) { mockProjectRepository.findById(1L) }
+                    }
+                }
+
+                context("이미 운영 중인 프로젝트를 운영 재개 요청할 때") {
+                    val project =
+                        ProjectJpaEntity().apply {
+                            id = 2L
+                            name = "운영중 프로젝트"
+                            description = "이미 운영 중인 프로젝트"
+                            startYear = 2024
+                            status = ProjectStatus.ACTIVE
+                        }
+
+                    beforeEach {
+                        every { mockProjectRepository.findById(2L) } returns Optional.of(project)
+                    }
+
+                    it("status는 ACTIVE로 유지되고 endYear는 null로 설정되어야 한다") {
+                        reactivateProjectService.execute(2L)
+
+                        project.status shouldBe ProjectStatus.ACTIVE
+                        project.endYear shouldBe null
+                    }
+                }
+
+                context("존재하지 않는 프로젝트를 운영 재개 요청할 때") {
+                    beforeEach {
+                        every { mockProjectRepository.findById(999L) } returns Optional.empty()
+                    }
+
+                    it("ExpectedException이 발생해야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                reactivateProjectService.execute(999L)
+                            }
+
+                        exception.message shouldBe "프로젝트를 찾을 수 없습니다."
+
+                        verify(exactly = 1) { mockProjectRepository.findById(999L) }
+                    }
+                }
+            }
+        }
+    })

--- a/migration/migrate_project_status.sql
+++ b/migration/migrate_project_status.sql
@@ -1,0 +1,7 @@
+-- Issue #294: 프로젝트 운영 상태 관리 추가
+-- tb_project 테이블에 start_year, end_year, status 컬럼 추가
+
+ALTER TABLE tb_project
+    ADD COLUMN start_year INT         NOT NULL DEFAULT 0,
+    ADD COLUMN end_year   INT         NULL,
+    ADD COLUMN status     VARCHAR(10) NOT NULL DEFAULT 'ACTIVE';

--- a/migration/migrate_project_status.sql
+++ b/migration/migrate_project_status.sql
@@ -1,7 +1,0 @@
--- Issue #294: 프로젝트 운영 상태 관리 추가
--- tb_project 테이블에 start_year, end_year, status 컬럼 추가
-
-ALTER TABLE tb_project
-    ADD COLUMN start_year INT         NOT NULL DEFAULT 0,
-    ADD COLUMN end_year   INT         NULL,
-    ADD COLUMN status     VARCHAR(10) NOT NULL DEFAULT 'ACTIVE';


### PR DESCRIPTION
## 개요

프로젝트의 생명주기를 관리하기 위해 운영 상태(`ACTIVE`, `ENDED`) 필드와 프로젝트의 기간을 나타내는 시작/종료 연도 필드를 추가하고 관련 API를 구현하였습니다.

## 본문

- `ProjectJpaEntity`에 `startYear`, `endYear`, `status` 필드를 추가하고 `ProjectStatus` Enum을 정의하였습니다.
- 운영 중인 프로젝트를 종료 처리하는 `EndProjectService`와 종료된 프로젝트를 다시 활성화하는 `ReactivateProjectService`를 구현하였습니다.
- `ProjectController`에 프로젝트 종료(`POST /v1/project/{projectId}/end`) 및 운영 재개(`POST /v1/project/{projectId}/reactivate`) 엔드포인트를 추가하였습니다.
- 프로젝트 생성 및 수정 시 `startYear`를 입력받도록 `ProjectReqDto`를 수정하고, 조회 시 필터링이 가능하도록 `QueryProjectReqDto`에 `status` 필드를 추가하였습니다.
- `datagsm-openapi`와 `datagsm-web` 모듈 모두에 해당 기능을 적용하고 서비스 레이어에 대한 단위 테스트를 작성하여 검증을 완료하였습니다.
- 기존 테이블 구조 변경을 위한 SQL 마이그레이션 스크립트를 `migration/migrate_project_status.sql`에 작성하였습니다.
