### PR TITLE
[neis] 시간표 공강 교시 슬롯 처리

### DIFF
--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/neis/timetable/service/impl/SyncTimetableServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/neis/timetable/service/impl/SyncTimetableServiceImpl.kt
@@ -58,9 +58,34 @@ class SyncTimetableServiceImpl(
         } while (timetables.size == pageSize)
 
         if (allTimetableEntities.isNotEmpty()) {
+            val filledTimetableEntities = fillEmptyPeriods(allTimetableEntities)
             timetableRedisRepository.deleteAll()
-            timetableRedisRepository.saveAll(allTimetableEntities)
+            timetableRedisRepository.saveAll(filledTimetableEntities)
         }
+    }
+
+    private fun fillEmptyPeriods(timetables: List<TimetableRedisEntity>): List<TimetableRedisEntity> =
+        timetables
+            .groupBy { Triple(it.date, it.grade, it.classNum) }
+            .flatMap { (_, groupedTimetables) ->
+                val existingPeriods = groupedTimetables.associateBy { it.period }
+                (FIRST_PERIOD..LAST_PERIOD).map { period ->
+                    existingPeriods[period] ?: createEmptyPeriod(groupedTimetables.first(), period)
+                }
+            }
+
+    private fun createEmptyPeriod(
+        reference: TimetableRedisEntity,
+        period: Int,
+    ): TimetableRedisEntity {
+        val timetableId =
+            "${reference.schoolCode}_${reference.date.format(DATE_FORMATTER)}_${reference.grade}_${reference.classNum}_$period"
+
+        return reference.copy(
+            id = timetableId,
+            period = period,
+            subject = EMPTY_PERIOD_SUBJECT,
+        )
     }
 
     private fun convertToEntity(dto: TimetableInfo): TimetableRedisEntity {
@@ -88,5 +113,8 @@ class SyncTimetableServiceImpl(
 
     companion object {
         private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd")
+        private const val FIRST_PERIOD = 1
+        private const val LAST_PERIOD = 7
+        private const val EMPTY_PERIOD_SUBJECT = "공강"
     }
 }

--- a/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/neis/timetable/service/SyncTimetableServiceTest.kt
+++ b/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/neis/timetable/service/SyncTimetableServiceTest.kt
@@ -1,9 +1,13 @@
 package team.themoment.datagsm.openapi.domain.neis.timetable.service
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import team.themoment.datagsm.common.domain.neis.dto.internal.HisTimetableWrapper
 import team.themoment.datagsm.common.domain.neis.dto.internal.NeisTimetableApiResponse
@@ -124,6 +128,93 @@ class SyncTimetableServiceTest :
 
                         verify(exactly = 1) { mockTimetableRepository.deleteAll() }
                         verify(exactly = 1) { mockTimetableRepository.saveAll(any<Iterable<TimetableRedisEntity>>()) }
+                    }
+                }
+
+                context("일부 교시가 공강이라 NEIS 응답에서 누락되었을 때") {
+                    val fromDate = LocalDate.of(2025, 3, 1)
+                    val toDate = LocalDate.of(2026, 2, 28)
+
+                    val timetableInfo1 =
+                        TimetableInfo(
+                            officeCode = "F10",
+                            officeName = "광주광역시교육청",
+                            schoolCode = "7380292",
+                            schoolName = "광주소프트웨어마이스터고등학교",
+                            academicYear = "2025",
+                            semester = "1",
+                            timetableDate = "20250401",
+                            grade = "1",
+                            classNum = "1",
+                            period = "1",
+                            subject = "국어",
+                            loadDateTime = null,
+                        )
+                    val timetableInfo5 =
+                        TimetableInfo(
+                            officeCode = "F10",
+                            officeName = "광주광역시교육청",
+                            schoolCode = "7380292",
+                            schoolName = "광주소프트웨어마이스터고등학교",
+                            academicYear = "2025",
+                            semester = "1",
+                            timetableDate = "20250401",
+                            grade = "1",
+                            classNum = "1",
+                            period = "5",
+                            subject = "영어",
+                            loadDateTime = null,
+                        )
+
+                    val apiResponse =
+                        NeisTimetableApiResponse(
+                            hisTimetable =
+                                listOf(
+                                    HisTimetableWrapper(
+                                        head = null,
+                                        row = listOf(timetableInfo1, timetableInfo5),
+                                    ),
+                                ),
+                        )
+
+                    val savedEntitiesSlot = slot<Iterable<TimetableRedisEntity>>()
+
+                    beforeEach {
+                        every { mockNeisEnvironment.key } returns "test-api-key"
+                        every { mockNeisEnvironment.officeCode } returns "F10"
+                        every { mockNeisEnvironment.schoolCode } returns "7380292"
+
+                        every {
+                            mockNeisApiClient.getHisTimetable(
+                                key = any(),
+                                pIndex = any(),
+                                pSize = any(),
+                                atptOfcdcScCode = any(),
+                                sdSchulCode = any(),
+                                tiFromYmd = any(),
+                                tiToYmd = any(),
+                            )
+                        } returns apiResponse
+
+                        every { mockTimetableRepository.saveAll(capture(savedEntitiesSlot)) } answers {
+                            @Suppress("UNCHECKED_CAST")
+                            (firstArg() as Iterable<TimetableRedisEntity>).toList()
+                        }
+                        every { mockTimetableRepository.deleteAll() } returns Unit
+                    }
+
+                    it("1~7교시 슬롯을 모두 채우고 공강 교시는 공강으로 저장해야 한다") {
+                        syncTimetableService.execute(fromDate, toDate)
+
+                        val savedEntities = savedEntitiesSlot.captured.toList()
+
+                        savedEntities shouldHaveSize 7
+                        savedEntities.map { it.period } shouldContainExactlyInAnyOrder (1..7).toList()
+                        savedEntities.first { it.period == 1 }.subject shouldBe "국어"
+                        savedEntities.first { it.period == 5 }.subject shouldBe "영어"
+                        savedEntities
+                            .filter { it.period in listOf(2, 3, 4, 6, 7) }
+                            .forEach { it.subject shouldBe "공강" }
                     }
                 }
 


### PR DESCRIPTION
## 개요

NEIS 시간표 동기화 시 공강 교시가 응답에서 누락되어 시간표 목록에서 빠지는 문제를 해결하였습니다. 공강이더라도 `1~7교시` 슬롯이 항상 존재하도록 수정하였습니다.

Resolves #334

## 본문

기존에는 NEIS API가 공강 교시를 응답에 포함하지 않아, 예를 들어 `2~4교시`가 공강이면 `1, 5, 6, 7교시`만 Redis에 저장되어 클라이언트로 전달되었습니다.

이를 해결하기 위해 `SyncTimetableServiceImpl`의 저장 시점에 공강을 채우도록 변경하였습니다.

- `fillEmptyPeriods` 메서드를 추가하여 `(date, grade, classNum)` 그룹별로 `1~7교시` 슬롯을 보장하였습니다.
- NEIS 응답에 누락된 교시는 `createEmptyPeriod` 메서드로 같은 그룹의 기존 엔티티를 복제하고 `subject` 값을 `"공강"`으로 채워 저장하였습니다.
- `timetableId`에 `period`가 포함되어 있어 공강 슬롯 추가 시 키 충돌은 발생하지 않습니다.
- 조회 로직(`SearchTimetableServiceImpl`)은 변경하지 않았으며, 저장된 데이터를 그대로 반환합니다.

`SyncTimetableServiceTest`에 일부 교시가 공강일 때 `1~7교시` 슬롯이 모두 채워지고 공강 교시가 `"공강"`으로 저장되는지 검증하는 테스트를 추가하였습니다.
