### PR TITLE
[oauth] `Oauth2TokenServiceImpl` 트랜잭션 `readOnly` 제거

### DIFF
--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
@@ -39,7 +39,7 @@ class Oauth2TokenServiceImpl(
     private val oauthScopeJpaRepository: OAuthScopeJpaRepository,
     private val oauthClientRateLimitService: OAuthClientRateLimitService,
 ) : Oauth2TokenService {
-    @Transactional(readOnly = true)
+    @Transactional
     override fun execute(reqDto: Oauth2TokenReqDto): Oauth2TokenResDto {
         val grantType = GrantType.from(reqDto.grantType)
 


### PR DESCRIPTION
## 개요

`Oauth2TokenServiceImpl.execute()`의 `@Transactional(readOnly = true)`를 `@Transactional`로 변경하였습니다.

## 본문

`execute()` 메서드는 `@Transactional(readOnly = true)`로 선언되어 있었으나, 내부에서 다음과 같은 쓰기 작업을 수행하였습니다.

- `oauthRefreshTokenRedisRepository.save()` — 신규 `refresh token` 저장
- `oauthCodeRedisRepository.delete()` — 인증 코드 삭제
- 기존 `refresh token` 삭제

`Redis` 작업은 JPA `readOnly` 플래그의 영향을 받지 않아 현재는 동작하지만, JPA `EntityManager`가 read-only 모드로 열린 상태에서 하위 호출에 JPA 쓰기가 포함되면 flush 시점에 실패할 수 있습니다. 또한 `Redis` 코드 삭제가 먼저 커밋된 뒤 JPA 트랜잭션이 롤백되면, 인증 코드는 소진되었으나 토큰은 발급되지 않는 비정상 상태가 발생할 수 있습니다.

이를 방지하기 위해 `readOnly = true`를 제거하여 쓰기 가능한 트랜잭션으로 변경하였습니다.

- 변경 파일: `Oauth2TokenServiceImpl.kt`
- `:datagsm-oauth-authorization:test` 전체 통과를 확인하였습니다.

Closes #347
