### PR TITLE
[global] `disender` 의존성 최신화

### DIFF
--- a/buildSrc/src/main/kotlin/dependency/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/dependency/DependencyVersions.kt
@@ -20,5 +20,5 @@ object DependencyVersions {
 
     const val POI_VERSION = "5.5.1"
 
-    const val DISENDER_VERSION = "0.1.0"
+    const val DISENDER_VERSION = "0.1.1"
 }


### PR DESCRIPTION
## 개요

0.1.0 버전의 disender 의존성이 애플리케이션 종료 시 알림이 여러 번 전송되는 오류가 있어 0.1.1 버전으로 최신화 하였습니다.