### PR TITLE
[oauth] `SecurityConfig` 세션 정책을 `STATELESS`로 변경

### DIFF
--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/security/config/SecurityConfig.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/security/config/SecurityConfig.kt
@@ -36,7 +36,7 @@ class SecurityConfig(
             .httpBasic(HttpBasicConfigurer<*>::disable)
             .formLogin(FormLoginConfigurer<*>::disable)
             .logout(LogoutConfigurer<*>::disable)
-            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED) }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .exceptionHandling { it.authenticationEntryPoint(customAuthenticationEntryPoint) }
             .addFilterBefore(
                 JwtAuthenticationFilter(jwtProvider, objectMapper),


### PR DESCRIPTION
## 개요

`datagsm-oauth-authorization` 모듈의 `SecurityConfig` 세션 생성 정책을 `SessionCreationPolicy.IF_REQUIRED`에서 `SessionCreationPolicy.STATELESS`로 변경하였습니다.

## 본문

기존에는 세션 생성 정책이 `IF_REQUIRED`로 설정되어 있어, 유효한 JWT 토큰 없이 요청이 들어올 경우 `Spring Security`가 불필요한 HTTP 세션을 생성하였습니다. 이는 JWT 기반 무상태 설계 원칙에 위배되며, 향후 필터나 인터셉터가 세션을 의도치 않게 참조할 경우 세션 기반 인증 우회 경로가 생길 수 있습니다.

`datagsm-web`, `datagsm-openapi`, `datagsm-oauth-userinfo` 등 다른 모든 모듈은 이미 `STATELESS`를 사용하고 있어, 본 변경으로 모듈 간 일관성을 맞추고 무상태 인증 원칙을 준수하도록 하였습니다.

- 변경 파일: `SecurityConfig.kt`
- `:datagsm-oauth-authorization:test` 전체 통과를 확인하였습니다.

Closes #350
