### PR TITLE
[global] `disender` 기반 시작/종료 Discord 알림 도입

### DIFF
--- a/buildSrc/src/main/kotlin/dependency/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependency/Dependencies.kt
@@ -2,6 +2,7 @@ package dependency
 
 import dependency.DependencyVersions.AWS_SDK_VERSION
 import dependency.DependencyVersions.BUCKET4J_VERSION
+import dependency.DependencyVersions.DISENDER_VERSION
 import dependency.DependencyVersions.JJWT_VERSION
 import dependency.DependencyVersions.KOTEST_VERSION
 import dependency.DependencyVersions.KOTLIN_COROUTINES_VERSION
@@ -66,6 +67,9 @@ object Dependencies {
 
     // Custom Libraries
     const val THE_MOMENT_THE_SDK = "com.github.themoment-team:the-sdk:${THE_MOMENT_THE_SDK_VERSION}"
+
+    // Disender (Discord webhook notifier)
+    const val DISENDER_SPRING_BOOT_STARTER = "io.github.zaman0806:disender-spring-boot-4-starter:${DISENDER_VERSION}"
 
     // Kotlin
     const val KOTLIN_REFLECT = "org.jetbrains.kotlin:kotlin-reflect"

--- a/buildSrc/src/main/kotlin/dependency/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/dependency/DependencyVersions.kt
@@ -19,4 +19,6 @@ object DependencyVersions {
     const val BUCKET4J_VERSION = "8.17.0"
 
     const val POI_VERSION = "5.5.1"
+
+    const val DISENDER_VERSION = "0.1.0"
 }

--- a/datagsm-oauth-authorization/build.gradle.kts
+++ b/datagsm-oauth-authorization/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
     runtimeOnly(dependency.Dependencies.JJWT_IMPL)
     runtimeOnly(dependency.Dependencies.JJWT_JACKSON)
 
+    // Disender (Discord webhook notifier)
+    implementation(dependency.Dependencies.DISENDER_SPRING_BOOT_STARTER)
+
     // Development Tools
     developmentOnly(dependency.Dependencies.SPRING_BOOT_DEVTOOLS)
     developmentOnly(dependency.Dependencies.SPRING_DOCKER_SUPPORT)

--- a/datagsm-oauth-authorization/src/main/resources/application.yml
+++ b/datagsm-oauth-authorization/src/main/resources/application.yml
@@ -125,5 +125,7 @@ sdk:
 springdoc:
   swagger-ui:
     enabled: true
+disender:
+  webhook-url: ${DISENDER_WEBHOOK_URL:}
 logging:
   config: classpath:logback-spring.xml

--- a/datagsm-oauth-userinfo/build.gradle.kts
+++ b/datagsm-oauth-userinfo/build.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
     runtimeOnly(dependency.Dependencies.JJWT_IMPL)
     runtimeOnly(dependency.Dependencies.JJWT_JACKSON)
 
+    // Disender (Discord webhook notifier)
+    implementation(dependency.Dependencies.DISENDER_SPRING_BOOT_STARTER)
+
     // Development Tools
     developmentOnly(dependency.Dependencies.SPRING_BOOT_DEVTOOLS)
     developmentOnly(dependency.Dependencies.SPRING_DOCKER_SUPPORT)

--- a/datagsm-oauth-userinfo/src/main/resources/application.yml
+++ b/datagsm-oauth-userinfo/src/main/resources/application.yml
@@ -77,5 +77,7 @@ sdk:
 springdoc:
   swagger-ui:
     enabled: true
+disender:
+  webhook-url: ${DISENDER_WEBHOOK_URL:}
 logging:
   config: classpath:logback-spring.xml

--- a/datagsm-openapi/build.gradle.kts
+++ b/datagsm-openapi/build.gradle.kts
@@ -9,6 +9,9 @@ dependencies {
     // Common Module
     implementation(project(":datagsm-common"))
 
+    // Disender (Discord webhook notifier)
+    implementation(dependency.Dependencies.DISENDER_SPRING_BOOT_STARTER)
+
     // Development Tools
     developmentOnly(dependency.Dependencies.SPRING_BOOT_DEVTOOLS)
     developmentOnly(dependency.Dependencies.SPRING_DOCKER_SUPPORT)

--- a/datagsm-openapi/src/main/resources/application.yml
+++ b/datagsm-openapi/src/main/resources/application.yml
@@ -85,5 +85,7 @@ sdk:
 springdoc:
   swagger-ui:
     enabled: true
+disender:
+  webhook-url: ${DISENDER_WEBHOOK_URL:}
 logging:
   config: classpath:logback-spring.xml

--- a/datagsm-web/build.gradle.kts
+++ b/datagsm-web/build.gradle.kts
@@ -21,6 +21,9 @@ dependencies {
     implementation(dependency.Dependencies.POI)
     implementation(dependency.Dependencies.POI_OOXML)
 
+    // Disender (Discord webhook notifier)
+    implementation(dependency.Dependencies.DISENDER_SPRING_BOOT_STARTER)
+
     // Development Tools
     developmentOnly(dependency.Dependencies.SPRING_BOOT_DEVTOOLS)
     developmentOnly(dependency.Dependencies.SPRING_DOCKER_SUPPORT)

--- a/datagsm-web/src/main/resources/application.yml
+++ b/datagsm-web/src/main/resources/application.yml
@@ -88,5 +88,8 @@ springdoc:
   swagger-ui:
     enabled: true
 
+disender:
+  webhook-url: ${DISENDER_WEBHOOK_URL:}
+
 logging:
   config: classpath:logback-spring.xml

--- a/datagsm-web/src/main/resources/application.yml
+++ b/datagsm-web/src/main/resources/application.yml
@@ -87,9 +87,7 @@ sdk:
 springdoc:
   swagger-ui:
     enabled: true
-
 disender:
   webhook-url: ${DISENDER_WEBHOOK_URL:}
-
 logging:
   config: classpath:logback-spring.xml


### PR DESCRIPTION
## 개요

각 Spring Boot 모듈이 시작/종료될 때 Discord 채널로 자동 알림을 보내도록 `disender-spring-boot-4-starter`를 도입하였습니다. 의존성과 `application.yml` 설정만 추가하면 동작하는 SDK이며, 별도 코드 변경 없이 4개 실행 모듈 모두에 동일하게 적용하였습니다.

## 본문

### 의존성 정의

- `buildSrc/dependency/DependencyVersions.kt`에 `DISENDER_VERSION = "0.1.0"` 상수를 추가하였습니다.
- `buildSrc/dependency/Dependencies.kt`에 `DISENDER_SPRING_BOOT_STARTER` 상수를 추가하여 모듈 간 동일한 좌표를 공유하도록 하였습니다.
- 본 프로젝트는 Spring Boot 4.0을 사용하므로 `disender-spring-boot-4-starter`를 선택하였습니다.

### 모듈별 의존성 추가

다음 4개 실행 모듈의 `build.gradle.kts`에 `implementation` 의존성을 추가하였습니다.

- `datagsm-web`
- `datagsm-oauth-authorization`
- `datagsm-oauth-userinfo`
- `datagsm-openapi`

`datagsm-common`은 라이브러리 모듈이므로 대상에서 제외하였습니다.

### 설정 추가

각 모듈의 `application.yml`에 동일한 블록을 추가하였습니다.

```yaml
disender:
  webhook-url: ${DISENDER_WEBHOOK_URL:}
```

환경 변수 `DISENDER_WEBHOOK_URL`이 비어 있으면 SDK가 자동으로 비활성화되므로, 로컬 개발 환경에서 별도 설정 없이도 애플리케이션 기동에 영향이 없도록 하였습니다.

### 동작 방식

- `ApplicationReadyEvent` 수신 시 시작 알림 embed를 발송합니다.
- `ContextClosedEvent` 수신 시 종료 알림 embed를 발송합니다.
- 메시지에는 `spring.application.name`과 호스트명이 자동 포함되어, MSA 환경에서 어느 서비스의 어느 인스턴스인지 식별할 수 있습니다.
- webhook 호출 실패 시 예외를 삼키고 WARN 로그만 남기므로 애플리케이션 기동/종료가 영향을 받지 않습니다.

### 운영 환경 적용

운영 환경에서는 `DISENDER_WEBHOOK_URL` 환경 변수를 주입하면 자동으로 알림이 활성화됩니다. 변수 미주입 시 기존 동작과 동일하게 동작합니다.
