### PR TITLE
[auth] 일반 사용자 허용 scope를 enum 메타데이터 기반으로 일원화

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/auth/entity/constant/ApiKeyScope.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/auth/entity/constant/ApiKeyScope.kt
@@ -55,13 +55,9 @@ enum class ApiKeyScope(
 
         private val ALL_SCOPES by lazy { entries.map { it.scope }.toSet() }
 
-        val READ_ONLY_SCOPES =
-            setOf(
-                STUDENT_READ.scope,
-                CLUB_READ.scope,
-                PROJECT_READ.scope,
-                NEIS_READ.scope,
-            )
+        val USER_ALLOWED_SCOPES: Set<String> by lazy {
+            entries.filter { it.accountRole == AccountRole.USER }.map { it.scope }.toSet()
+        }
 
         fun fromString(scope: String): ApiKeyScope? = entries.find { it.scope == scope }
 

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/auth/service/impl/CreateCurrentAccountApiKeyServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/auth/service/impl/CreateCurrentAccountApiKeyServiceImpl.kt
@@ -32,14 +32,14 @@ class CreateCurrentAccountApiKeyServiceImpl(
 
         val isAdmin = account.role in setOf(AccountRole.ADMIN, AccountRole.ROOT)
 
-        val validScopes = if (isAdmin) ApiKeyScope.getAllScopes() else ApiKeyScope.READ_ONLY_SCOPES
+        val validScopes = if (isAdmin) ApiKeyScope.getAllScopes() else ApiKeyScope.USER_ALLOWED_SCOPES
         val invalidScopes = reqDto.scopes.filter { it !in validScopes }
         if (invalidScopes.isNotEmpty()) {
             throw ExpectedException(
                 if (isAdmin) {
                     "유효하지 않은 권한 범위입니다."
                 } else {
-                    "일반 사용자는 읽기 전용 권한 범위만 사용 가능합니다."
+                    "일반 사용자에게 허용되지 않는 권한 범위입니다."
                 },
                 HttpStatus.BAD_REQUEST,
             )

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/auth/service/impl/ModifyCurrentAccountApiKeyServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/auth/service/impl/ModifyCurrentAccountApiKeyServiceImpl.kt
@@ -44,7 +44,7 @@ class ModifyCurrentAccountApiKeyServiceImpl(
         }
 
         val isAdmin = account.role in setOf(AccountRole.ADMIN, AccountRole.ROOT)
-        val validScopes = if (isAdmin) ApiKeyScope.getAllScopes() else ApiKeyScope.READ_ONLY_SCOPES
+        val validScopes = if (isAdmin) ApiKeyScope.getAllScopes() else ApiKeyScope.USER_ALLOWED_SCOPES
         val invalidScopes = reqDto.scopes.filter { it !in validScopes }
         if (invalidScopes.isNotEmpty()) {
             logger().warn(

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/auth/service/CreateCurrentAccountApiKeyServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/auth/service/CreateCurrentAccountApiKeyServiceTest.kt
@@ -204,7 +204,7 @@ class CreateCurrentAccountApiKeyServiceTest :
                             }
 
                         exception.statusCode.value() shouldBe 400
-                        exception.message shouldBe "일반 사용자는 읽기 전용 권한 범위만 사용 가능합니다."
+                        exception.message shouldBe "일반 사용자에게 허용되지 않는 권한 범위입니다."
 
                         verify(exactly = 1) { mockCurrentUserProvider.getCurrentAccount() }
                         verify(exactly = 1) { mockApiKeyRepository.findByAccount(mockAccount) }
@@ -230,7 +230,7 @@ class CreateCurrentAccountApiKeyServiceTest :
                             }
 
                         exception.statusCode.value() shouldBe 400
-                        exception.message shouldBe "일반 사용자는 읽기 전용 권한 범위만 사용 가능합니다."
+                        exception.message shouldBe "일반 사용자에게 허용되지 않는 권한 범위입니다."
 
                         verify(exactly = 0) { mockApiKeyRepository.save(any()) }
                     }
@@ -254,7 +254,7 @@ class CreateCurrentAccountApiKeyServiceTest :
                             }
 
                         exception.statusCode.value() shouldBe 400
-                        exception.message shouldBe "일반 사용자는 읽기 전용 권한 범위만 사용 가능합니다."
+                        exception.message shouldBe "일반 사용자에게 허용되지 않는 권한 범위입니다."
 
                         verify(exactly = 0) { mockApiKeyRepository.save(any()) }
                     }


### PR DESCRIPTION
## 개요

일반 사용자가 API Key를 생성/수정할 때 허용되는 scope 목록을 `ApiKeyScope` enum의 `accountRole` 메타데이터로부터 자동 도출하도록 일원화하였습니다. 이로써 `WEBHOOK_WRITE`처럼 `AccountRole.USER`로 정의된 scope가 일반 사용자에게도 정상적으로 허용되며, 향후 신규 scope 추가 시 분기 로직을 별도로 수정할 필요가 없게 되었습니다.

## 본문

### 문제

`CreateCurrentAccountApiKeyServiceImpl`과 `ModifyCurrentAccountApiKeyServiceImpl`에서 일반 사용자의 허용 scope를 `ApiKeyScope.READ_ONLY_SCOPES` 상수로 하드코딩하고 있었습니다. 그러나 `ApiKeyScope` enum에는 이미 각 scope마다 어떤 `AccountRole`에 허용되는지를 나타내는 `accountRole` 필드가 존재하였고, `WEBHOOK_WRITE` scope는 `AccountRole.USER`로 선언되어 있음에도 불구하고 위 두 서비스에서는 일반 사용자에게 차단되고 있었습니다. 단일 진실 소스가 분산되어 있어 신규 scope 추가 시 누락이 발생할 수 있는 구조였습니다.

### 변경 사항

- `ApiKeyScope`에 enum 메타데이터(`accountRole == AccountRole.USER`)로부터 자동 계산되는 `USER_ALLOWED_SCOPES` lazy 상수를 추가하였습니다.
- 더 이상 참조되지 않게 된 `READ_ONLY_SCOPES` 상수를 제거하였습니다.
- `CreateCurrentAccountApiKeyServiceImpl`과 `ModifyCurrentAccountApiKeyServiceImpl`의 일반 사용자 분기 로직을 `USER_ALLOWED_SCOPES` 참조로 교체하였습니다.
- `CreateCurrentAccountApiKeyServiceImpl`의 에러 메시지를 `"일반 사용자는 읽기 전용 권한 범위만 사용 가능합니다."`에서 `"일반 사용자에게 허용되지 않는 권한 범위입니다."`로 변경하였습니다. 실제 허용 범위가 읽기 전용으로 한정되지 않게 되었기 때문입니다.

### 영향

- 일반 사용자가 `webhook:write` scope를 포함한 API Key 생성 및 수정이 가능해졌습니다.
- 향후 `ApiKeyScope`에 `AccountRole.USER` scope를 추가하면 별도 코드 수정 없이 일반 사용자 허용 목록에 자동 반영됩니다.
- 관리자(ADMIN/ROOT) 동작은 변경되지 않았으며 기존과 동일하게 모든 scope를 허용합니다.
