### PR TITLE
[ci/cd] 팀원의 Github ID 변경 반영

### DIFF
--- a/.github/workflows/datagsm-prod-ci.yaml
+++ b/.github/workflows/datagsm-prod-ci.yaml
@@ -78,7 +78,7 @@ jobs:
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-label "waiting for review:검토 대기"
           gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-assignee "$PR_AUTHOR"
-          ALL_REVIEWERS="wwwcomcomcomcom,ZaMan-O,hongjm0912,snowykte0426"
+          ALL_REVIEWERS="wwwcomcomcomcom,ZaMan0806,hongjm0912,snowykte0426"
           REVIEWERS=$(echo "$ALL_REVIEWERS" | tr ',' '\n' | grep -v "^${PR_AUTHOR}$" | tr '\n' ',' | sed 's/,$//')
           if [ -n "$REVIEWERS" ]; then
             gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer "$REVIEWERS"

--- a/.github/workflows/datagsm-stage-ci.yaml
+++ b/.github/workflows/datagsm-stage-ci.yaml
@@ -76,7 +76,7 @@ jobs:
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-label "waiting for review:검토 대기"
           gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-assignee "$PR_AUTHOR"
-          ALL_REVIEWERS="wwwcomcomcomcom,ZaMan-O,hongjm0912,snowykte0426"
+          ALL_REVIEWERS="wwwcomcomcomcom,ZaMan0806,hongjm0912,snowykte0426"
           REVIEWERS=$(echo "$ALL_REVIEWERS" | tr ',' '\n' | grep -v "^${PR_AUTHOR}$" | tr '\n' ',' | sed 's/,$//')
           if [ -n "$REVIEWERS" ]; then
             gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer "$REVIEWERS"


### PR DESCRIPTION
## 개요

팀원의 GitHub 계정이 `zaman-o`에서 `ZaMan0806`으로 변경되어, PR 자동 reviewer 할당 워크플로우에 사용되는 계정 ID를 업데이트하였습니다.

## 본문

PR이 생성될 때 자동으로 reviewer를 추가하는 CI 워크플로우(`datagsm-prod-ci.yaml`, `datagsm-stage-ci.yaml`)에서 하드코딩된 reviewer 목록의 계정 ID를 변경하였습니다.

**변경 사항:**
- `ZaMan-O` → `ZaMan0806`

이 변경으로 인해 향후 PR 자동 reviewer 할당이 정상적으로 작동할 것입니다.

## 테스트

- 워크플로우 문법 검증: `validate-title` job이 정상 실행됨
- reviewer 할당 로직: GitHub 계정 ID 변경 반영
