### PR TITLE
[web] 클라이언트 수정/삭제 권한 체크에 `ROOT` 역할 추가

### DIFF
--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/client/service/impl/DeleteClientServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/client/service/impl/DeleteClientServiceImpl.kt
@@ -22,7 +22,7 @@ class DeleteClientServiceImpl(
                 .orElseThrow { ExpectedException("Id에 해당하는 Client를 찾지 못했습니다.", HttpStatus.NOT_FOUND) }
         val currentAccount = currentUserProvider.getCurrentAccount()
 
-        val isAdmin = currentAccount.role in setOf(AccountRole.ADMIN, AccountRole.ROOT)
+        val isAdmin = currentAccount.role == AccountRole.ADMIN || currentAccount.role == AccountRole.ROOT
 
         if (client.account != currentAccount && !isAdmin) {
             throw ExpectedException("Client 삭제 권한이 없습니다.", HttpStatus.FORBIDDEN)

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/client/service/impl/DeleteClientServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/client/service/impl/DeleteClientServiceImpl.kt
@@ -1,7 +1,6 @@
 package team.themoment.datagsm.web.domain.client.service.impl
 
 import org.springframework.http.HttpStatus
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
@@ -23,10 +22,7 @@ class DeleteClientServiceImpl(
                 .orElseThrow { ExpectedException("Id에 해당하는 Client를 찾지 못했습니다.", HttpStatus.NOT_FOUND) }
         val currentAccount = currentUserProvider.getCurrentAccount()
 
-        // ADMIN 권한 확인
-        val authentication = SecurityContextHolder.getContext().authentication
-        val authorities = authentication?.authorities?.map { it.authority } ?: emptyList()
-        val isAdmin = authorities.contains(AccountRole.ADMIN.name) || currentAccount.role == AccountRole.ADMIN
+        val isAdmin = currentAccount.role in setOf(AccountRole.ADMIN, AccountRole.ROOT)
 
         if (client.account != currentAccount && !isAdmin) {
             throw ExpectedException("Client 삭제 권한이 없습니다.", HttpStatus.FORBIDDEN)

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/client/service/impl/ModifyClientServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/client/service/impl/ModifyClientServiceImpl.kt
@@ -1,7 +1,6 @@
 package team.themoment.datagsm.web.domain.client.service.impl
 
 import org.springframework.http.HttpStatus
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
@@ -28,10 +27,7 @@ class ModifyClientServiceImpl(
                 .orElseThrow { ExpectedException("Id에 해당하는 Client를 찾지 못했습니다.", HttpStatus.NOT_FOUND) }
         val currentAccount = currentUserProvider.getCurrentAccount()
 
-        // ADMIN 권한 확인
-        val authentication = SecurityContextHolder.getContext().authentication
-        val authorities = authentication?.authorities?.map { it.authority } ?: emptyList()
-        val isAdmin = authorities.contains(AccountRole.ADMIN.name) || currentAccount.role == AccountRole.ADMIN
+        val isAdmin = currentAccount.role in setOf(AccountRole.ADMIN, AccountRole.ROOT)
 
         if (client.account != currentAccount && !isAdmin) {
             throw ExpectedException("Client 변경 권한이 없습니다.", HttpStatus.FORBIDDEN)

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/client/service/impl/ModifyClientServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/client/service/impl/ModifyClientServiceImpl.kt
@@ -27,7 +27,7 @@ class ModifyClientServiceImpl(
                 .orElseThrow { ExpectedException("Id에 해당하는 Client를 찾지 못했습니다.", HttpStatus.NOT_FOUND) }
         val currentAccount = currentUserProvider.getCurrentAccount()
 
-        val isAdmin = currentAccount.role in setOf(AccountRole.ADMIN, AccountRole.ROOT)
+        val isAdmin = currentAccount.role == AccountRole.ADMIN || currentAccount.role == AccountRole.ROOT
 
         if (client.account != currentAccount && !isAdmin) {
             throw ExpectedException("Client 변경 권한이 없습니다.", HttpStatus.FORBIDDEN)

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/DeleteClientServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/DeleteClientServiceTest.kt
@@ -121,6 +121,48 @@ class DeleteClientServiceTest :
                         verify(exactly = 0) { mockClientRepository.delete(any()) }
                     }
                 }
+
+                context("소유자가 아닌 ADMIN 사용자가 삭제를 시도할 때") {
+                    val adminAccount =
+                        AccountJpaEntity().apply {
+                            id = 3L
+                            email = "admin@gsm.hs.kr"
+                            role = AccountRole.ADMIN
+                        }
+
+                    beforeEach {
+                        every { mockClientRepository.findById(clientId) } returns Optional.of(existingClient)
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns adminAccount
+                        every { mockClientRepository.delete(existingClient) } returns Unit
+                    }
+
+                    it("클라이언트가 성공적으로 삭제되어야 한다") {
+                        deleteClientService.execute(clientId)
+
+                        verify(exactly = 1) { mockClientRepository.delete(existingClient) }
+                    }
+                }
+
+                context("소유자가 아닌 ROOT 사용자가 삭제를 시도할 때") {
+                    val rootAccount =
+                        AccountJpaEntity().apply {
+                            id = 4L
+                            email = "root@gsm.hs.kr"
+                            role = AccountRole.ROOT
+                        }
+
+                    beforeEach {
+                        every { mockClientRepository.findById(clientId) } returns Optional.of(existingClient)
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns rootAccount
+                        every { mockClientRepository.delete(existingClient) } returns Unit
+                    }
+
+                    it("클라이언트가 성공적으로 삭제되어야 한다") {
+                        deleteClientService.execute(clientId)
+
+                        verify(exactly = 1) { mockClientRepository.delete(existingClient) }
+                    }
+                }
             }
         }
     })

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/ModifyClientServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/client/service/ModifyClientServiceTest.kt
@@ -175,6 +175,58 @@ class ModifyClientServiceTest :
                         verify(exactly = 1) { mockCurrentUserProvider.getCurrentAccount() }
                     }
                 }
+
+                context("소유자가 아닌 ADMIN 사용자가 수정을 시도할 때") {
+                    val adminAccount =
+                        AccountJpaEntity().apply {
+                            id = 3L
+                            email = "admin@gsm.hs.kr"
+                            role = AccountRole.ADMIN
+                        }
+
+                    val updateRequest =
+                        ModifyClientReqDto(
+                            clientName = "관리자 수정",
+                        )
+
+                    beforeEach {
+                        every { mockClientRepository.findById(clientId) } returns Optional.of(existingClient)
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns adminAccount
+                    }
+
+                    it("클라이언트가 성공적으로 수정되어야 한다") {
+                        val result = modifyClientService.execute(clientId, updateRequest)
+
+                        result.id shouldBe clientId
+                        result.clientName shouldBe "관리자 수정"
+                    }
+                }
+
+                context("소유자가 아닌 ROOT 사용자가 수정을 시도할 때") {
+                    val rootAccount =
+                        AccountJpaEntity().apply {
+                            id = 4L
+                            email = "root@gsm.hs.kr"
+                            role = AccountRole.ROOT
+                        }
+
+                    val updateRequest =
+                        ModifyClientReqDto(
+                            clientName = "루트 수정",
+                        )
+
+                    beforeEach {
+                        every { mockClientRepository.findById(clientId) } returns Optional.of(existingClient)
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns rootAccount
+                    }
+
+                    it("클라이언트가 성공적으로 수정되어야 한다") {
+                        val result = modifyClientService.execute(clientId, updateRequest)
+
+                        result.id shouldBe clientId
+                        result.clientName shouldBe "루트 수정"
+                    }
+                }
             }
         }
     })


### PR DESCRIPTION
## 개요

`ModifyClientServiceImpl`과 `DeleteClientServiceImpl`의 관리자 권한 판별 로직에서 `ROOT` 역할 누락과 데드 코드를 수정하였습니다.

## 본문

기존 admin 판별 로직에는 두 가지 버그가 있었습니다.

**버그 1 — `ROOT` 역할 누락**
`SecurityConfig`는 `/v1/clients` 엔드포인트에 `ADMIN`과 `ROOT` 역할 모두 접근을 허용하지만, 서비스 레이어의 admin 체크에는 `ROOT`가 누락되어 있었습니다. 이로 인해 `ROOT` 역할 사용자가 다른 사용자의 클라이언트를 수정/삭제하려 하면 `403 Forbidden`이 반환되었습니다.

**버그 2 — 항상 `false`인 데드 코드**
`authorities.contains(AccountRole.ADMIN.name)` 조건에서 `AccountRole.ADMIN.name`은 `"ADMIN"`이지만, `Spring Security`에 등록된 실제 authority 문자열은 `"ROLE_ADMIN"`이므로 이 조건은 항상 `false`로 평가되었습니다.

두 버그를 함께 해소하기 위해 권한 판별을 다음과 같이 단순화하였습니다.

```kotlin
val isAdmin = currentAccount.role in setOf(AccountRole.ADMIN, AccountRole.ROOT)
```

더 이상 사용하지 않는 `SecurityContextHolder` import도 제거하였습니다.

- 변경 파일: `ModifyClientServiceImpl.kt`, `DeleteClientServiceImpl.kt`
- `ADMIN`/`ROOT` 사용자가 비소유 클라이언트를 수정/삭제할 수 있음을 검증하는 테스트를 추가하였으며, `:datagsm-web` 클라이언트 테스트 전체 통과를 확인하였습니다.

Closes #348
