### PR TITLE
[auth] 회원가입 시 이메일 `gsm.hs.kr` 도메인 검증 추가

### DIFF
--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/service/impl/SendSignupEmailServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/service/impl/SendSignupEmailServiceImpl.kt
@@ -22,7 +22,7 @@ class SendSignupEmailServiceImpl(
 ) : SendSignupEmailService {
     @PasswordResetRateLimited(type = PasswordResetRateLimitType.SIGNUP_SEND_EMAIL)
     override fun execute(reqDto: SendEmailReqDto) {
-        if (!reqDto.email.endsWith("@gsm.hs.kr")) {
+        if (!reqDto.email.endsWith("@gsm.hs.kr", ignoreCase = true)) {
             throw ExpectedException("gsm.hs.kr 도메인 이메일만 가입할 수 있습니다.", HttpStatus.BAD_REQUEST)
         }
 

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/service/impl/SendSignupEmailServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/service/impl/SendSignupEmailServiceImpl.kt
@@ -22,6 +22,10 @@ class SendSignupEmailServiceImpl(
 ) : SendSignupEmailService {
     @PasswordResetRateLimited(type = PasswordResetRateLimitType.SIGNUP_SEND_EMAIL)
     override fun execute(reqDto: SendEmailReqDto) {
+        if (!reqDto.email.endsWith("@gsm.hs.kr")) {
+            throw ExpectedException("gsm.hs.kr 도메인 이메일만 가입할 수 있습니다.", HttpStatus.BAD_REQUEST)
+        }
+
         if (accountJpaRepository.findByEmail(reqDto.email).isPresent) {
             throw ExpectedException("이미 해당 이메일을 가진 계정이 존재합니다.", HttpStatus.CONFLICT)
         }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/service/impl/SendSignupEmailServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/service/impl/SendSignupEmailServiceImplTest.kt
@@ -80,4 +80,20 @@ class SendSignupEmailServiceImplTest :
                 }
             }
         }
+
+        Given("대문자가 포함된 gsm.hs.kr 도메인 이메일로") {
+            val email = "NEW@GSM.HS.KR"
+            val reqDto = SendEmailReqDto(email = email)
+
+            every { accountJpaRepository.findByEmail(email) } returns Optional.empty()
+            every { emailCodeRedisRepository.save(any()) } answers { firstArg() }
+
+            When("회원가입 이메일을 요청하면") {
+                Then("대소문자 구분 없이 인증 코드가 생성되고 이메일이 발송된다") {
+                    service.execute(reqDto)
+
+                    verify(exactly = 1) { emailSenderService.sendEmail(email, any(), any()) }
+                }
+            }
+        }
     })

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/service/impl/SendSignupEmailServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/service/impl/SendSignupEmailServiceImplTest.kt
@@ -27,6 +27,24 @@ class SendSignupEmailServiceImplTest :
                 emailSenderService,
             )
 
+        Given("gsm.hs.kr 도메인이 아닌 이메일로") {
+            val email = "outsider@gmail.com"
+            val reqDto = SendEmailReqDto(email = email)
+
+            When("회원가입 이메일을 요청하면") {
+                Then("400 Bad Request 예외가 발생하고 이메일이 발송되지 않는다") {
+                    val exception =
+                        shouldThrow<ExpectedException> {
+                            service.execute(reqDto)
+                        }
+
+                    exception.message shouldBe "gsm.hs.kr 도메인 이메일만 가입할 수 있습니다."
+                    verify(exactly = 0) { emailSenderService.sendEmail(any(), any(), any()) }
+                    verify(exactly = 0) { emailCodeRedisRepository.save(any()) }
+                }
+            }
+        }
+
         Given("이미 존재하는 이메일로") {
             val email = "existing@gsm.hs.kr"
             val reqDto = SendEmailReqDto(email = email)


### PR DESCRIPTION
## 개요

회원가입 시 이메일이 `@gsm.hs.kr` 도메인인 경우에만 가입을 허용하도록 검증을 추가하였습니다.

## 본문

기존 회원가입은 Jakarta 표준 `@field:Email`만 검증하여 `someone@gmail.com` 같은 외부 이메일로도 가입 흐름을 시작할 수 있었습니다. 학교 구성원만 가입하도록 `@gsm.hs.kr` 도메인을 강제하였습니다.

회원가입 진입점인 `SendSignupEmailServiceImpl`의 `execute` 최상단에 도메인 검증을 추가하였습니다. 중복 계정 조회보다 먼저 실행되므로, 잘못된 도메인은 DB 조회 없이 즉시 차단됩니다.

```kotlin
if (!reqDto.email.endsWith("@gsm.hs.kr")) {
    throw ExpectedException("gsm.hs.kr 도메인 이메일만 가입할 수 있습니다.", HttpStatus.BAD_REQUEST)
}
```

회원가입은 반드시 `이메일 인증 발송 → 코드 검증 → 계정 생성` 순서이므로, 첫 단계에서 막으면 잘못된 도메인은 인증 코드를 받지 못해 이후 단계로 진행할 수 없습니다.

클라이언트가 항상 `@gsm.hs.kr`(소문자)로 정규화해 보내는 것을 계약으로 신뢰하여, 대소문자 보정은 하지 않았습니다.

`SendSignupEmailServiceImplTest`에 도메인이 `@gsm.hs.kr`가 아닌 경우 `ExpectedException`(`BAD_REQUEST`)이 발생하고 이메일 발송·`Redis` 저장이 일어나지 않음을 검증하는 테스트를 추가하였습니다.
