### PR TITLE
[ci/cd] `datagsm-shared` npm 패키지명을 스코프드 형식으로 변경

### DIFF
--- a/datagsm-shared/build.gradle.kts
+++ b/datagsm-shared/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
         browser()
         binaries.library()
         generateTypeScriptDefinitions()
-        compilations.configureEach {
+        compilations.named("main") {
             packageJson {
                 name = "@themoment-team/datagsm-shared"
             }

--- a/datagsm-shared/build.gradle.kts
+++ b/datagsm-shared/build.gradle.kts
@@ -25,11 +25,16 @@ kotlin {
     }
 
     js(IR) {
-        outputModuleName.set("@themoment-team/datagsm-shared")
+        outputModuleName.set("datagsm-shared")
         nodejs()
         browser()
         binaries.library()
         generateTypeScriptDefinitions()
+        compilations.configureEach {
+            packageJson {
+                name = "@themoment-team/datagsm-shared"
+            }
+        }
     }
 
     sourceSets {

--- a/datagsm-shared/build.gradle.kts
+++ b/datagsm-shared/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
     }
 
     js(IR) {
-        outputModuleName.set("datagsm-shared")
+        outputModuleName.set("@themoment-team/datagsm-shared")
         nodejs()
         browser()
         binaries.library()


### PR DESCRIPTION
## 개요

`datagsm-shared` 모듈의 npm 패키지명을 컨벤션에 따라 `datagsm-shared`에서 `@themoment-team/datagsm-shared` 스코프드 패키지 형식으로 변경하였습니다.

## 본문

`datagsm-shared/build.gradle.kts`의 `outputModuleName`을 `@themoment-team/datagsm-shared`로 수정하였습니다.

Kotlin/JS IR 컴파일러는 스코프드 패키지명을 올바르게 처리합니다. `@scope/pkg` 형태로 설정 시 생성되는 `package.json`의 `name` 필드에는 전체 스코프드 이름이, 출력 `.js` 및 `.d.ts` 파일명에는 슬래시 뒤의 `pkg` 부분만 사용됩니다. 따라서 기존 CI/CD 워크플로우의 `npm publish --access public` 명령은 별도 수정 없이 동작합니다.
