### PR TITLE
[oauth] `@PreAuthorize` SpEL 파싱 오류로 인한 인가 방식 수정

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/constant/OAuthScope.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/constant/OAuthScope.kt
@@ -20,6 +20,11 @@ class OAuthScope(
     override fun hashCode(): Int = scope.hashCode()
 
     companion object {
+        fun authorityOf(
+            applicationId: String,
+            scopeName: String,
+        ): String = "SCOPE_$applicationId:$scopeName"
+
         fun fromScopeString(scopeStr: String): OAuthScope? {
             val colonIdx = scopeStr.indexOf(':')
             if (colonIdx <= 0 || colonIdx == scopeStr.lastIndex) return null

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/controller/UserInfoController.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/controller/UserInfoController.kt
@@ -2,7 +2,6 @@ package team.themoment.datagsm.oauth.userinfo.domain.userinfo.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 import team.themoment.datagsm.common.domain.account.dto.response.AccountInfoResDto
@@ -14,7 +13,6 @@ class UserInfoController(
     private val queryUserInfoService: QueryUserInfoService,
 ) {
     @GetMapping("/userinfo")
-    @PreAuthorize("hasAuthority('SCOPE_' + @oauthJwtVerificationEnvironment.datagsmApplicationId + ':self_read')")
     @Operation(
         summary = "사용자 정보 조회",
         description = "OAuth2 Access Token을 사용하여 현재 사용자 정보를 조회합니다.",

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
@@ -3,7 +3,6 @@ package team.themoment.datagsm.oauth.userinfo.global.security.config
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer
@@ -15,6 +14,7 @@ import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.web.cors.CorsConfigurationSource
 import team.themoment.datagsm.common.global.data.OAuthClientRateLimitEnvironment
+import team.themoment.datagsm.oauth.userinfo.global.data.OauthJwtVerificationEnvironment
 import team.themoment.datagsm.oauth.userinfo.global.security.filter.OAuthClientRateLimitFilter
 import team.themoment.datagsm.oauth.userinfo.global.security.handler.CustomAuthenticationEntryPoint
 import team.themoment.datagsm.oauth.userinfo.global.security.jwt.JwtProvider
@@ -24,7 +24,6 @@ import tools.jackson.databind.ObjectMapper
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity(prePostEnabled = true)
 class SecurityConfig(
     @param:Qualifier("configure") private val corsConfigurationSource: CorsConfigurationSource,
     private val jwtProvider: JwtProvider,
@@ -32,9 +31,12 @@ class SecurityConfig(
     private val objectMapper: ObjectMapper,
     private val oauthClientRateLimitService: OAuthClientRateLimitService,
     private val oauthClientRateLimitEnvironment: OAuthClientRateLimitEnvironment,
+    private val oauthJwtVerificationEnvironment: OauthJwtVerificationEnvironment,
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        val selfReadAuthority = "SCOPE_${oauthJwtVerificationEnvironment.datagsmApplicationId}:self_read"
+
         http
             .csrf(CsrfConfigurer<*>::disable)
             .cors { it.configurationSource(corsConfigurationSource) }
@@ -52,7 +54,7 @@ class SecurityConfig(
             ).authorizeHttpRequests {
                 it
                     .requestMatchers("/userinfo")
-                    .authenticated()
+                    .hasAuthority(selfReadAuthority)
                     .anyRequest()
                     .permitAll()
             }

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
@@ -13,6 +13,7 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.web.cors.CorsConfigurationSource
+import team.themoment.datagsm.common.domain.client.entity.constant.OAuthScope
 import team.themoment.datagsm.common.global.data.OAuthClientRateLimitEnvironment
 import team.themoment.datagsm.oauth.userinfo.global.data.OauthJwtVerificationEnvironment
 import team.themoment.datagsm.oauth.userinfo.global.security.filter.OAuthClientRateLimitFilter
@@ -35,7 +36,7 @@ class SecurityConfig(
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-        val selfReadAuthority = "SCOPE_${oauthJwtVerificationEnvironment.datagsmApplicationId}:self_read"
+        val selfReadAuthority = OAuthScope.authorityOf(oauthJwtVerificationEnvironment.datagsmApplicationId, "self_read")
 
         http
             .csrf(CsrfConfigurer<*>::disable)


### PR DESCRIPTION
## 개요

`/userinfo` 엔드포인트의 `@PreAuthorize` SpEL 표현식에서 콜론(`:`)을 포함한 문자열 리터럴이 파서 오류를 일으켜 `IllegalArgumentException`이 발생하는 버그를 수정하였습니다. `@PreAuthorize`를 제거하고 `SecurityConfig`의 `authorizeHttpRequests`에서 `hasAuthority`로 인가를 처리하도록 변경하였습니다.

## 본문

### 문제

`UserInfoController`의 `@PreAuthorize` 어노테이션에서 아래와 같은 SpEL 표현식을 사용하였습니다.

```
hasAuthority('SCOPE_' + @oauthJwtVerificationEnvironment.datagsmApplicationId + ':self_read')
```

SpEL 파서가 `':self_read'`의 콜론(`:`)을 삼항 연산자 구분자로 해석하여 표현식 평가에 실패하였습니다. 그 결과 `/userinfo` 요청마다 `IllegalArgumentException: Failed to evaluate expression`이 발생하였습니다.

### 변경 사항

- `UserInfoController`: `@PreAuthorize` 어노테이션 및 `@EnableMethodSecurity` 관련 import 제거
- `SecurityConfig`: `@EnableMethodSecurity` 제거, `OauthJwtVerificationEnvironment`를 주입받아 `selfReadAuthority` 문자열을 Kotlin 문자열 템플릿으로 조합한 뒤 `.hasAuthority(selfReadAuthority)`로 인가 처리

### 동작 방식

`OAuthScope.getAuthority()`가 반환하는 `"SCOPE_<applicationId>:<scopeName>"` 형식과 `SecurityConfig`에서 조합하는 `"SCOPE_${datagsmApplicationId}:self_read"` 값이 동일하게 일치하므로 기존과 동일한 인가 정책이 유지됩니다.
