### PR TITLE
[global] `Codex` 훅과 스킬 탐색 개선

### DIFF
--- a/.agents/scripts/discover-domains.sh
+++ b/.agents/scripts/discover-domains.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Discover domain names from the project's domain directory structure.
+# Works on Linux and macOS (POSIX-compatible).
+find . -type d -path "*/domain/*" \
+  ! -path "*/build/*" \
+  ! -path "*/test/*" \
+  ! -path "*/.gradle/*" \
+  | awk -F'/domain/' 'NF>1 { split($NF, a, "/"); print a[1] }' \
+  | sort -u

--- a/.agents/scripts/discover-modules.sh
+++ b/.agents/scripts/discover-modules.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-# Discover module names from settings.gradle.kts.
-# Strips the 'datagsm-' prefix. Works on Linux and macOS (POSIX-compatible).
-grep 'include' settings.gradle.kts \
-  | grep -oE '"[^"]+"' \
-  | tr -d '"' \
-  | sed 's/^datagsm-//'

--- a/.agents/scripts/discover-modules.sh
+++ b/.agents/scripts/discover-modules.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Discover module names from settings.gradle.kts.
+# Strips the 'datagsm-' prefix. Works on Linux and macOS (POSIX-compatible).
+grep 'include' settings.gradle.kts \
+  | grep -oE '"[^"]+"' \
+  | tr -d '"' \
+  | sed 's/^datagsm-//'

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -37,8 +37,8 @@ Format: `type(scope): 설명`
 
 - **Types**: `add` / `update` / `fix` / `refactor` / `ci/cd` / `docs` / `test` / `merge` (English)
 - **Scopes** (English):
-  - **Primary**: Domain names (`account`, `application`, `auth`, `client`, `club`, `neis`, `oauth`, `project`, `student`, `utility`)
-  - **Cross-cutting concerns only**: Module names (`web`, `oauth`, `openapi`) or `global`
+  - **Primary**: Domain names — discover at runtime: `sh .agents/scripts/discover-domains.sh`
+  - **Cross-cutting concerns only**: Module names (without `datagsm-` prefix) or `global`
   - Use domain names by default. Only use module names when changes affect multiple modules or are cross-cutting.
 - **Description**: Korean, no period, avoid endings: `~한다/~된다`, `~하기/~하기 위해`, `~합니다/~됩니다`, `~했습니다`
   - Good examples: `엔티티 필드 추가`, `트랜잭션 롤백 방지`, `로직 개선`
@@ -49,7 +49,7 @@ Format: `type(scope): 설명`
 
 For the full scope selection table and examples, read `references/scope-guide.md`.
 
-Quick rule: use domain name (`auth`, `application`, `student`, `club`, `neis`, etc.) by default. Use `global` / `ci/cd` / module names only for cross-cutting changes.
+Quick rule: run `sh .agents/scripts/discover-domains.sh` to get available domains, then pick the one matching the changed files. Use `global` / `ci/cd` / module names only for cross-cutting changes.
 
 ## Commit Flow
 

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -37,7 +37,7 @@ Format: `type(scope): 설명`
 
 - **Types**: `add` / `update` / `fix` / `refactor` / `ci/cd` / `docs` / `test` / `merge` (English)
 - **Scopes** (English):
-  - **Primary**: Domain names — discover at runtime: `sh .agents/scripts/discover-domains.sh`
+  - **Primary**: Domain names — discover at runtime: `sh scripts/discover-domains.sh`
   - **Cross-cutting concerns only**: Module names (without `datagsm-` prefix) or `global`
   - Use domain names by default. Only use module names when changes affect multiple modules or are cross-cutting.
 - **Description**: Korean, no period, avoid endings: `~한다/~된다`, `~하기/~하기 위해`, `~합니다/~됩니다`, `~했습니다`
@@ -49,7 +49,7 @@ Format: `type(scope): 설명`
 
 For the full scope selection table and examples, read `references/scope-guide.md`.
 
-Quick rule: run `sh .agents/scripts/discover-domains.sh` to get available domains, then pick the one matching the changed files. Use `global` / `ci/cd` / module names only for cross-cutting changes.
+Quick rule: run `sh scripts/discover-domains.sh` to get available domains, then pick the one matching the changed files. Use `global` / `ci/cd` / module names only for cross-cutting changes.
 
 ## Commit Flow
 

--- a/.agents/skills/commit/references/scope-guide.md
+++ b/.agents/skills/commit/references/scope-guide.md
@@ -6,29 +6,33 @@
 
 Always use a domain name. Only fall back to a module name when the change is genuinely cross-cutting (affects multiple domains or the entire module).
 
-## Domain Names (Primary)
+## Discover Domains at Runtime
 
-| Scope         | When to use                |
-|---------------|----------------------------|
-| `account`     | Account management         |
-| `application` | Registered API application |
-| `auth`        | Authentication, API keys   |
-| `client`      | OAuth client               |
-| `club`        | Club / project information |
-| `neis`        | NEIS integration           |
-| `oauth`       | OAuth2 flow                |
-| `project`     | Project information        |
-| `student`     | Student information        |
-| `utility`     | Shared utilities           |
+Run this before selecting a scope — do not use a hardcoded list:
+
+```bash
+sh .agents/scripts/discover-domains.sh
+```
+
+Use the output as the candidate domain scope list.
+
+## Discover Modules at Runtime
+
+Run this to get the module list (strips `datagsm-` prefix for use as scope):
+
+```bash
+sh .agents/scripts/discover-modules.sh
+```
+
+Module scopes are secondary — use only when changes are cross-cutting across multiple domains within that module.
 
 ## Module / Cross-cutting Names (Secondary)
 
-| Scope     | When to use                                         |
-|-----------|-----------------------------------------------------|
-| `global`  | Affects multiple modules                            |
-| `ci/cd`   | Build / deployment pipelines                        |
-| `web`     | Changes scoped to the entire datagsm-web module     |
-| `openapi` | Changes scoped to the entire datagsm-openapi module |
+| Scope      | When to use                        |
+|------------|------------------------------------|
+| `global`   | Affects multiple modules           |
+| `ci/cd`    | Build / deployment pipelines       |
+| (module)   | Changes scoped to an entire module (use name without `datagsm-` prefix) |
 
 ## Wrong vs Correct Examples
 

--- a/.agents/skills/commit/references/scope-guide.md
+++ b/.agents/skills/commit/references/scope-guide.md
@@ -11,7 +11,7 @@ Always use a domain name. Only fall back to a module name when the change is gen
 Run this before selecting a scope — do not use a hardcoded list:
 
 ```bash
-sh .agents/scripts/discover-domains.sh
+sh .agents/skills/commit/scripts/discover-domains.sh
 ```
 
 Use the output as the candidate domain scope list.
@@ -21,18 +21,18 @@ Use the output as the candidate domain scope list.
 Run this to get the module list (strips `datagsm-` prefix for use as scope):
 
 ```bash
-sh .agents/scripts/discover-modules.sh
+sh .agents/skills/commit/scripts/discover-modules.sh
 ```
 
 Module scopes are secondary — use only when changes are cross-cutting across multiple domains within that module.
 
 ## Module / Cross-cutting Names (Secondary)
 
-| Scope      | When to use                        |
-|------------|------------------------------------|
-| `global`   | Affects multiple modules           |
-| `ci/cd`    | Build / deployment pipelines       |
-| (module)   | Changes scoped to an entire module (use name without `datagsm-` prefix) |
+| Scope    | When to use                                                             |
+|----------|-------------------------------------------------------------------------|
+| `global` | Affects multiple modules                                                |
+| `ci/cd`  | Build / deployment pipelines                                            |
+| (module) | Changes scoped to an entire module (use name without `datagsm-` prefix) |
 
 ## Wrong vs Correct Examples
 

--- a/.agents/skills/commit/scripts/discover-domains.sh
+++ b/.agents/skills/commit/scripts/discover-domains.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
-# Discover domain names from the project's domain directory structure.
-# Works on Linux and macOS (POSIX-compatible).
 find . -type d -path "*/domain/*" \
   ! -path "*/build/*" \
   ! -path "*/test/*" \

--- a/.agents/skills/commit/scripts/discover-modules.sh
+++ b/.agents/skills/commit/scripts/discover-modules.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+grep 'include' settings.gradle.kts \
+  | grep -oE '"[^"]+"' \
+  | tr -d '"' \
+  | sed 's/^datagsm-//'

--- a/.agents/skills/commit/scripts/discover-modules.sh
+++ b/.agents/skills/commit/scripts/discover-modules.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-grep 'include' settings.gradle.kts \
+grep '^[[:space:]]*include' settings.gradle.kts \
   | grep -oE '"[^"]+"' \
   | tr -d '"' \
   | sed 's/^datagsm-//'

--- a/.agents/skills/kotest-guide/SKILL.md
+++ b/.agents/skills/kotest-guide/SKILL.md
@@ -125,5 +125,5 @@ context("API 키가 존재하지 않는 경우") {
 
 Discover real test examples dynamically:
 ```bash
-find . -name "*ServiceTest.kt" -not -path "*/build/*" | head -5
+find . -name "*ServiceTest.kt" ! -path "*/build/*" | head -5
 ```

--- a/.agents/skills/kotlin-spring-arch/SKILL.md
+++ b/.agents/skills/kotlin-spring-arch/SKILL.md
@@ -69,7 +69,7 @@ val student = studentRepository.findById(id).orElseThrow {
 Do not create custom exception subclasses extending `ExpectedException`.
 
 ### Global Handler
-See `datagsm-common/.../global/common/error/GlobalExceptionHandler.kt`
+Locate with: `find . -name "GlobalExceptionHandler.kt" ! -path "*/build/*"`
 
 ## DTO Conversion Pattern
 

--- a/.agents/skills/migration-guide/SKILL.md
+++ b/.agents/skills/migration-guide/SKILL.md
@@ -14,7 +14,7 @@ description: Guide for DB schema changes and Entity modifications — impact ana
 
 ## Change Order
 
-1. **Modify Entity**: `datagsm-common/.../domain/`
+1. **Modify Entity**: locate domain directory with `find . -type d -name "domain" -path "*/main/*" ! -path "*/build/*"`
 2. **Modify DTO**: ReqDto, ResDto
 3. **Modify Repository**: Adjust QueryDSL queries if needed
 4. **Modify Service**: Update business logic

--- a/.agents/skills/security-checklist/SKILL.md
+++ b/.agents/skills/security-checklist/SKILL.md
@@ -54,5 +54,9 @@ grep -rE "['\"]([A-Za-z0-9+/]{40,}={0,2})['\"]" --include="*.kt"
 
 ## References
 
-- `datagsm-oauth-authorization/.../auth/service/ApiKeyService.kt` - API Key security example
-- `datagsm-common/.../global/common/security/` - Security configuration
+Locate reference files at runtime:
+
+```bash
+find . -name "ApiKeyService.kt" ! -path "*/build/*"
+find . -type d -name "security" -path "*/main/*" ! -path "*/build/*"
+```

--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -8,13 +8,18 @@ allowed-tools: Bash, Glob, Grep
 
 Based on the user's request or changed files, choose the appropriate scope:
 
-| Scope | Command |
-|-------|---------|
+| Scope               | Command                                              |
+|---------------------|------------------------------------------------------|
 | Specific test class | `./gradlew test --tests "fully.qualified.ClassName"` |
-| Specific module | `./gradlew :<module>:test` |
-| All modules | `./gradlew test` |
+| Specific module     | `./gradlew :<module>:test`                           |
+| All modules         | `./gradlew test`                                     |
 
-Available modules: `datagsm-common`, `datagsm-oauth-authorization`, `datagsm-oauth-userinfo`, `datagsm-openapi`, `datagsm-web`
+Discover available modules at runtime (full name for Gradle commands, no `datagsm-` prefix for display):
+
+```bash
+sh .agents/scripts/discover-modules.sh   # display names (prefix stripped)
+grep 'include' settings.gradle.kts | grep -oE '"[^"]+"' | tr -d '"'  # full names for :module:test
+```
 
 ## Run Tests
 

--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -18,7 +18,7 @@ Discover available modules at runtime (full name for Gradle commands, no `datags
 
 ```bash
 sh scripts/discover-modules.sh   # display names (prefix stripped)
-grep 'include' settings.gradle.kts | grep -oE '"[^"]+"' | tr -d '"'  # full names for :module:test
+grep '^[[:space:]]*include' settings.gradle.kts | grep -oE '"[^"]+"' | tr -d '"'  # full names for :module:test
 ```
 
 ## Run Tests

--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -17,7 +17,7 @@ Based on the user's request or changed files, choose the appropriate scope:
 Discover available modules at runtime (full name for Gradle commands, no `datagsm-` prefix for display):
 
 ```bash
-sh .agents/scripts/discover-modules.sh   # display names (prefix stripped)
+sh scripts/discover-modules.sh   # display names (prefix stripped)
 grep 'include' settings.gradle.kts | grep -oE '"[^"]+"' | tr -d '"'  # full names for :module:test
 ```
 

--- a/.agents/skills/test/scripts/discover-modules.sh
+++ b/.agents/skills/test/scripts/discover-modules.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+grep 'include' settings.gradle.kts \
+  | grep -oE '"[^"]+"' \
+  | tr -d '"' \
+  | sed 's/^datagsm-//'

--- a/.agents/skills/test/scripts/discover-modules.sh
+++ b/.agents/skills/test/scripts/discover-modules.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-grep 'include' settings.gradle.kts \
+grep '^[[:space:]]*include' settings.gradle.kts \
   | grep -oE '"[^"]+"' \
   | tr -d '"' \
   | sed 's/^datagsm-//'

--- a/.agents/skills/write-pr/SKILL.md
+++ b/.agents/skills/write-pr/SKILL.md
@@ -26,7 +26,7 @@ Read `references/labels.md` and select 1–2 appropriate labels based on the nat
 ## Step 3 — Generate PR Content
 
 **Title** — Generate 3 options in the format `[scope] description`:
-- Scope: domain name (`[account]`, `[application]`, `[auth]`, `[client]`, `[club]`, `[neis]`, `[oauth]`, `[project]`, `[student]`, `[utility]`) or `[global]` / `[ci/cd]` for cross-cutting changes
+- Scope: determine from changed files — run `sh .agents/scripts/discover-domains.sh` to get the current domain list, then pick the one matching the changes. Use `[global]` / `[ci/cd]` for cross-cutting changes only. Wrap in brackets: `[auth]`, `[student]`, etc.
 - Description: Korean, concise, no emojis, max 50 characters total
 - Wrap class names, method names, annotations, and technical terms in backticks (e.g., `@Transactional`, `StudentServiceImpl`)
 

--- a/.agents/skills/write-pr/SKILL.md
+++ b/.agents/skills/write-pr/SKILL.md
@@ -26,7 +26,7 @@ Read `references/labels.md` and select 1–2 appropriate labels based on the nat
 ## Step 3 — Generate PR Content
 
 **Title** — Generate 3 options in the format `[scope] description`:
-- Scope: determine from changed files — run `sh .agents/scripts/discover-domains.sh` to get the current domain list, then pick the one matching the changes. Use `[global]` / `[ci/cd]` for cross-cutting changes only. Wrap in brackets: `[auth]`, `[student]`, etc.
+- Scope: determine from changed files — run `sh scripts/discover-domains.sh` to get the current domain list, then pick the one matching the changes. Use `[global]` / `[ci/cd]` for cross-cutting changes only. Wrap in brackets: `[auth]`, `[student]`, etc.
 - Description: Korean, concise, no emojis, max 50 characters total
 - Wrap class names, method names, annotations, and technical terms in backticks (e.g., `@Transactional`, `StudentServiceImpl`)
 

--- a/.agents/skills/write-pr/scripts/discover-domains.sh
+++ b/.agents/skills/write-pr/scripts/discover-domains.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+find . -type d -path "*/domain/*" \
+  ! -path "*/build/*" \
+  ! -path "*/test/*" \
+  ! -path "*/.gradle/*" \
+  | awk -F'/domain/' 'NF>1 { split($NF, a, "/"); print a[1] }' \
+  | sort -u

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -49,5 +49,5 @@
     "context7@claude-plugins-official": true
   },
   "language": "korean",
-  "effortLevel": "medium"
+  "effortLevel": "high"
 }

--- a/.claude/skills/commit/references/scope-guide.md
+++ b/.claude/skills/commit/references/scope-guide.md
@@ -11,7 +11,7 @@ Always use a domain name. Only fall back to a module name when the change is gen
 Run this before selecting a scope — do not use a hardcoded list:
 
 ```bash
-sh .agents/scripts/discover-domains.sh
+sh "${CLAUDE_SKILL_DIR}/scripts/discover-domains.sh"
 ```
 
 Use the output as the candidate domain scope list.
@@ -21,7 +21,7 @@ Use the output as the candidate domain scope list.
 Run this to get the module list (strips `datagsm-` prefix for use as scope):
 
 ```bash
-sh .agents/scripts/discover-modules.sh
+sh "${CLAUDE_SKILL_DIR}/scripts/discover-modules.sh"
 ```
 
 Module scopes are secondary — use only when changes are cross-cutting across multiple domains within that module.

--- a/.claude/skills/commit/references/scope-guide.md
+++ b/.claude/skills/commit/references/scope-guide.md
@@ -6,29 +6,33 @@
 
 Always use a domain name. Only fall back to a module name when the change is genuinely cross-cutting (affects multiple domains or the entire module).
 
-## Domain Names (Primary)
+## Discover Domains at Runtime
 
-| Scope         | When to use                |
-|---------------|----------------------------|
-| `account`     | Account management         |
-| `application` | Registered API application |
-| `auth`        | Authentication, API keys   |
-| `client`      | OAuth client               |
-| `club`        | Club / project information |
-| `neis`        | NEIS integration           |
-| `oauth`       | OAuth2 flow                |
-| `project`     | Project information        |
-| `student`     | Student information        |
-| `utility`     | Shared utilities           |
+Run this before selecting a scope — do not use a hardcoded list:
+
+```bash
+sh .agents/scripts/discover-domains.sh
+```
+
+Use the output as the candidate domain scope list.
+
+## Discover Modules at Runtime
+
+Run this to get the module list (strips `datagsm-` prefix for use as scope):
+
+```bash
+sh .agents/scripts/discover-modules.sh
+```
+
+Module scopes are secondary — use only when changes are cross-cutting across multiple domains within that module.
 
 ## Module / Cross-cutting Names (Secondary)
 
-| Scope     | When to use                                         |
-|-----------|-----------------------------------------------------|
-| `global`  | Affects multiple modules                            |
-| `ci/cd`   | Build / deployment pipelines                        |
-| `web`     | Changes scoped to the entire datagsm-web module     |
-| `openapi` | Changes scoped to the entire datagsm-openapi module |
+| Scope      | When to use                        |
+|------------|------------------------------------|
+| `global`   | Affects multiple modules           |
+| `ci/cd`    | Build / deployment pipelines       |
+| (module)   | Changes scoped to an entire module (use name without `datagsm-` prefix) |
 
 ## Wrong vs Correct Examples
 

--- a/.claude/skills/commit/scripts/discover-domains.sh
+++ b/.claude/skills/commit/scripts/discover-domains.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+find . -type d -path "*/domain/*" \
+  ! -path "*/build/*" \
+  ! -path "*/test/*" \
+  ! -path "*/.gradle/*" \
+  | awk -F'/domain/' 'NF>1 { split($NF, a, "/"); print a[1] }' \
+  | sort -u

--- a/.claude/skills/commit/scripts/discover-modules.sh
+++ b/.claude/skills/commit/scripts/discover-modules.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+grep 'include' settings.gradle.kts \
+  | grep -oE '"[^"]+"' \
+  | tr -d '"' \
+  | sed 's/^datagsm-//'

--- a/.claude/skills/commit/scripts/discover-modules.sh
+++ b/.claude/skills/commit/scripts/discover-modules.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-grep 'include' settings.gradle.kts \
+grep '^[[:space:]]*include' settings.gradle.kts \
   | grep -oE '"[^"]+"' \
   | tr -d '"' \
   | sed 's/^datagsm-//'

--- a/.claude/skills/kotest-guide/SKILL.md
+++ b/.claude/skills/kotest-guide/SKILL.md
@@ -125,5 +125,5 @@ context("API 키가 존재하지 않는 경우") {
 
 Discover real test examples dynamically:
 ```bash
-find . -name "*ServiceTest.kt" -not -path "*/build/*" | head -5
+find . -name "*ServiceTest.kt" ! -path "*/build/*" | head -5
 ```

--- a/.claude/skills/kotlin-spring-arch/SKILL.md
+++ b/.claude/skills/kotlin-spring-arch/SKILL.md
@@ -61,7 +61,7 @@ val apiKey = repository.findById(id).orElseThrow {
 Do not create custom exception subclasses extending `ExpectedException`.
 
 ### Global Handler
-See `datagsm-common/.../global/common/error/GlobalExceptionHandler.kt`
+Locate with: `find . -name "GlobalExceptionHandler.kt" ! -path "*/build/*"`
 
 ## DTO Conversion Pattern
 

--- a/.claude/skills/migration-guide/SKILL.md
+++ b/.claude/skills/migration-guide/SKILL.md
@@ -14,7 +14,7 @@ description: Guide for DB schema changes and Entity modifications — impact ana
 
 ## Change Order
 
-1. **Modify Entity**: `datagsm-common/.../domain/`
+1. **Modify Entity**: locate domain directory with `find . -type d -name "domain" -path "*/main/*" ! -path "*/build/*"`
 2. **Modify DTO**: ReqDto, ResDto
 3. **Modify Repository**: Adjust QueryDSL queries if needed
 4. **Modify Service**: Update business logic

--- a/.claude/skills/security-checklist/SKILL.md
+++ b/.claude/skills/security-checklist/SKILL.md
@@ -54,5 +54,9 @@ grep -rE "['\"]([A-Za-z0-9+/]{40,}={0,2})['\"]" --include="*.kt"
 
 ## References
 
-- `datagsm-oauth-authorization/.../auth/service/ApiKeyService.kt` - API Key security example
-- `datagsm-common/.../global/common/security/` - Security configuration
+Locate reference files at runtime:
+
+```bash
+find . -name "ApiKeyService.kt" ! -path "*/build/*"
+find . -type d -name "security" -path "*/main/*" ! -path "*/build/*"
+```

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -8,13 +8,18 @@ allowed-tools: Bash, Glob, Grep
 
 Based on the user's request or changed files, choose the appropriate scope:
 
-| Scope | Command |
-|-------|---------|
+| Scope               | Command                                              |
+|---------------------|------------------------------------------------------|
 | Specific test class | `./gradlew test --tests "fully.qualified.ClassName"` |
-| Specific module | `./gradlew :<module>:test` |
-| All modules | `./gradlew test` |
+| Specific module     | `./gradlew :<module>:test`                           |
+| All modules         | `./gradlew test`                                     |
 
-Available modules: `datagsm-common`, `datagsm-oauth-authorization`, `datagsm-oauth-userinfo`, `datagsm-openapi`, `datagsm-web`
+Discover available modules at runtime (full name for Gradle commands, no `datagsm-` prefix for display):
+
+```bash
+sh .agents/scripts/discover-modules.sh   # display names (prefix stripped)
+grep 'include' settings.gradle.kts | grep -oE '"[^"]+"' | tr -d '"'  # full names for :module:test
+```
 
 ## Run Tests
 

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -18,7 +18,7 @@ Discover available modules at runtime (full name for Gradle commands, no `datags
 
 ```bash
 sh "${CLAUDE_SKILL_DIR}/scripts/discover-modules.sh"   # display names (prefix stripped)
-grep 'include' settings.gradle.kts | grep -oE '"[^"]+"' | tr -d '"'  # full names for :module:test
+grep '^[[:space:]]*include' settings.gradle.kts | grep -oE '"[^"]+"' | tr -d '"'  # full names for :module:test
 ```
 
 ## Run Tests

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -17,7 +17,7 @@ Based on the user's request or changed files, choose the appropriate scope:
 Discover available modules at runtime (full name for Gradle commands, no `datagsm-` prefix for display):
 
 ```bash
-sh .agents/scripts/discover-modules.sh   # display names (prefix stripped)
+sh "${CLAUDE_SKILL_DIR}/scripts/discover-modules.sh"   # display names (prefix stripped)
 grep 'include' settings.gradle.kts | grep -oE '"[^"]+"' | tr -d '"'  # full names for :module:test
 ```
 

--- a/.claude/skills/test/scripts/discover-modules.sh
+++ b/.claude/skills/test/scripts/discover-modules.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+grep 'include' settings.gradle.kts \
+  | grep -oE '"[^"]+"' \
+  | tr -d '"' \
+  | sed 's/^datagsm-//'

--- a/.claude/skills/test/scripts/discover-modules.sh
+++ b/.claude/skills/test/scripts/discover-modules.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-grep 'include' settings.gradle.kts \
+grep '^[[:space:]]*include' settings.gradle.kts \
   | grep -oE '"[^"]+"' \
   | tr -d '"' \
   | sed 's/^datagsm-//'

--- a/.claude/skills/write-pr/SKILL.md
+++ b/.claude/skills/write-pr/SKILL.md
@@ -26,7 +26,7 @@ Read `${CLAUDE_SKILL_DIR}/references/labels.md` and select 1–2 appropriate lab
 ## Step 3 — Generate PR Content
 
 **Title** — Generate 3 options in the format `[scope] description`:
-- Scope: determine from changed files — run `sh .agents/scripts/discover-domains.sh` to get the current domain list, then pick the one matching the changes. Use `[global]` / `[ci/cd]` for cross-cutting changes only. Wrap in brackets: `[auth]`, `[student]`, etc.
+- Scope: determine from changed files — run `sh "${CLAUDE_SKILL_DIR}/scripts/discover-domains.sh"` to get the current domain list, then pick the one matching the changes. Use `[global]` / `[ci/cd]` for cross-cutting changes only. Wrap in brackets: `[auth]`, `[student]`, etc.
 - Description: Korean, concise, no emojis, max 50 characters total
 - Wrap class names, method names, annotations, file names, and technical terms in backticks (e.g., `@Transactional`, `QueryProjectServiceImpl`, `SKILL.md`)
 

--- a/.claude/skills/write-pr/SKILL.md
+++ b/.claude/skills/write-pr/SKILL.md
@@ -26,7 +26,7 @@ Read `${CLAUDE_SKILL_DIR}/references/labels.md` and select 1–2 appropriate lab
 ## Step 3 — Generate PR Content
 
 **Title** — Generate 3 options in the format `[scope] description`:
-- Scope: domain name (`[account]`, `[application]`, `[auth]`, `[client]`, `[club]`, `[neis]`, `[oauth]`, `[project]`, `[student]`, `[utility]`) or `[global]` / `[ci/cd]` for cross-cutting changes
+- Scope: determine from changed files — run `sh .agents/scripts/discover-domains.sh` to get the current domain list, then pick the one matching the changes. Use `[global]` / `[ci/cd]` for cross-cutting changes only. Wrap in brackets: `[auth]`, `[student]`, etc.
 - Description: Korean, concise, no emojis, max 50 characters total
 - Wrap class names, method names, annotations, file names, and technical terms in backticks (e.g., `@Transactional`, `QueryProjectServiceImpl`, `SKILL.md`)
 

--- a/.claude/skills/write-pr/scripts/discover-domains.sh
+++ b/.claude/skills/write-pr/scripts/discover-domains.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+find . -type d -path "*/domain/*" \
+  ! -path "*/build/*" \
+  ! -path "*/test/*" \
+  ! -path "*/.gradle/*" \
+  | awk -F'/domain/' 'NF>1 { split($NF, a, "/"); print a[1] }' \
+  | sort -u

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,12 @@
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+web_search = "live"
+
+[approval]
+policy = "on-request"
+
+[shell]
+login_shell_allowed = true
+
+[features]
+codex_hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "command": ".codex/hooks/pre-tool-use.sh"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "command": ".codex/hooks/post-tool-use.sh"
+      }
+    ]
+  }
+}

--- a/.codex/hooks/post-tool-use.sh
+++ b/.codex/hooks/post-tool-use.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name')
+
+if [[ "$TOOL_NAME" == "Edit" ]] || [[ "$TOOL_NAME" == "Write" ]] || [[ "$TOOL_NAME" == "write_file" ]]; then
+    FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
+    CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+    if [[ "$FILE_PATH" == *.kt ]] && [[ -n "$CWD" ]]; then
+        echo "[Hook] Running ktlintFormat for $(basename "$FILE_PATH")" >&2
+        cd "$CWD"
+        if ./gradlew ktlintFormat -q 2>&1; then
+            echo "[Hook] Format OK" >&2
+        else
+            echo "[Hook] Format failed" >&2
+        fi
+
+        FILE_NAME=$(basename "$FILE_PATH")
+        if [[ "$FILE_NAME" == *ServiceImpl.kt ]] && [[ "$FILE_PATH" != */test/* ]]; then
+            RELATIVE="${FILE_PATH#$CWD/}"
+            MODULE=$(echo "$RELATIVE" | cut -d'/' -f1)
+            if [[ -n "$MODULE" ]] && [[ -d "$CWD/$MODULE/src/test" ]]; then
+                TEST_CLASS="${FILE_NAME%Impl.kt}Test"
+                echo "[Hook] Running test $TEST_CLASS in $MODULE..." >&2
+                TEST_OUTPUT=$(./gradlew ":${MODULE}:test" --tests "$TEST_CLASS" 2>&1)
+                TEST_EXIT=$?
+                TAIL=$(echo "$TEST_OUTPUT" | tail -5)
+                if [[ $TEST_EXIT -ne 0 ]]; then
+                    echo "[Hook] Test FAILED in $MODULE. Last 5 lines:"
+                    echo "$TAIL"
+                    echo "Tests failed after editing $FILE_NAME. Consider running /test skill."
+                else
+                    echo "[Hook] Tests passed in $MODULE. Last 5 lines:"
+                    echo "$TAIL"
+                fi
+            fi
+        fi
+    fi
+fi
+
+exit 0

--- a/.codex/hooks/post-tool-use.sh
+++ b/.codex/hooks/post-tool-use.sh
@@ -8,8 +8,15 @@ if [[ "$TOOL_NAME" == "Edit" ]] || [[ "$TOOL_NAME" == "Write" ]] || [[ "$TOOL_NA
     CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
     if [[ "$FILE_PATH" == *.kt ]] && [[ -n "$CWD" ]]; then
+        PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$CWD")
+        if [[ "$FILE_PATH" == /* ]]; then
+            FILE_ABS="$FILE_PATH"
+        else
+            FILE_ABS="$CWD/$FILE_PATH"
+        fi
+
         echo "[Hook] Running ktlintFormat for $(basename "$FILE_PATH")" >&2
-        cd "$CWD"
+        cd "$PROJECT_ROOT"
         if ./gradlew ktlintFormat -q 2>&1; then
             echo "[Hook] Format OK" >&2
         else
@@ -18,9 +25,9 @@ if [[ "$TOOL_NAME" == "Edit" ]] || [[ "$TOOL_NAME" == "Write" ]] || [[ "$TOOL_NA
 
         FILE_NAME=$(basename "$FILE_PATH")
         if [[ "$FILE_NAME" == *ServiceImpl.kt ]] && [[ "$FILE_PATH" != */test/* ]]; then
-            RELATIVE="${FILE_PATH#$CWD/}"
+            RELATIVE="${FILE_ABS#$PROJECT_ROOT/}"
             MODULE=$(echo "$RELATIVE" | cut -d'/' -f1)
-            if [[ -n "$MODULE" ]] && [[ -d "$CWD/$MODULE/src/test" ]]; then
+            if [[ "$FILE_ABS" == "$PROJECT_ROOT"/* ]] && [[ -n "$MODULE" ]] && [[ -d "$PROJECT_ROOT/$MODULE/src/test" ]]; then
                 TEST_CLASS="${FILE_NAME%Impl.kt}Test"
                 echo "[Hook] Running test $TEST_CLASS in $MODULE..." >&2
                 TEST_OUTPUT=$(./gradlew ":${MODULE}:test" --tests "$TEST_CLASS" 2>&1)

--- a/.codex/hooks/pre-tool-use.sh
+++ b/.codex/hooks/pre-tool-use.sh
@@ -15,7 +15,7 @@ if [[ "$TOOL_NAME" == "Bash" ]] || [[ "$TOOL_NAME" == "shell" ]]; then
     fi
 
     BLOCKED_PATTERNS=(
-        "rm -rf[[:space:]]*/[[:space:]]*$"
+        "rm -rf[[:space:]]*/"
         "sudo rm"
         "> /dev/"
         "dd if="

--- a/.codex/hooks/pre-tool-use.sh
+++ b/.codex/hooks/pre-tool-use.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name')
+
+if [[ "$TOOL_NAME" == "Bash" ]] || [[ "$TOOL_NAME" == "shell" ]]; then
+    COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // .tool_input.cmd // empty')
+    CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+    TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+
+    if [[ -n "$CWD" ]]; then
+        LOG_FILE="$CWD/.codex/command.log"
+        mkdir -p "$(dirname "$LOG_FILE")"
+        echo "[$TIMESTAMP] $COMMAND" >> "$LOG_FILE"
+    fi
+
+    BLOCKED_PATTERNS=(
+        "rm -rf[[:space:]]*/[[:space:]]*$"
+        "sudo rm"
+        "> /dev/"
+        "dd if="
+        "mkfs"
+        "curl.*\| sh"
+        "wget.*\| sh"
+    )
+    for pattern in "${BLOCKED_PATTERNS[@]}"; do
+        if [[ "$COMMAND" =~ $pattern ]]; then
+            echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Dangerous command blocked by project hook"}}'
+            exit 0
+        fi
+    done
+fi
+
+exit 0


### PR DESCRIPTION
## 개요

`Codex` 전용 설정과 훅을 추가하여 프로젝트 작업 환경을 명시하였습니다.
스킬 문서가 도메인, 모듈, 참조 경로를 하드코딩하지 않고 런타임에 탐색하도록 개선하였습니다.

## 본문

`Codex` 설정 파일인 `.codex/config.toml`과 `.codex/hooks.json`을 추가하였습니다. 기본 모델, 추론 강도, 웹 검색, 승인 정책, 로그인 셸 허용 여부, 훅 사용 여부를 저장소 단위로 관리하도록 구성하였습니다.

`PreToolUse` 훅은 셸 명령을 `.codex/command.log`에 기록하고 위험한 명령 패턴을 차단하도록 추가하였습니다. `PostToolUse` 훅은 `Kotlin` 파일 편집 후 `ktlintFormat`을 실행하고, `ServiceImpl.kt` 변경 시 대응 테스트 실행을 시도하도록 구성하였습니다.

`.agents/scripts/discover-domains.sh`와 `.agents/scripts/discover-modules.sh`를 추가하여 현재 저장소 구조에서 도메인과 모듈 범위를 탐색할 수 있도록 하였습니다. `commit`, `write-pr`, `test`, `security-checklist`, `migration-guide`, `kotlin-spring-arch`, `kotest-guide` 스킬 문서도 이 탐색 방식을 사용하도록 갱신하였습니다.

애플리케이션 코드 변경은 없어 별도 테스트는 실행하지 않았습니다.
