### PR TITLE
[ci/cd] shared 모듈 배포 workflow 개선

### DIFF
--- a/.github/workflows/datagsm-prod-cd.yaml
+++ b/.github/workflows/datagsm-prod-cd.yaml
@@ -21,6 +21,15 @@ on:
         required: false
         default: 'master'
         type: string
+      target:
+        description: 'Deployment target'
+        required: false
+        default: 'deploy-server'
+        type: choice
+        options:
+          - deploy-server
+          - deploy-shared
+          - both
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,7 +37,9 @@ concurrency:
 
 jobs:
   generate-version:
-    if: github.event_name == 'push'
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.target == 'deploy-shared' || inputs.target == 'both'))
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.value }}
@@ -87,7 +98,9 @@ jobs:
   CD:
     runs-on: ubuntu-latest
     environment: prod
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
+    if: |
+      (github.event_name == 'workflow_dispatch' && (inputs.target == 'deploy-server' || inputs.target == 'both')) ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6


### PR DESCRIPTION
## 개요

`datagsm-shared` 배포를 위한 `prod CD` 워크플로우의 `workflow_dispatch` 트리거를 개선하였습니다.

## 본문

기존에는 `workflow_dispatch`로 수동 실행하더라도 `generate-version`, `publish-jvm`, `publish-js` 잡이 항상 skip되고 `CD` 잡만 실행되어, SDK를 수동으로 재배포할 방법이 없었습니다. 이번 변경으로 수동 실행 시 원하는 작업을 선택할 수 있도록 `target` 입력 옵션(`deploy-server` / `deploy-shared` / `both`)을 추가하였습니다.

- `target: deploy-server` (기본값): `CD` 잡만 실행하여 서버를 배포합니다.
- `target: deploy-shared`: `generate-version`, `publish-jvm`, `publish-js` 잡을 실행하여 `datagsm-shared` SDK를 publish합니다.
- `target: both`: 서버 배포와 SDK publish를 모두 실행합니다.

`publish-jvm`/`publish-js`는 `needs: generate-version`을 가지고 있어 `generate-version`이 skip되면 자동으로 함께 skip되므로 별도 조건 추가 없이 의도한 대로 동작합니다.

## 리뷰 요청사항

현재 shared 모듈 배포를 대한 job의 조건분기식이 더러워졌습니다. 기존처럼 shared 모듈 배포를 별도의 workflow로 분리하는건 어떤지 의견 부탁드립니다.

## 기타

https://github.com/themoment-team/datagsm-openapi-sdk-java/pull/15
현 PR이 위 PR을 마저 작업하기 위해 필요한 변경사항이기 때문에 곧바로 main으로 병합이 필요할 것 같습니다.