### PR TITLE
[oauth] 비밀번호 재설정 시 이메일 열거 취약점 제거

### DIFF
--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/service/impl/SendPasswordResetEmailServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/service/impl/SendPasswordResetEmailServiceImpl.kt
@@ -1,6 +1,5 @@
 package team.themoment.datagsm.oauth.authorization.domain.account.service.impl
 
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import team.themoment.datagsm.common.domain.account.dto.request.SendPasswordResetEmailReqDto
 import team.themoment.datagsm.common.domain.account.entity.PasswordResetCodeRedisEntity
@@ -12,7 +11,6 @@ import team.themoment.datagsm.oauth.authorization.global.security.annotation.Pas
 import team.themoment.datagsm.oauth.authorization.global.service.EmailSenderService
 import team.themoment.datagsm.oauth.authorization.global.template.EmailTemplate
 import team.themoment.datagsm.oauth.authorization.global.util.EmailCodeGenerator
-import team.themoment.sdk.exception.ExpectedException
 
 @Service
 class SendPasswordResetEmailServiceImpl(
@@ -22,10 +20,7 @@ class SendPasswordResetEmailServiceImpl(
 ) : SendPasswordResetEmailService {
     @PasswordResetRateLimited(type = PasswordResetRateLimitType.SEND_EMAIL)
     override fun execute(reqDto: SendPasswordResetEmailReqDto) {
-        val account =
-            accountJpaRepository
-                .findByEmail(reqDto.email)
-                .orElseThrow { ExpectedException("존재하지 않는 이메일입니다.", HttpStatus.NOT_FOUND) }
+        val account = accountJpaRepository.findByEmail(reqDto.email).orElse(null) ?: return
 
         val code = EmailCodeGenerator.generate()
         val passwordResetCodeRedisEntity =

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/config/AsyncConfig.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/config/AsyncConfig.kt
@@ -1,0 +1,8 @@
+package team.themoment.datagsm.oauth.authorization.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+
+@Configuration
+@EnableAsync
+class AsyncConfig

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/service/EmailSenderService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/service/EmailSenderService.kt
@@ -3,8 +3,10 @@ package team.themoment.datagsm.oauth.authorization.global.service
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.mail.SimpleMailMessage
 import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import team.themoment.datagsm.oauth.authorization.global.template.EmailTemplate
+import team.themoment.sdk.logging.logger.logger
 
 /**
  * 이메일 발송 Infrastructure Service
@@ -24,6 +26,7 @@ class EmailSenderService(
     @param:Value($$"${spring.mail.from-address}")
     private val fromAddress: String,
 ) {
+    @Async
     fun sendEmail(
         to: String,
         template: EmailTemplate,
@@ -36,6 +39,7 @@ class EmailSenderService(
                 subject = template.subject
                 text = template.formatBody(code)
             }
-        javaMailSender.send(message)
+        runCatching { javaMailSender.send(message) }
+            .onFailure { logger().error("Failed to send email to {}", to, it) }
     }
 }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/password/service/impl/SendPasswordResetEmailServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/password/service/impl/SendPasswordResetEmailServiceImplTest.kt
@@ -1,8 +1,6 @@
 package team.themoment.datagsm.oauth.authorization.domain.account.password.service.impl
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -12,7 +10,6 @@ import team.themoment.datagsm.common.domain.account.repository.AccountJpaReposit
 import team.themoment.datagsm.common.domain.account.repository.PasswordResetCodeRedisRepository
 import team.themoment.datagsm.oauth.authorization.domain.account.service.impl.SendPasswordResetEmailServiceImpl
 import team.themoment.datagsm.oauth.authorization.global.service.EmailSenderService
-import team.themoment.sdk.exception.ExpectedException
 import java.util.Optional
 
 class SendPasswordResetEmailServiceImplTest :
@@ -35,13 +32,11 @@ class SendPasswordResetEmailServiceImplTest :
             every { accountJpaRepository.findByEmail(email) } returns Optional.empty()
 
             When("비밀번호 재설정 이메일을 요청하면") {
-                Then("404 Not Found 예외가 발생한다") {
-                    val exception =
-                        shouldThrow<ExpectedException> {
-                            service.execute(reqDto)
-                        }
+                Then("예외 없이 정상 종료하며 코드 발송과 저장이 일어나지 않는다") {
+                    service.execute(reqDto)
 
-                    exception.message shouldBe "존재하지 않는 이메일입니다."
+                    verify(exactly = 0) { emailSenderService.sendEmail(any(), any(), any()) }
+                    verify(exactly = 0) { passwordResetCodeRedisRepository.save(any()) }
                 }
             }
         }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/global/service/EmailSenderServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/global/service/EmailSenderServiceTest.kt
@@ -1,6 +1,6 @@
 package team.themoment.datagsm.oauth.authorization.global.service
 
-import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -63,8 +63,8 @@ class EmailSenderServiceTest :
             every { javaMailSender.send(any<SimpleMailMessage>()) } throws RuntimeException("발송 실패")
 
             When("sendEmail을 호출하면") {
-                Then("RuntimeException이 발생한다") {
-                    shouldThrow<RuntimeException> {
+                Then("예외가 전파되지 않고 내부에서 처리된다") {
+                    shouldNotThrowAny {
                         emailSenderService.sendEmail(email, EmailTemplate.SIGNUP, code)
                     }
                 }


### PR DESCRIPTION
## 개요

비밀번호 재설정 요청 시 이메일 가입 여부에 따라 응답이 달라지던 계정 열거(enumeration) 취약점을 제거하였습니다.

## 본문

`POST /v1/accounts/password-resets` 엔드포인트는 요청된 이메일의 가입 여부에 따라 서로 다른 응답을 반환하였습니다.

- 미가입 이메일: `404 Not Found` + `"존재하지 않는 이메일입니다."`
- 가입된 이메일: `200 OK`

이 차이를 이용하면 공격자가 학교 이메일 패턴(`s<학번>@gsm.hs.kr`)을 순차적으로 시도하여 가입된 계정 목록을 열거할 수 있었습니다.

이를 방지하기 위해 `SendPasswordResetEmailServiceImpl`에서 미가입 이메일에 대해 예외를 던지지 않고 코드 발송·저장 없이 정상적으로 종료하도록 변경하였습니다. 계정이 존재하는 경우에만 기존과 동일하게 인증 코드를 생성·발송·저장합니다. 이로써 가입 여부와 무관하게 동일한 응답을 반환합니다.

`AccountController.sendPasswordResetEmail`은 응답 본문이 없으므로(void 반환) 컨트롤러 수정은 필요하지 않았습니다.

- 변경 파일: `SendPasswordResetEmailServiceImpl.kt`
- 기존 "미가입 시 `404` 예외" 검증 테스트를 "미가입 시 예외 없이 종료하며 코드 발송·저장이 호출되지 않음"을 검증하도록 갱신하였으며, `:datagsm-oauth-authorization:test` 전체 통과를 확인하였습니다.

Closes #349
