### PR TITLE
[oauth] `OAuthException` 발생 시 HTML 에러 페이지 응답 지원

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/common/error/GlobalExceptionHandler.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/common/error/GlobalExceptionHandler.kt
@@ -1,8 +1,11 @@
 package team.themoment.datagsm.common.global.common.error
 
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.ConstraintViolationException
 import org.springframework.core.env.Environment
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
@@ -15,6 +18,8 @@ import org.springframework.web.context.request.ServletRequestAttributes
 import org.springframework.web.multipart.MaxUploadSizeExceededException
 import org.springframework.web.servlet.NoHandlerFoundException
 import org.springframework.web.servlet.config.annotation.EnableWebMvc
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.context.Context
 import team.themoment.datagsm.common.domain.oauth.dto.response.OAuthErrorResDto
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.global.common.discord.error.DiscordErrorNotificationService
@@ -29,20 +34,39 @@ import java.nio.charset.StandardCharsets
 class GlobalExceptionHandler(
     private val discordErrorNotificationService: DiscordErrorNotificationService? = null,
     private val environment: Environment,
+    private val errorMessageResolver: ErrorMessageResolver,
+    private val templateEngine: TemplateEngine,
 ) {
     @ExceptionHandler(OAuthException::class)
-    fun handleOAuthException(ex: OAuthException): ResponseEntity<OAuthErrorResDto> {
+    fun handleOAuthException(
+        ex: OAuthException,
+        request: HttpServletRequest,
+    ): ResponseEntity<*> {
         logger().warn("Caught OAuth error with code {} and description {}", ex.error, ex.errorDescription)
         logger().trace("OAuth Error Details: ", ex)
 
-        val errorResponse =
+        val acceptHeader = request.getHeader(HttpHeaders.ACCEPT) ?: ""
+        if (acceptHeader.contains(MediaType.TEXT_HTML_VALUE)) {
+            val status = ex.httpStatus
+            val context = Context()
+            context.setVariable("statusCode", status.value())
+            context.setVariable("error", status.reasonPhrase)
+            context.setVariable("message", errorMessageResolver.resolveMessage(status))
+            context.setVariable("path", request.requestURI)
+            val html = templateEngine.process("error", context)
+            return ResponseEntity
+                .status(status)
+                .contentType(MediaType.TEXT_HTML)
+                .body(html)
+        }
+
+        return ResponseEntity.status(ex.httpStatus).body(
             OAuthErrorResDto(
                 error = ex.error,
                 errorDescription = ex.errorDescription,
                 errorUri = null,
-            )
-
-        return ResponseEntity.status(ex.httpStatus).body(errorResponse)
+            ),
+        )
     }
 
     @ExceptionHandler(ExpectedException::class)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/common/error/GlobalExceptionHandler.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/common/error/GlobalExceptionHandler.kt
@@ -56,7 +56,7 @@ class GlobalExceptionHandler(
             val html = templateEngine.process("error", context)
             return ResponseEntity
                 .status(status)
-                .contentType(MediaType.TEXT_HTML)
+                .contentType(MediaType(MediaType.TEXT_HTML, StandardCharsets.UTF_8))
                 .body(html)
         }
 

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/common/error/GlobalExceptionHandler.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/common/error/GlobalExceptionHandler.kt
@@ -43,10 +43,10 @@ class GlobalExceptionHandler(
         request: HttpServletRequest,
     ): ResponseEntity<*> {
         logger().warn("Caught OAuth error with code {} and description {}", ex.error, ex.errorDescription)
-        logger().trace("OAuth Error Details: ", ex)
+        logger().trace("OAuth Error Details ", ex)
 
         val acceptHeader = request.getHeader(HttpHeaders.ACCEPT) ?: ""
-        if (acceptHeader.contains(MediaType.TEXT_HTML_VALUE)) {
+        if (acceptHeader.contains(MediaType.TEXT_HTML_VALUE) && !isOAuthTokenEndpoint()) {
             val status = ex.httpStatus
             val context = Context()
             context.setVariable("statusCode", status.value())


### PR DESCRIPTION
## 개요

`OAuthException` 발생 시 클라이언트의 `Accept` 헤더에 따라 HTML 에러 페이지를 응답할 수 있도록 개선하였습니다. 브라우저를 통한 인증 과정에서 발생하는 오류를 사용자에게 더 명확하게 전달합니다.

## 본문

- `GlobalExceptionHandler`의 `handleOAuthException` 메서드를 수정하여 `HttpServletRequest`를 인자로 받도록 변경하였습니다.
- 요청의 `Accept` 헤더가 `text/html`을 포함하는 경우, `TemplateEngine`을 사용하여 `error.html` 템플릿을 렌더링한 HTML을 반환합니다.
- HTML 응답 시 `ErrorMessageResolver`를 통해 상태 코드에 맞는 메시지를 처리하여 전달합니다.
- 그 외의 요청(JSON 등)에 대해서는 기존과 동일하게 `OAuthErrorResDto`를 통한 JSON 응답을 유지합니다.
