### PR TITLE
[global] `Gradle Wrapper`를 `9.5.1`로 업데이트

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 개요

`Gradle Wrapper` 버전을 `9.4.0`에서 `9.5.1`로 상향하였습니다. `gradle/wrapper/gradle-wrapper.properties`의 `distributionUrl`만 변경하여 패치 릴리스를 반영하였습니다.

## 본문

Gradle 공식 문서를 확인한 뒤 `9.5.1`이 `9.5.0`의 첫 패치 릴리스이며 업그레이드를 권장하는 버전임을 반영하였습니다. 공식 `release notes` 기준으로 `OOM upgrading from 9.4.1 to 9.5.0` 문제와 `Tooling API`의 상대 경로 프로젝트 디렉터리 문제 수정이 포함되어 있습니다.

업그레이드 후 다음 검증을 수행하였습니다.
- `./gradlew --version`
- `./gradlew test`
- `./gradlew help --warning-mode=all`

검증 결과 `Gradle 9.5.1`로 정상 기동되었고 전체 테스트가 성공하였습니다. 또한 `--warning-mode=all` 실행 시 `deprecation` 경고는 확인되지 않았습니다.
