### PR TITLE
[ci/cd] Harness 동기화 언어 설정을 한국어로 변경

### DIFF
--- a/.harness/sync.yml
+++ b/.harness/sync.yml
@@ -27,3 +27,5 @@ overrides:
 
 branch_prefix: update/
 base_branch: develop
+
+language: ko


### PR DESCRIPTION
## 개요

`.harness/sync.yml` 파일에 한국어 설정을 추가하였습니다.

## 본문

Harness 동기화 설정 파일인 `.harness/sync.yml`의 `language` 속성을 `ko`로 설정하여 기본 언어를 한국어로 지정하였습니다.
