### PR TITLE
[global] `review-pr` 스킬에서 커밋 해시를 7자리로 사용하도록 설정 및 push 스텝 추가

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: review-pr
 description: Collect PR review comments, critically assess each one against project conventions, auto-apply valid ones, post refutation replies for invalid ones, and prompt for partial ones. Replaces resolve-pr-comments.
 compatibility: Requires git, gh (GitHub CLI), and jq
-allowed-tools: Bash(bash *get-pr-data.sh:*), Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git rev-parse:*), Bash(rm:*), Edit, Read
+allowed-tools: Bash(bash *get-pr-data.sh:*), Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git push:*), Bash(git rev-parse:*), Bash(rm:*), Edit, Read
 ---
 
 ## Step 1 — Collect PR Data
@@ -52,7 +52,7 @@ Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`
 3. If the changes have not been committed yet, commit them
 4. Record the short commit hash for use in Step 5:
    ```bash
-   git rev-parse --short HEAD
+   git rev-parse --short=7 HEAD
    ```
 
 On failure: record the reason and fall back to PARTIAL.
@@ -88,7 +88,15 @@ Accept? (y / n / s = skip for now)
 | 3 | alice | Baz.kt:56 | ⚠️ PARTIAL | - | PENDING |
 ```
 
-## Step 5 — Post GitHub Replies
+## Step 5 — Push Commits
+
+If any VALID fixes were committed in Step 3, push them before posting replies so the referenced commit hashes are visible on GitHub:
+
+```bash
+git push
+```
+
+## Step 6 — Post GitHub Replies
 
 Post an inline reply for each comment. Always quote `path` and `comment_id` to prevent shell injection.
 
@@ -99,7 +107,7 @@ gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
 
 For reply body templates, read `references/reply-formats.md`.
 
-## Step 6 — Cleanup
+## Step 7 — Cleanup
 
 ```bash
 rm -rf .pr-tmp

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: review-pr
 description: Collect PR review comments, critically assess each one against project conventions, auto-apply valid ones, post refutation replies for invalid ones, and prompt for partial ones. Replaces resolve-pr-comments.
 disable-model-invocation: true
-allowed-tools: Bash(bash *get-pr-data.sh:*), Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git rev-parse:*), Bash(rm:*), Edit, Read
+allowed-tools: Bash(bash *get-pr-data.sh:*), Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git push:*), Bash(git rev-parse:*), Bash(rm:*), Edit, Read
 ---
 
 ## Step 1 — Collect PR Data
@@ -62,7 +62,7 @@ Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`
 3. If the changes have not been committed yet, commit them
 4. Record the short commit hash for use in Step 5:
    ```bash
-   git rev-parse --short HEAD
+   git rev-parse --short=8 HEAD
    ```
 
 On failure: record the reason and fall back to PARTIAL.
@@ -98,7 +98,15 @@ Accept? (y / n / s = skip for now)
 | 3 | alice | Baz.kt:56 | ⚠️ PARTIAL | - | PENDING |
 ```
 
-## Step 5 — Post GitHub Replies
+## Step 5 — Push Commits
+
+If any VALID fixes were committed in Step 3, push them before posting replies so the referenced commit hashes are visible on GitHub:
+
+```bash
+git push
+```
+
+## Step 6 — Post GitHub Replies
 
 Post an inline reply for each comment. Always quote `path` and `comment_id` to prevent shell injection.
 
@@ -109,7 +117,7 @@ gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
 
 For reply body templates, read `${CLAUDE_SKILL_DIR}/references/reply-formats.md`.
 
-## Step 6 — Cleanup
+## Step 7 — Cleanup
 
 ```bash
 rm -rf .pr-tmp

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -62,7 +62,7 @@ Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`
 3. If the changes have not been committed yet, commit them
 4. Record the short commit hash for use in Step 5:
    ```bash
-   git rev-parse --short=8 HEAD
+   git rev-parse --short=7 HEAD
    ```
 
 On failure: record the reason and fall back to PARTIAL.

--- a/.claude/skills/review-pr/references/reply-formats.md
+++ b/.claude/skills/review-pr/references/reply-formats.md
@@ -7,7 +7,7 @@ All replies must be written in Korean.
 ## VALID — fix succeeded
 
 ```
-<abc1234> 에서 반영했습니다. (근거: <출처>)
+<abc12345> 에서 반영했습니다. (근거: <출처>)
 ```
 
 ## VALID — fix failed

--- a/.claude/skills/review-pr/references/reply-formats.md
+++ b/.claude/skills/review-pr/references/reply-formats.md
@@ -7,7 +7,7 @@ All replies must be written in Korean.
 ## VALID — fix succeeded
 
 ```
-<abc12345> 에서 반영했습니다. (근거: <출처>)
+<abc1234> 에서 반영했습니다. (근거: <출처>)
 ```
 
 ## VALID — fix failed


### PR DESCRIPTION
## 개요

`review-pr` 스킬의 두 가지 문제를 수정하였습니다. 인라인 코멘트 게시 전 `git push`가 누락되어 GitHub에서 커밋 해시를 확인할 수 없었던 문제와, 커밋 해시가 8자리로 출력되던 문제를 교정하였습니다.

## 본문

### `git push` 스텝 추가

기존 플로우에서는 VALID 판정 수정 사항을 커밋한 뒤 곧바로 GitHub 인라인 코멘트를 게시하였습니다. 이 경우 커밋이 원격에 푸시되지 않은 상태에서 해시를 답글에 포함하게 되어, 리뷰어가 해당 커밋을 GitHub에서 확인할 수 없었습니다.

`SKILL.md`에 **Step 5 — Push Commits**를 신규 삽입하여, VALID 수정 커밋이 존재할 경우 `git push`를 먼저 실행한 뒤 인라인 코멘트를 게시하도록 순서를 변경하였습니다. 기존 Step 5·6은 각각 Step 6·7로 번호가 조정되었습니다. 또한 `allowed-tools`에 `Bash(git push:*)`를 추가하여 스킬 실행 시 권한 오류가 발생하지 않도록 하였습니다.

### 커밋 해시 7자리로 명시

`git rev-parse --short HEAD`는 기본값인 7자리 해시를 출력합니다. 기존에 `--short` 옵션이 잘못 적용되어 8자리 해시가 출력되던 문제를 `--short=7`로 수정하였습니다. `reply-formats.md`의 예시 플레이스홀더도 `<abc1234>`(7자)로 통일하였습니다.