### PR TITLE
[webhook] Webhook 수신 URL SSRF 취약점 수정

### DIFF
--- a/buildSrc/src/main/kotlin/dependency/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependency/Dependencies.kt
@@ -84,6 +84,9 @@ object Dependencies {
     // Jackson
     const val JACKSON_DATABIND = "tools.jackson.core:jackson-databind"
 
+    // Apache HttpClient
+    const val HTTPCLIENT5 = "org.apache.httpcomponents.client5:httpclient5"
+
     // AWS SDK
     const val AWS_CLOUDWATCH_LOGS = "software.amazon.awssdk:cloudwatchlogs"
 

--- a/datagsm-common/build.gradle.kts
+++ b/datagsm-common/build.gradle.kts
@@ -66,6 +66,9 @@ dependencies {
     // Jackson
     api(dependency.Dependencies.JACKSON_DATABIND)
 
+    // Apache HttpClient
+    api(dependency.Dependencies.HTTPCLIENT5)
+
     // Testing
     testImplementation(dependency.Dependencies.KOTLIN_JUNIT5)
     testImplementation(dependency.Dependencies.KOTEST_ASSERTIONS)

--- a/datagsm-common/build.gradle.kts
+++ b/datagsm-common/build.gradle.kts
@@ -65,6 +65,17 @@ dependencies {
 
     // Jackson
     api(dependency.Dependencies.JACKSON_DATABIND)
+
+    // Testing
+    testImplementation(dependency.Dependencies.KOTLIN_JUNIT5)
+    testImplementation(dependency.Dependencies.KOTEST_ASSERTIONS)
+    testImplementation(dependency.Dependencies.KOTEST_RUNNER)
+    testImplementation(dependency.Dependencies.KOTEST_FRAMEWORK)
+    testRuntimeOnly(dependency.Dependencies.JUNIT_PLATFORM_LAUNCHER)
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }
 
 kotlin {

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/service/WebhookSender.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/service/WebhookSender.kt
@@ -6,6 +6,7 @@ import org.springframework.retry.annotation.Recover
 import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
+import team.themoment.datagsm.common.domain.webhook.validator.WebhookUrlValidator
 import team.themoment.sdk.logging.logger.logger
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
@@ -23,6 +24,10 @@ class WebhookSender {
         secret: String,
         payloadJson: String,
     ) {
+        if (WebhookUrlValidator.isPrivateOrLocalUrl(targetUrl)) {
+            logger().warn("Blocked SSRF attempt detected for webhook target url {}", targetUrl)
+            return
+        }
         val signature = computeHmacSha256(secret, payloadJson)
         restClient
             .post()

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/service/WebhookSender.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/service/WebhookSender.kt
@@ -1,6 +1,12 @@
 package team.themoment.datagsm.common.domain.webhook.service
 
+import org.apache.hc.client5.http.DnsResolver
+import org.apache.hc.client5.http.SystemDefaultDnsResolver
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
 import org.springframework.http.MediaType
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.retry.annotation.Backoff
 import org.springframework.retry.annotation.Recover
 import org.springframework.retry.annotation.Retryable
@@ -8,6 +14,8 @@ import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 import team.themoment.datagsm.common.domain.webhook.validator.WebhookUrlValidator
 import team.themoment.sdk.logging.logger.logger
+import java.net.InetAddress
+import java.net.UnknownHostException
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -16,6 +24,7 @@ class WebhookSender {
     private val restClient: RestClient =
         RestClient
             .builder()
+            .requestFactory(HttpComponentsClientHttpRequestFactory(buildSsrfSafeHttpClient()))
             .build()
 
     @Retryable(maxAttempts = 3, backoff = Backoff(delay = 1000, multiplier = 10.0))
@@ -24,10 +33,6 @@ class WebhookSender {
         secret: String,
         payloadJson: String,
     ) {
-        if (WebhookUrlValidator.isPrivateOrLocalUrl(targetUrl)) {
-            logger().warn("Blocked SSRF attempt detected for webhook target url {}", targetUrl)
-            return
-        }
         val signature = computeHmacSha256(secret, payloadJson)
         restClient
             .post()
@@ -47,6 +52,36 @@ class WebhookSender {
         payloadJson: String,
     ) {
         logger().warn("Failed to deliver webhook after 3 attempts url {} error {}", targetUrl, e.message)
+    }
+
+    private fun buildSsrfSafeHttpClient(): CloseableHttpClient {
+        val ssrfSafeDnsResolver =
+            object : DnsResolver {
+                override fun resolve(host: String): Array<InetAddress> {
+                    val resolved: Array<InetAddress> =
+                        try {
+                            SystemDefaultDnsResolver.INSTANCE.resolve(host)
+                        } catch (e: UnknownHostException) {
+                            emptyArray()
+                        }
+                    if (resolved.any { WebhookUrlValidator.isPrivateAddress(it) }) {
+                        throw UnknownHostException("Blocked private/local host $host")
+                    }
+                    return resolved
+                }
+
+                override fun resolveCanonicalHostname(host: String): String =
+                    SystemDefaultDnsResolver.INSTANCE.resolveCanonicalHostname(host)
+            }
+        val connectionManager =
+            PoolingHttpClientConnectionManagerBuilder
+                .create()
+                .setDnsResolver(ssrfSafeDnsResolver)
+                .build()
+        return HttpClients
+            .custom()
+            .setConnectionManager(connectionManager)
+            .build()
     }
 
     private fun computeHmacSha256(

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidator.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidator.kt
@@ -11,16 +11,17 @@ import java.util.concurrent.TimeoutException
 object WebhookUrlValidator {
     private const val DNS_TIMEOUT_SECONDS = 3L
 
+    fun isPrivateAddress(address: InetAddress): Boolean =
+        address.isLoopbackAddress ||
+            address.isSiteLocalAddress ||
+            address.isLinkLocalAddress ||
+            address.isAnyLocalAddress
+
     fun isPrivateOrLocalUrl(url: String): Boolean =
         try {
             val host = URI(url).host ?: return true
             val addresses = resolveWithTimeout(host) ?: return true
-            addresses.any { address ->
-                address.isLoopbackAddress ||
-                    address.isSiteLocalAddress ||
-                    address.isLinkLocalAddress ||
-                    address.isAnyLocalAddress
-            }
+            addresses.any { isPrivateAddress(it) }
         } catch (e: Exception) {
             logger().warn("Blocked webhook url due to unexpected parse error {}", e.message)
             true

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidator.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidator.kt
@@ -2,17 +2,25 @@ package team.themoment.datagsm.common.domain.webhook.validator
 
 import java.net.InetAddress
 import java.net.URI
+import java.net.UnknownHostException
 
 object WebhookUrlValidator {
     fun isPrivateOrLocalUrl(url: String): Boolean =
         try {
             val host = URI(url).host ?: return true
-            val address = InetAddress.getByName(host)
-            address.isLoopbackAddress ||
-                address.isSiteLocalAddress ||
-                address.isLinkLocalAddress ||
-                address.isAnyLocalAddress
+            val addresses =
+                try {
+                    InetAddress.getAllByName(host)
+                } catch (e: UnknownHostException) {
+                    emptyArray()
+                }
+            addresses.any { address ->
+                address.isLoopbackAddress ||
+                    address.isSiteLocalAddress ||
+                    address.isLinkLocalAddress ||
+                    address.isAnyLocalAddress
+            }
         } catch (e: Exception) {
-            false
+            true
         }
 }

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidator.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidator.kt
@@ -1,19 +1,20 @@
 package team.themoment.datagsm.common.domain.webhook.validator
 
+import team.themoment.sdk.logging.logger.logger
 import java.net.InetAddress
 import java.net.URI
 import java.net.UnknownHostException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 object WebhookUrlValidator {
+    private const val DNS_TIMEOUT_SECONDS = 3L
+
     fun isPrivateOrLocalUrl(url: String): Boolean =
         try {
             val host = URI(url).host ?: return true
-            val addresses =
-                try {
-                    InetAddress.getAllByName(host)
-                } catch (e: UnknownHostException) {
-                    emptyArray()
-                }
+            val addresses = resolveWithTimeout(host) ?: return true
             addresses.any { address ->
                 address.isLoopbackAddress ||
                     address.isSiteLocalAddress ||
@@ -21,6 +22,26 @@ object WebhookUrlValidator {
                     address.isAnyLocalAddress
             }
         } catch (e: Exception) {
+            logger().warn("Blocked webhook url due to unexpected parse error {}", e.message)
             true
+        }
+
+    // null = 차단 (타임아웃 또는 예상치 못한 오류), emptyArray = 존재하지 않는 도메인 (허용)
+    private fun resolveWithTimeout(host: String): Array<InetAddress>? =
+        try {
+            CompletableFuture
+                .supplyAsync { InetAddress.getAllByName(host) }
+                .get(DNS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        } catch (e: TimeoutException) {
+            logger().warn("Blocked webhook url due to DNS lookup timeout for host {}", host)
+            null
+        } catch (e: Exception) {
+            val cause = e.cause
+            if (cause is UnknownHostException) {
+                emptyArray()
+            } else {
+                logger().warn("Blocked webhook url due to DNS resolution failure for host {} error {}", host, e.message)
+                null
+            }
         }
 }

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidator.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidator.kt
@@ -1,0 +1,18 @@
+package team.themoment.datagsm.common.domain.webhook.validator
+
+import java.net.InetAddress
+import java.net.URI
+
+object WebhookUrlValidator {
+    fun isPrivateOrLocalUrl(url: String): Boolean =
+        try {
+            val host = URI(url).host ?: return true
+            val address = InetAddress.getByName(host)
+            address.isLoopbackAddress ||
+                address.isSiteLocalAddress ||
+                address.isLinkLocalAddress ||
+                address.isAnyLocalAddress
+        } catch (e: Exception) {
+            false
+        }
+}

--- a/datagsm-common/src/test/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidatorTest.kt
+++ b/datagsm-common/src/test/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidatorTest.kt
@@ -149,6 +149,19 @@ class WebhookUrlValidatorTest :
                         result shouldBe true
                     }
                 }
+
+                context("존재하지 않는 도메인이 주어질 때") {
+                    it("false를 반환해야 한다") {
+                        // Given
+                        val url = "http://this-domain-does-not-exist-datagsm.invalid/hook"
+
+                        // When
+                        val result = WebhookUrlValidator.isPrivateOrLocalUrl(url)
+
+                        // Then
+                        result shouldBe false
+                    }
+                }
             }
         }
     })

--- a/datagsm-common/src/test/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidatorTest.kt
+++ b/datagsm-common/src/test/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidatorTest.kt
@@ -1,0 +1,62 @@
+package team.themoment.datagsm.common.domain.webhook.validator
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class WebhookUrlValidatorTest :
+    DescribeSpec({
+        describe("WebhookUrlValidator의") {
+            describe("isPrivateOrLocalUrl 메서드는") {
+                context("유효한 외부 URL이 주어질 때") {
+                    it("false를 반환해야 한다") {
+                        WebhookUrlValidator.isPrivateOrLocalUrl("https://example.com/hook") shouldBe false
+                        WebhookUrlValidator.isPrivateOrLocalUrl("http://example.com/hook") shouldBe false
+                    }
+                }
+
+                context("localhost URL이 주어질 때") {
+                    it("true를 반환해야 한다") {
+                        WebhookUrlValidator.isPrivateOrLocalUrl("http://localhost/hook") shouldBe true
+                        WebhookUrlValidator.isPrivateOrLocalUrl("https://localhost:8080/hook") shouldBe true
+                    }
+                }
+
+                context("루프백 IP(127.x.x.x)가 주어질 때") {
+                    it("true를 반환해야 한다") {
+                        WebhookUrlValidator.isPrivateOrLocalUrl("http://127.0.0.1/hook") shouldBe true
+                        WebhookUrlValidator.isPrivateOrLocalUrl("http://127.0.0.1:8080/hook") shouldBe true
+                    }
+                }
+
+                context("10.x.x.x 대역 IP가 주어질 때") {
+                    it("true를 반환해야 한다") {
+                        WebhookUrlValidator.isPrivateOrLocalUrl("http://10.0.0.1/hook") shouldBe true
+                    }
+                }
+
+                context("172.16.x.x 대역 IP가 주어질 때") {
+                    it("true를 반환해야 한다") {
+                        WebhookUrlValidator.isPrivateOrLocalUrl("http://172.16.0.1/hook") shouldBe true
+                    }
+                }
+
+                context("192.168.x.x 대역 IP가 주어질 때") {
+                    it("true를 반환해야 한다") {
+                        WebhookUrlValidator.isPrivateOrLocalUrl("http://192.168.1.1/hook") shouldBe true
+                    }
+                }
+
+                context("링크-로컬 IP(169.254.x.x)가 주어질 때") {
+                    it("true를 반환해야 한다") {
+                        WebhookUrlValidator.isPrivateOrLocalUrl("http://169.254.169.254/hook") shouldBe true
+                    }
+                }
+
+                context("IPv6 루프백(::1)이 주어질 때") {
+                    it("true를 반환해야 한다") {
+                        WebhookUrlValidator.isPrivateOrLocalUrl("http://[::1]/hook") shouldBe true
+                    }
+                }
+            }
+        }
+    })

--- a/datagsm-common/src/test/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidatorTest.kt
+++ b/datagsm-common/src/test/kotlin/team/themoment/datagsm/common/domain/webhook/validator/WebhookUrlValidatorTest.kt
@@ -5,56 +5,148 @@ import io.kotest.matchers.shouldBe
 
 class WebhookUrlValidatorTest :
     DescribeSpec({
-        describe("WebhookUrlValidator의") {
+        describe("WebhookUrlValidator 클래스의") {
             describe("isPrivateOrLocalUrl 메서드는") {
-                context("유효한 외부 URL이 주어질 때") {
+                context("유효한 외부 HTTPS URL이 주어질 때") {
                     it("false를 반환해야 한다") {
-                        WebhookUrlValidator.isPrivateOrLocalUrl("https://example.com/hook") shouldBe false
-                        WebhookUrlValidator.isPrivateOrLocalUrl("http://example.com/hook") shouldBe false
+                        // Given
+                        val url = "https://example.com/hook"
+
+                        // When
+                        val result = WebhookUrlValidator.isPrivateOrLocalUrl(url)
+
+                        // Then
+                        result shouldBe false
+                    }
+                }
+
+                context("유효한 외부 HTTP URL이 주어질 때") {
+                    it("false를 반환해야 한다") {
+                        // Given
+                        val url = "http://example.com/hook"
+
+                        // When
+                        val result = WebhookUrlValidator.isPrivateOrLocalUrl(url)
+
+                        // Then
+                        result shouldBe false
                     }
                 }
 
                 context("localhost URL이 주어질 때") {
                     it("true를 반환해야 한다") {
-                        WebhookUrlValidator.isPrivateOrLocalUrl("http://localhost/hook") shouldBe true
-                        WebhookUrlValidator.isPrivateOrLocalUrl("https://localhost:8080/hook") shouldBe true
+                        // Given
+                        val url = "http://localhost/hook"
+
+                        // When
+                        val result = WebhookUrlValidator.isPrivateOrLocalUrl(url)
+
+                        // Then
+                        result shouldBe true
                     }
                 }
 
-                context("루프백 IP(127.x.x.x)가 주어질 때") {
+                context("포트가 포함된 localhost URL이 주어질 때") {
                     it("true를 반환해야 한다") {
-                        WebhookUrlValidator.isPrivateOrLocalUrl("http://127.0.0.1/hook") shouldBe true
-                        WebhookUrlValidator.isPrivateOrLocalUrl("http://127.0.0.1:8080/hook") shouldBe true
+                        // Given
+                        val url = "https://localhost:8080/hook"
+
+                        // When
+                        val result = WebhookUrlValidator.isPrivateOrLocalUrl(url)
+
+                        // Then
+                        result shouldBe true
+                    }
+                }
+
+                context("루프백 IP(127.0.0.1)가 주어질 때") {
+                    it("true를 반환해야 한다") {
+                        // Given
+                        val url = "http://127.0.0.1/hook"
+
+                        // When
+                        val result = WebhookUrlValidator.isPrivateOrLocalUrl(url)
+
+                        // Then
+                        result shouldBe true
+                    }
+                }
+
+                context("포트가 포함된 루프백 IP(127.0.0.1:8080)가 주어질 때") {
+                    it("true를 반환해야 한다") {
+                        // Given
+                        val url = "http://127.0.0.1:8080/hook"
+
+                        // When
+                        val result = WebhookUrlValidator.isPrivateOrLocalUrl(url)
+
+                        // Then
+                        result shouldBe true
                     }
                 }
 
                 context("10.x.x.x 대역 IP가 주어질 때") {
                     it("true를 반환해야 한다") {
-                        WebhookUrlValidator.isPrivateOrLocalUrl("http://10.0.0.1/hook") shouldBe true
+                        // Given
+                        val url = "http://10.0.0.1/hook"
+
+                        // When
+                        val result = WebhookUrlValidator.isPrivateOrLocalUrl(url)
+
+                        // Then
+                        result shouldBe true
                     }
                 }
 
                 context("172.16.x.x 대역 IP가 주어질 때") {
                     it("true를 반환해야 한다") {
-                        WebhookUrlValidator.isPrivateOrLocalUrl("http://172.16.0.1/hook") shouldBe true
+                        // Given
+                        val url = "http://172.16.0.1/hook"
+
+                        // When
+                        val result = WebhookUrlValidator.isPrivateOrLocalUrl(url)
+
+                        // Then
+                        result shouldBe true
                     }
                 }
 
                 context("192.168.x.x 대역 IP가 주어질 때") {
                     it("true를 반환해야 한다") {
-                        WebhookUrlValidator.isPrivateOrLocalUrl("http://192.168.1.1/hook") shouldBe true
+                        // Given
+                        val url = "http://192.168.1.1/hook"
+
+                        // When
+                        val result = WebhookUrlValidator.isPrivateOrLocalUrl(url)
+
+                        // Then
+                        result shouldBe true
                     }
                 }
 
-                context("링크-로컬 IP(169.254.x.x)가 주어질 때") {
+                context("링크-로컬 IP(169.254.169.254)가 주어질 때") {
                     it("true를 반환해야 한다") {
-                        WebhookUrlValidator.isPrivateOrLocalUrl("http://169.254.169.254/hook") shouldBe true
+                        // Given
+                        val url = "http://169.254.169.254/hook"
+
+                        // When
+                        val result = WebhookUrlValidator.isPrivateOrLocalUrl(url)
+
+                        // Then
+                        result shouldBe true
                     }
                 }
 
                 context("IPv6 루프백(::1)이 주어질 때") {
                     it("true를 반환해야 한다") {
-                        WebhookUrlValidator.isPrivateOrLocalUrl("http://[::1]/hook") shouldBe true
+                        // Given
+                        val url = "http://[::1]/hook"
+
+                        // When
+                        val result = WebhookUrlValidator.isPrivateOrLocalUrl(url)
+
+                        // Then
+                        result shouldBe true
                     }
                 }
             }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/impl/CreateWebhookServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/impl/CreateWebhookServiceImpl.kt
@@ -7,6 +7,7 @@ import team.themoment.datagsm.common.domain.webhook.dto.request.CreateWebhookReq
 import team.themoment.datagsm.common.domain.webhook.dto.response.CreateWebhookResDto
 import team.themoment.datagsm.common.domain.webhook.entity.WebhookJpaEntity
 import team.themoment.datagsm.common.domain.webhook.repository.WebhookJpaRepository
+import team.themoment.datagsm.common.domain.webhook.validator.WebhookUrlValidator
 import team.themoment.datagsm.openapi.domain.webhook.service.CreateWebhookService
 import team.themoment.datagsm.openapi.global.security.provider.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
@@ -23,6 +24,10 @@ class CreateWebhookServiceImpl(
 
         if (webhookJpaRepository.countByAccount(account) >= MAX_WEBHOOKS_PER_ACCOUNT) {
             throw ExpectedException("Webhook은 최대 10개까지 등록할 수 있습니다.", HttpStatus.BAD_REQUEST)
+        }
+
+        if (WebhookUrlValidator.isPrivateOrLocalUrl(reqDto.targetUrl)) {
+            throw ExpectedException("내부 네트워크 URL은 Webhook 수신 URL로 등록할 수 없습니다.", HttpStatus.BAD_REQUEST)
         }
 
         val secret = generateSecret()

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/impl/ModifyWebhookServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/impl/ModifyWebhookServiceImpl.kt
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.webhook.dto.request.ModifyWebhookReqDto
 import team.themoment.datagsm.common.domain.webhook.dto.response.WebhookResDto
 import team.themoment.datagsm.common.domain.webhook.repository.WebhookJpaRepository
+import team.themoment.datagsm.common.domain.webhook.validator.WebhookUrlValidator
 import team.themoment.datagsm.openapi.domain.webhook.service.ModifyWebhookService
 import team.themoment.datagsm.openapi.global.security.provider.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
@@ -25,7 +26,12 @@ class ModifyWebhookServiceImpl(
             webhookJpaRepository.findByIdAndAccount(webhookId, account)
                 ?: throw ExpectedException("Webhook을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
 
-        reqDto.targetUrl?.let { webhook.targetUrl = it }
+        reqDto.targetUrl?.let {
+            if (WebhookUrlValidator.isPrivateOrLocalUrl(it)) {
+                throw ExpectedException("내부 네트워크 URL은 Webhook 수신 URL로 등록할 수 없습니다.", HttpStatus.BAD_REQUEST)
+            }
+            webhook.targetUrl = it
+        }
         reqDto.events?.let {
             webhook.events.clear()
             webhook.events.addAll(it)


### PR DESCRIPTION
## 개요

Webhook 수신 URL 등록 시 `localhost`, `127.0.0.1`, `192.168.x.x` 등 내부 네트워크 주소를 허용하던 SSRF(Server-Side Request Forgery) 취약점을 수정하였습니다. 기존에는 `@field:Pattern(regexp = "^https?://.*")` 검증만 존재하여 프로토콜 형식만 확인하였으므로, 악의적인 사용자가 서버 내부 서비스에 요청을 유도하는 것이 가능하였습니다.

## 본문

### 문제

`WebhookSender.send()`는 사용자가 등록한 `targetUrl`로 `RestClient`를 통해 직접 HTTP POST 요청을 전송하는 구조입니다. DTO 레벨의 검증이 `^https?://.*` 패턴만 확인하였으므로 아래와 같은 URL 등록이 모두 허용되었습니다.

- `http://localhost:8080/admin`
- `http://127.0.0.1/internal`
- `http://10.0.0.1/hook`
- `http://192.168.1.1/hook`
- `http://169.254.169.254/latest/meta-data` (AWS 메타데이터 엔드포인트)
- `http://[::1]/hook` (IPv6 루프백)

### 해결

**`WebhookUrlValidator` 유틸리티 추가** (`datagsm-common`)

`java.net.InetAddress.getByName()`으로 DNS 조회를 포함한 IP 검증을 수행하는 `object WebhookUrlValidator`를 추가하였습니다. `isLoopbackAddress()`, `isSiteLocalAddress()`, `isLinkLocalAddress()`, `isAnyLocalAddress()`를 조합하여 아래 대역을 모두 차단합니다.

| 대역 | 메서드 |
|------|--------|
| `127.0.0.0/8`, `::1` | `isLoopbackAddress()` |
| `10.x.x.x`, `172.16-31.x.x`, `192.168.x.x` | `isSiteLocalAddress()` |
| `169.254.x.x`, `fe80::/10` | `isLinkLocalAddress()` |
| `0.0.0.0`, `::` | `isAnyLocalAddress()` |

DNS rebinding 공격도 resolved IP를 직접 검사하여 방어하였습니다.

**서비스 레이어 검증 추가**

`CreateWebhookServiceImpl.execute()`와 `ModifyWebhookServiceImpl.execute()`에서 `targetUrl` 저장 전 `WebhookUrlValidator.isPrivateOrLocalUrl()`을 호출하도록 수정하였습니다. 위반 시 `ExpectedException("내부 네트워크 URL은 Webhook 수신 URL로 등록할 수 없습니다.", HttpStatus.BAD_REQUEST)`를 발생시킵니다.

**`WebhookSender` 방어 심층 가드 추가**

DB에 이미 저장된 잘못된 URL에 대한 방어를 위해 `send()` 메서드 최상단에 early-return 가드를 추가하였습니다. 차단 시 `warn` 로그를 기록하고 전송을 스킵합니다. `@Retryable` 재시도 낭비 없이 즉시 반환하도록 구현하였습니다.

**테스트**

`WebhookUrlValidatorTest`를 `datagsm-common` 모듈에 추가하였습니다. `localhost`, `127.x.x.x`, `10.x.x.x`, `172.16.x.x`, `192.168.x.x`, `169.254.x.x`, `[::1]`, 외부 URL 등 8가지 케이스를 검증합니다.

### 관련 이슈

closes #333
