### PR TITLE
[ci/cd] 이슈 검증 허용 scope에 `webhook` 추가

### DIFF
--- a/.github/workflows/datagsm-issue-validation.yaml
+++ b/.github/workflows/datagsm-issue-validation.yaml
@@ -20,7 +20,7 @@ jobs:
             const allowedScopes = [
               'global', 'account', 'auth', 'client', 'club',
               'neis', 'oauth', 'project', 'student',
-              'web', 'oauth', 'openapi', 'ci/cd', 'application'
+              'web', 'oauth', 'openapi', 'ci/cd', 'application', 'webhook'
             ];
             const titlePattern = /^\[([^\]]+)\]\s+(.+)$/;
             const match = title.match(titlePattern);


### PR DESCRIPTION
## 개요

이슈 제목 검증 워크플로의 허용 `scope` 목록에 `webhook`을 추가하였습니다.

## 본문

`datagsm-issue-validation.yaml`의 `allowedScopes` 배열에 `webhook` scope가 누락되어 있어, `[webhook]` 형식의 이슈 제목이 검증을 통과하지 못하는 문제가 있었습니다.

이를 해결하기 위해 `allowedScopes` 목록에 `webhook`을 추가하여, `webhook` 관련 이슈가 정상적으로 검증을 통과하도록 수정하였습니다.
