### PR TITLE
[webhook] `datagsm-openapi` 모듈 Webhook 관리 API에 사용중지 적용

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/repository/WebhookJpaRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/webhook/repository/WebhookJpaRepository.kt
@@ -8,13 +8,25 @@ import team.themoment.datagsm.common.domain.webhook.entity.constant.WebhookEvent
 
 @Repository
 interface WebhookJpaRepository : JpaRepository<WebhookJpaEntity, Long> {
+    @Deprecated(
+        message = "datagsm-openapi Webhook 관리 API 이전에 따라 제거 예정입니다. issue #344 참고",
+        level = DeprecationLevel.WARNING,
+    )
     fun findAllByAccount(account: AccountJpaEntity): List<WebhookJpaEntity>
 
+    @Deprecated(
+        message = "datagsm-openapi Webhook 관리 API 이전에 따라 제거 예정입니다. issue #344 참고",
+        level = DeprecationLevel.WARNING,
+    )
     fun findByIdAndAccount(
         id: Long,
         account: AccountJpaEntity,
     ): WebhookJpaEntity?
 
+    @Deprecated(
+        message = "datagsm-openapi Webhook 관리 API 이전에 따라 제거 예정입니다. issue #344 참고",
+        level = DeprecationLevel.WARNING,
+    )
     fun countByAccount(account: AccountJpaEntity): Long
 
     fun findAllByEventsContainsAndIsActiveTrue(event: WebhookEvent): List<WebhookJpaEntity>

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/controller/WebhookController.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/controller/WebhookController.kt
@@ -38,7 +38,11 @@ class WebhookController(
     private val deleteWebhookService: DeleteWebhookService,
 ) {
     @Deprecated("이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고")
-    @Operation(summary = "Webhook 등록", description = "새로운 Webhook을 등록합니다. secret은 이 응답에서만 확인할 수 있습니다.", deprecated = true)
+    @Operation(
+        summary = "Webhook 등록",
+        description = "새로운 Webhook을 등록합니다. secret은 이 응답에서만 확인할 수 있습니다.",
+        deprecated = true,
+    )
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "등록 성공"),
@@ -54,7 +58,11 @@ class WebhookController(
     ): CreateWebhookResDto = createWebhookService.execute(reqDto)
 
     @Deprecated("이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고")
-    @Operation(summary = "Webhook 목록 조회", description = "현재 API Key 소유자의 Webhook 목록을 조회합니다.", deprecated = true)
+    @Operation(
+        summary = "Webhook 목록 조회",
+        description = "현재 API Key 소유자의 Webhook 목록을 조회합니다.",
+        deprecated = true,
+    )
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "조회 성공"),
@@ -67,7 +75,11 @@ class WebhookController(
     fun getWebhooks(): WebhookListResDto = queryWebhookService.execute()
 
     @Deprecated("이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고")
-    @Operation(summary = "Webhook 수정", description = "Webhook의 수신 URL 또는 구독 이벤트를 수정합니다.", deprecated = true)
+    @Operation(
+        summary = "Webhook 수정",
+        description = "Webhook의 수신 URL 또는 구독 이벤트를 수정합니다.",
+        deprecated = true,
+    )
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "수정 성공"),
@@ -85,7 +97,11 @@ class WebhookController(
     ): WebhookResDto = modifyWebhookService.execute(webhookId, reqDto)
 
     @Deprecated("이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고")
-    @Operation(summary = "Webhook 삭제", description = "등록된 Webhook을 삭제합니다.", deprecated = true)
+    @Operation(
+        summary = "Webhook 삭제",
+        description = "등록된 Webhook을 삭제합니다.",
+        deprecated = true,
+    )
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "삭제 성공"),

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/controller/WebhookController.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/controller/WebhookController.kt
@@ -37,7 +37,8 @@ class WebhookController(
     private val modifyWebhookService: ModifyWebhookService,
     private val deleteWebhookService: DeleteWebhookService,
 ) {
-    @Operation(summary = "Webhook 등록", description = "새로운 Webhook을 등록합니다. secret은 이 응답에서만 확인할 수 있습니다.")
+    @Deprecated("이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고")
+    @Operation(summary = "Webhook 등록", description = "새로운 Webhook을 등록합니다. secret은 이 응답에서만 확인할 수 있습니다.", deprecated = true)
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "등록 성공"),
@@ -52,7 +53,8 @@ class WebhookController(
         @RequestBody @Valid reqDto: CreateWebhookReqDto,
     ): CreateWebhookResDto = createWebhookService.execute(reqDto)
 
-    @Operation(summary = "Webhook 목록 조회", description = "현재 API Key 소유자의 Webhook 목록을 조회합니다.")
+    @Deprecated("이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고")
+    @Operation(summary = "Webhook 목록 조회", description = "현재 API Key 소유자의 Webhook 목록을 조회합니다.", deprecated = true)
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "조회 성공"),
@@ -64,7 +66,8 @@ class WebhookController(
     @GetMapping
     fun getWebhooks(): WebhookListResDto = queryWebhookService.execute()
 
-    @Operation(summary = "Webhook 수정", description = "Webhook의 수신 URL 또는 구독 이벤트를 수정합니다.")
+    @Deprecated("이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고")
+    @Operation(summary = "Webhook 수정", description = "Webhook의 수신 URL 또는 구독 이벤트를 수정합니다.", deprecated = true)
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "수정 성공"),
@@ -81,7 +84,8 @@ class WebhookController(
         @RequestBody @Valid reqDto: ModifyWebhookReqDto,
     ): WebhookResDto = modifyWebhookService.execute(webhookId, reqDto)
 
-    @Operation(summary = "Webhook 삭제", description = "등록된 Webhook을 삭제합니다.")
+    @Deprecated("이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고")
+    @Operation(summary = "Webhook 삭제", description = "등록된 Webhook을 삭제합니다.", deprecated = true)
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "삭제 성공"),

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/controller/WebhookController.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/controller/WebhookController.kt
@@ -31,13 +31,17 @@ import team.themoment.sdk.response.CommonApiResponse
 @Tag(name = "Webhook", description = "Webhook 관련 API")
 @RestController
 @RequestMapping("/v1/webhooks")
+@Suppress("DEPRECATION")
 class WebhookController(
     private val createWebhookService: CreateWebhookService,
     private val queryWebhookService: QueryWebhookService,
     private val modifyWebhookService: ModifyWebhookService,
     private val deleteWebhookService: DeleteWebhookService,
 ) {
-    @Deprecated("이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고")
+    @Deprecated(
+        message = "이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고",
+        level = DeprecationLevel.WARNING,
+    )
     @Operation(
         summary = "Webhook 등록",
         description = "새로운 Webhook을 등록합니다. secret은 이 응답에서만 확인할 수 있습니다.",
@@ -46,7 +50,11 @@ class WebhookController(
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "등록 성공"),
-            ApiResponse(responseCode = "400", description = "잘못된 요청 (검증 실패 또는 Webhook 최대 개수 초과)", content = [Content()]),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (검증 실패 또는 Webhook 최대 개수 초과)",
+                content = [Content()],
+            ),
             ApiResponse(responseCode = "401", description = "인증 실패", content = [Content()]),
             ApiResponse(responseCode = "403", description = "권한 없음", content = [Content()]),
         ],
@@ -57,7 +65,10 @@ class WebhookController(
         @RequestBody @Valid reqDto: CreateWebhookReqDto,
     ): CreateWebhookResDto = createWebhookService.execute(reqDto)
 
-    @Deprecated("이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고")
+    @Deprecated(
+        message = "이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고",
+        level = DeprecationLevel.WARNING,
+    )
     @Operation(
         summary = "Webhook 목록 조회",
         description = "현재 API Key 소유자의 Webhook 목록을 조회합니다.",
@@ -74,7 +85,10 @@ class WebhookController(
     @GetMapping
     fun getWebhooks(): WebhookListResDto = queryWebhookService.execute()
 
-    @Deprecated("이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고")
+    @Deprecated(
+        message = "이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고",
+        level = DeprecationLevel.WARNING,
+    )
     @Operation(
         summary = "Webhook 수정",
         description = "Webhook의 수신 URL 또는 구독 이벤트를 수정합니다.",
@@ -96,7 +110,10 @@ class WebhookController(
         @RequestBody @Valid reqDto: ModifyWebhookReqDto,
     ): WebhookResDto = modifyWebhookService.execute(webhookId, reqDto)
 
-    @Deprecated("이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고")
+    @Deprecated(
+        message = "이 API는 datagsm-web으로 이전 예정입니다. issue #344 참고",
+        level = DeprecationLevel.WARNING,
+    )
     @Operation(
         summary = "Webhook 삭제",
         description = "등록된 Webhook을 삭제합니다.",

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/CreateWebhookService.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/CreateWebhookService.kt
@@ -3,6 +3,10 @@ package team.themoment.datagsm.openapi.domain.webhook.service
 import team.themoment.datagsm.common.domain.webhook.dto.request.CreateWebhookReqDto
 import team.themoment.datagsm.common.domain.webhook.dto.response.CreateWebhookResDto
 
+@Deprecated(
+    message = "이 인터페이스는 datagsm-web 모듈로 이전 예정입니다. issue #344 참고",
+    level = DeprecationLevel.WARNING,
+)
 interface CreateWebhookService {
     fun execute(reqDto: CreateWebhookReqDto): CreateWebhookResDto
 }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/DeleteWebhookService.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/DeleteWebhookService.kt
@@ -1,5 +1,9 @@
 package team.themoment.datagsm.openapi.domain.webhook.service
 
+@Deprecated(
+    message = "이 인터페이스는 datagsm-web 모듈로 이전 예정입니다. issue #344 참고",
+    level = DeprecationLevel.WARNING,
+)
 interface DeleteWebhookService {
     fun execute(webhookId: Long)
 }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/ModifyWebhookService.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/ModifyWebhookService.kt
@@ -3,6 +3,10 @@ package team.themoment.datagsm.openapi.domain.webhook.service
 import team.themoment.datagsm.common.domain.webhook.dto.request.ModifyWebhookReqDto
 import team.themoment.datagsm.common.domain.webhook.dto.response.WebhookResDto
 
+@Deprecated(
+    message = "이 인터페이스는 datagsm-web 모듈로 이전 예정입니다. issue #344 참고",
+    level = DeprecationLevel.WARNING,
+)
 interface ModifyWebhookService {
     fun execute(
         webhookId: Long,

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/QueryWebhookService.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/QueryWebhookService.kt
@@ -2,6 +2,10 @@ package team.themoment.datagsm.openapi.domain.webhook.service
 
 import team.themoment.datagsm.common.domain.webhook.dto.response.WebhookListResDto
 
+@Deprecated(
+    message = "이 인터페이스는 datagsm-web 모듈로 이전 예정입니다. issue #344 참고",
+    level = DeprecationLevel.WARNING,
+)
 interface QueryWebhookService {
     fun execute(): WebhookListResDto
 }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/impl/CreateWebhookServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/impl/CreateWebhookServiceImpl.kt
@@ -13,6 +13,11 @@ import team.themoment.datagsm.openapi.global.security.provider.CurrentUserProvid
 import team.themoment.sdk.exception.ExpectedException
 import java.security.SecureRandom
 
+@Deprecated(
+    message = "이 클래스는 datagsm-web 모듈로 이전 예정입니다. issue #344 참고",
+    level = DeprecationLevel.WARNING,
+)
+@Suppress("DEPRECATION")
 @Service
 class CreateWebhookServiceImpl(
     private val webhookJpaRepository: WebhookJpaRepository,

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/impl/DeleteWebhookServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/impl/DeleteWebhookServiceImpl.kt
@@ -8,6 +8,11 @@ import team.themoment.datagsm.openapi.domain.webhook.service.DeleteWebhookServic
 import team.themoment.datagsm.openapi.global.security.provider.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
 
+@Deprecated(
+    message = "이 클래스는 datagsm-web 모듈로 이전 예정입니다. issue #344 참고",
+    level = DeprecationLevel.WARNING,
+)
+@Suppress("DEPRECATION")
 @Service
 class DeleteWebhookServiceImpl(
     private val webhookJpaRepository: WebhookJpaRepository,

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/impl/ModifyWebhookServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/impl/ModifyWebhookServiceImpl.kt
@@ -11,6 +11,11 @@ import team.themoment.datagsm.openapi.domain.webhook.service.ModifyWebhookServic
 import team.themoment.datagsm.openapi.global.security.provider.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
 
+@Deprecated(
+    message = "이 클래스는 datagsm-web 모듈로 이전 예정입니다. issue #344 참고",
+    level = DeprecationLevel.WARNING,
+)
+@Suppress("DEPRECATION")
 @Service
 class ModifyWebhookServiceImpl(
     private val webhookJpaRepository: WebhookJpaRepository,

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/impl/QueryWebhookServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/webhook/service/impl/QueryWebhookServiceImpl.kt
@@ -8,6 +8,11 @@ import team.themoment.datagsm.common.domain.webhook.repository.WebhookJpaReposit
 import team.themoment.datagsm.openapi.domain.webhook.service.QueryWebhookService
 import team.themoment.datagsm.openapi.global.security.provider.CurrentUserProvider
 
+@Deprecated(
+    message = "이 클래스는 datagsm-web 모듈로 이전 예정입니다. issue #344 참고",
+    level = DeprecationLevel.WARNING,
+)
+@Suppress("DEPRECATION")
 @Service
 class QueryWebhookServiceImpl(
     private val webhookJpaRepository: WebhookJpaRepository,


### PR DESCRIPTION
## 개요

`datagsm-openapi`의 Webhook 관리 API 전체(컨트롤러, 서비스 인터페이스/구현체, 레포지터리 쿼리 메서드)에 `@Deprecated` 처리를 적용하였습니다. Webhook 관리 API는 향후 `datagsm-web`으로 이전될 예정이며, 이는 issue #344 에서 추적됩니다.

## 본문

API 키 관리 및 OAuth 클라이언트 관리는 `datagsm-web`(JWT 인증)에서 사용자가 직접 다루는 리소스인데, Webhook 관리만 `datagsm-openapi`(API Key 인증)에 위치해 있어 관리 기능의 인증 방식이 불일치하였습니다.

이를 해소하기 위해 Webhook 관리 API를 `datagsm-web`으로 이전하는 작업을 계획하였고, 이전 완료 전까지 관련 코드 전반에 deprecated 처리를 적용하였습니다.

**변경 내용**
- `WebhookController` 4개 메서드에 `@Deprecated(message, level)` 추가, `@Operation(deprecated = true)` 설정
- `@ApiResponse` 120자 초과 라인 멀티라인으로 분리
- `WebhookController`에 `@Suppress("DEPRECATION")` 추가
- `CreateWebhookService`, `QueryWebhookService`, `ModifyWebhookService`, `DeleteWebhookService` 인터페이스에 `@Deprecated` 추가
- `CreateWebhookServiceImpl`, `QueryWebhookServiceImpl`, `ModifyWebhookServiceImpl`, `DeleteWebhookServiceImpl`에 `@Deprecated` 및 `@Suppress("DEPRECATION")` 추가
- `WebhookJpaRepository`의 `findAllByAccount`, `findByIdAndAccount`, `countByAccount` 3개 메서드에 `@Deprecated` 추가 (`findAllByEventsContainsAndIsActiveTrue`는 `WebhookPublisherImpl`이 사용하므로 제외)