### PR TITLE
[global] 에러 페이지 홈 이동 URL 변경

### DIFF
--- a/datagsm-common/src/main/resources/templates/error.html
+++ b/datagsm-common/src/main/resources/templates/error.html
@@ -134,7 +134,7 @@
             <h1 class="error-title" th:text="${error}">Not Found</h1>
             <p class="error-message" th:text="${message}">요청하신 페이지를 찾을 수 없습니다</p>
             <div class="error-path" th:text="${path}">/unknown</div>
-            <a href="https://datagsm-front-client.vercel.app/" class="button">
+            <a href="https://datagsm.kr/" class="button">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
                     <polyline points="9 22 9 12 15 12 15 22"></polyline>


### PR DESCRIPTION
## 개요

공통 에러 페이지의 홈 버튼 링크 주소를 실제 운영 중인 도메인으로 수정하였습니다.

## 본문

`datagsm-common` 모듈의 `error.html` 파일에서 홈 버튼(`<a>` 태그)의 `href` 속성값을 `https://datagsm-front-client.vercel.app/`에서 `https://datagsm.kr/`로 변경하였습니다. 이를 통해 에러 발생 시 사용자가 공식 홈페이지로 원활하게 이동할 수 있도록 개선하였습니다.