### PR TITLE
[oauth] 로그인 이메일 gsm.hs.kr 도메인 검증 추가

### DIFF
--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
@@ -51,6 +51,10 @@ class CompleteOauthAuthorizeFlowServiceImpl(
             throw ExpectedException("요청 한도를 초과했습니다.", HttpStatus.TOO_MANY_REQUESTS)
         }
 
+        if (!reqDto.email.endsWith("@gsm.hs.kr", ignoreCase = true)) {
+            throw ExpectedException("존재하지 않는 이메일입니다.", HttpStatus.UNAUTHORIZED)
+        }
+
         val account =
             accountJpaRepository
                 .findByEmail(reqDto.email)

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
@@ -52,16 +52,16 @@ class CompleteOauthAuthorizeFlowServiceImpl(
         }
 
         if (!reqDto.email.endsWith("@gsm.hs.kr", ignoreCase = true)) {
-            throw ExpectedException("존재하지 않는 이메일입니다.", HttpStatus.UNAUTHORIZED)
+            throw ExpectedException("이메일 또는 비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED)
         }
 
         val account =
             accountJpaRepository
                 .findByEmail(reqDto.email)
-                .orElseThrow { ExpectedException("존재하지 않는 이메일입니다.", HttpStatus.UNAUTHORIZED) }
+                .orElseThrow { ExpectedException("이메일 또는 비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED) }
 
         if (!passwordEncoder.matches(reqDto.password, account.password)) {
-            throw ExpectedException("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED)
+            throw ExpectedException("이메일 또는 비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED)
         }
 
         val code = generateAuthorizationCode()

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
@@ -192,7 +192,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                                 completeOauthAuthorizeFlowService.execute(reqDto)
                             }
 
-                        exception.message shouldBe "존재하지 않는 이메일입니다."
+                        exception.message shouldBe "이메일 또는 비밀번호가 일치하지 않습니다."
                         exception.statusCode shouldBe HttpStatus.UNAUTHORIZED
 
                         verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
@@ -231,7 +231,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                                 completeOauthAuthorizeFlowService.execute(reqDto)
                             }
 
-                        exception.message shouldBe "비밀번호가 일치하지 않습니다."
+                        exception.message shouldBe "이메일 또는 비밀번호가 일치하지 않습니다."
                         exception.statusCode shouldBe HttpStatus.UNAUTHORIZED
 
                         verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
@@ -268,7 +268,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                                 completeOauthAuthorizeFlowService.execute(reqDto)
                             }
 
-                        exception.message shouldBe "존재하지 않는 이메일입니다."
+                        exception.message shouldBe "이메일 또는 비밀번호가 일치하지 않습니다."
                         exception.statusCode shouldBe HttpStatus.UNAUTHORIZED
 
                         verify(exactly = 0) { mockAccountJpaRepository.findByEmail(any()) }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
@@ -237,6 +237,44 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
                     }
                 }
+
+                context("gsm.hs.kr 도메인이 아닌 이메일이 주어졌을 때") {
+                    val reqDto =
+                        OauthAuthorizeSubmitReqDto(
+                            email = "outsider@gmail.com",
+                            password = "password123!",
+                            token = testToken,
+                        )
+
+                    val mockStateEntity =
+                        OauthAuthorizeStateRedisEntity(
+                            token = testToken,
+                            clientId = testClientId,
+                            redirectUri = testRedirectUri,
+                            state = "random-state",
+                            codeChallenge = "challenge",
+                            codeChallengeMethod = "S256",
+                            scopes = setOf("self:read"),
+                            ttl = 600,
+                        )
+
+                    beforeEach {
+                        every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns Optional.of(mockStateEntity)
+                    }
+
+                    it("계정 조회 없이 ExpectedException 예외가 발생해야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                completeOauthAuthorizeFlowService.execute(reqDto)
+                            }
+
+                        exception.message shouldBe "존재하지 않는 이메일입니다."
+                        exception.statusCode shouldBe HttpStatus.UNAUTHORIZED
+
+                        verify(exactly = 0) { mockAccountJpaRepository.findByEmail(any()) }
+                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                    }
+                }
             }
         }
     })


### PR DESCRIPTION
## 개요

로그인(OAuth 인증) 시 이메일이 `@gsm.hs.kr` 도메인인 경우에만 인증을 허용하도록 방어적 검증을 추가하였습니다.

## 본문

기존 로그인 흐름(`CompleteOauthAuthorizeFlowServiceImpl`)은 이메일 형식만 검증하고 도메인은 제한하지 않았습니다. 회원가입에 `@gsm.hs.kr` 도메인 검증이 추가되어 신규 계정은 학교 도메인만 생성되므로 로그인 시점의 검증은 실질적으로는 불필요하지만, 이중 안전장치로서 로그인 진입점에도 동일한 도메인 검증을 추가하였습니다.

```kotlin
if (!reqDto.email.endsWith("@gsm.hs.kr", ignoreCase = true)) {
    throw ExpectedException("존재하지 않는 이메일입니다.", HttpStatus.UNAUTHORIZED)
}
```

검증 위치는 인증 상태 토큰 검증과 `Rate Limit` 확인 이후, 계정 조회 직전입니다. 도메인이 일치하지 않으면 DB 조회 없이 차단됩니다.

예외 메시지는 회원가입의 `BAD_REQUEST`와 달리 `존재하지 않는 이메일입니다.`(`UNAUTHORIZED`)로 통일하였습니다. 로그인 단계에서 "해당 도메인 계정의 존재 여부"라는 힌트를 노출하지 않도록 기존 계정 조회 실패 응답과 동일하게 처리하였습니다.

회원가입 도메인 검증과 동일하게 `ignoreCase = true`를 적용하여 대소문자를 구분하지 않습니다.

`CompleteOauthAuthorizeFlowServiceTest`에 `@gsm.hs.kr`가 아닌 이메일로 요청 시 계정 조회 없이 `ExpectedException`(`UNAUTHORIZED`)이 발생함을 검증하는 테스트를 추가하였습니다.
