### PR TITLE
[global] 문서에 누락된 모듈 설명 추가

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,9 @@ DataGSM is a Spring Boot REST API service providing school information (students
 - `datagsm-oauth-userinfo/`: OAuth2 UserInfo endpoint (external clients)
 - `datagsm-openapi/`: Public read-only API (students, clubs, NEIS)
 - `datagsm-web/`: Web service API (user features, admin features, Excel)
-- Each module: `controller/`, `service/`, `repository/`, `entity/`, `dto/`
+- `datagsm-shared/`: Kotlin Multiplatform module — published type definitions (Maven + npm)
+- `datagsm-ksp-processor/`: KSP processor — generates KMP/TypeScript types from `@KmpExport`
+- Each service module: `controller/`, `service/`, `repository/`, `entity/`, `dto/`
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ datagsm-server/
 └── datagsm-ksp-processor/     # KSP processor — generates KMP/TypeScript types from @KmpExport
 ```
 
-Each module follows: `controller/`, `service/`, `repository/`, `entity/`, `dto/`
+Each service module follows: `controller/`, `service/`, `repository/`, `entity/`, `dto/`
 
 **Note**: `/v1/health` endpoint is provided by `HealthController` in `datagsm-common/global/controller/` and is shared across all modules.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,9 @@ datagsm-server/
 ├── datagsm-oauth-authorization/ # OAuth2 authentication, account lifecycle (signup, password reset)
 ├── datagsm-oauth-userinfo/    # OAuth2 UserInfo endpoint (external clients)
 ├── datagsm-openapi/           # Public read-only API (students, clubs, NEIS)
-└── datagsm-web/               # Web service API (user features, admin features, Excel)
+├── datagsm-web/               # Web service API (user features, admin features, Excel)
+├── datagsm-shared/            # Kotlin Multiplatform module — published type definitions (Maven + npm)
+└── datagsm-ksp-processor/     # KSP processor — generates KMP/TypeScript types from @KmpExport
 ```
 
 Each module follows: `controller/`, `service/`, `repository/`, `entity/`, `dto/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ School information API server for Gwangju Software Meister High School (students
 - datagsm-oauth-userinfo: OAuth2 UserInfo endpoint (external clients)
 - datagsm-openapi: Public read-only API (students, clubs, NEIS integration)
 - datagsm-web: Web service API (user features, admin features, Excel processing)
+- datagsm-shared: Kotlin Multiplatform module — externally published type definitions (Maven + npm)
+- datagsm-ksp-processor: KSP processor — generates KMP/TypeScript types from `@KmpExport` (consumed by datagsm-common)
 
 **Note**: `/v1/health` endpoint is provided by `HealthController` in `datagsm-common` module and is shared across all modules.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,20 +125,24 @@ datagsm-server/
 ├── datagsm-oauth-userinfo/     # OAuth2 UserInfo 서버 (포트: 8083)
 │   └── domain/
 │       └── userinfo/           # UserInfo API
-└── datagsm-web/                # 관리자 웹 API (포트: 8080)
-    └── domain/
-        └── excel/              # Excel 처리
+├── datagsm-web/                # 관리자 웹 API (포트: 8080)
+│   └── domain/
+│       └── excel/              # Excel 처리
+├── datagsm-shared/             # KMP 공유 모듈 (외부 배포용 타입 정의, Maven·npm)
+└── datagsm-ksp-processor/      # KSP 프로세서 (@KmpExport → KMP·TypeScript 타입 생성)
 ```
 
 ### 모듈별 역할
 
-| 모듈                              | 역할                                               | 의존성            |
-|---------------------------------|--------------------------------------------------|----------------|
-| **datagsm-common**              | 공통 Entity, DTO, Repository, 예외 처리, Health API 제공 | -              |
-| **datagsm-oauth-authorization** | DataGSM OAuth 제공                                 | datagsm-common |
-| **datagsm-oauth-userinfo**      | DataGSM OAuth UserInfo 제공                        | datagsm-common |
-| **datagsm-openapi**             | DataGSM OpenAPI 제공                               | datagsm-common |
-| **datagsm-web**                 | DataGSM Web 서비스 전용 API 제공                        | datagsm-common |
+| 모듈                              | 역할                                               | 의존성                      |
+|---------------------------------|--------------------------------------------------|--------------------------|
+| **datagsm-common**              | 공통 Entity, DTO, Repository, 예외 처리, Health API 제공 | -                        |
+| **datagsm-oauth-authorization** | DataGSM OAuth 제공                                 | datagsm-common           |
+| **datagsm-oauth-userinfo**      | DataGSM OAuth UserInfo 제공                        | datagsm-common           |
+| **datagsm-openapi**             | DataGSM OpenAPI 제공                               | datagsm-common           |
+| **datagsm-web**                 | DataGSM Web 서비스 전용 API 제공                        | datagsm-common           |
+| **datagsm-shared**              | KMP 공유 모듈, 외부 배포용 타입 정의 (Maven·npm)              | datagsm-common (KSP 생성물) |
+| **datagsm-ksp-processor**       | `@KmpExport` 클래스 → KMP·TypeScript 타입 생성 KSP 프로세서 | -                        |
 
 ### 패키지 구조
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ datagsm-server/
 
 ### 패키지 구조
 
-모든 모듈은 다음 패키지 구조를 따릅니다:
+모든 서비스 모듈은 다음 패키지 구조를 따릅니다:
 
 ```
 team.themoment.datagsm.{module}/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ DataGSM은 광주소프트웨어마이스터고등학교의 학생, 동아리, �
 | **datagsm-oauth-userinfo**      | OAuth2 UserInfo API                    | 8083 |
 | **datagsm-openapi**             | 리소스 API (학생, 동아리, NEIS 등)              | 8082 |
 | **datagsm-web**                 | DataGSM 웹 서비스 API                      | 8080 |
+| **datagsm-shared**              | KMP 공유 모듈 (외부 배포용 타입 정의)               | -    |
+| **datagsm-ksp-processor**       | KSP 프로세서 (KMP·TypeScript 타입 자동 생성)     | -    |
 
 ## 문서
 


### PR DESCRIPTION
## 개요

`settings.gradle.kts`에 등록된 7개 모듈 중 문서의 모듈 구조 설명에서 누락됐던 `datagsm-shared`와 `datagsm-ksp-processor` 두 모듈을 5개 문서에 보완했습니다.

## 본문

기존 문서들은 서비스 모듈 5개(common, oauth-authorization, oauth-userinfo, openapi, web)만 설명하고 있어, 빌드/배포 관련 모듈 2개가 누락된 상태였습니다.

추가한 모듈 설명:
- **datagsm-shared** — Kotlin Multiplatform 모듈. `datagsm-common`이 KSP로 생성한 타입을 모아 외부에 배포(Maven · npm)하는 유일한 artifact
- **datagsm-ksp-processor** — `@KmpExport` 클래스를 KMP·TypeScript 타입(`index.d.ts`)으로 생성하는 KSP 프로세서 (`datagsm-common`이 소비)

반영 문서 (각 포맷에 맞춰 일관 적용):
- `README.md` — 모듈 구조 표
- `AGENTS.md` — Project Structure 트리
- `CONTRIBUTING.md` — 프로젝트 구조 트리 + 모듈별 역할 표(의존성 컬럼 포함)
- `.github/copilot-instructions.md` — Project Structure 리스트
- `CLAUDE.md` — Module Structure 리스트

부수 변경:
- copilot-instructions.md의 "Each module: controller/, service/..." → 빌드 모듈에는 해당하지 않아 "Each service module:"로 정정