### PR TITLE
[ci/cd] CD 파이프라인 정합성 및 명칭 일관성 정리

### DIFF
--- a/.github/workflows/datagsm-prod-cd.yaml
+++ b/.github/workflows/datagsm-prod-cd.yaml
@@ -56,12 +56,18 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - name: Checkout Code
+        uses: actions/checkout@v6
+      - name: Setup JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-read-only: false
+          cache-cleanup: always
       - name: Publish JVM artifact to GitHub Packages
         run: >
           ./gradlew :datagsm-common:kspKotlin
@@ -75,13 +81,20 @@ jobs:
     needs: generate-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - name: Checkout Code
+        uses: actions/checkout@v6
+      - name: Setup JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
-          cache: 'gradle'
-      - uses: actions/setup-node@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-read-only: false
+          cache-cleanup: always
+      - name: Setup Node
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -95,7 +108,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  CD:
+  deploy:
     runs-on: ubuntu-latest
     environment: prod
     if: |
@@ -182,21 +195,21 @@ jobs:
       - name: Code Deploy
         run: aws deploy create-deployment --application-name datagsm-prod-server-codedeploy --deployment-config-name CodeDeployDefault.AllAtOnce --deployment-group-name datagsm-prod-server --s3-location bucket=${{ secrets.AWS_S3_BUCKET_NAME }},bundleType=zip,key=prod/$GITHUB_SHA.zip
 
-      - name: CD Success Notification
+      - name: Deploy Success Notification
         uses: sarisia/actions-status-discord@v1
         if: success()
         with:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
           color: 0x4CAF50
 
-      - name: CD Failure Notification
+      - name: Deploy Failure Notification
         uses: sarisia/actions-status-discord@v1
         if: failure()
         with:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
           color: 0xFF4C4C
 
-      - name: CD Cancelled Notification
+      - name: Deploy Cancelled Notification
         uses: sarisia/actions-status-discord@v1
         if: cancelled()
         with:

--- a/.github/workflows/datagsm-prod-cd.yaml
+++ b/.github/workflows/datagsm-prod-cd.yaml
@@ -51,7 +51,7 @@ jobs:
             echo "shared_changed=true" >> $GITHUB_OUTPUT
             exit 0
           fi
-          CHANGED=$(git diff --name-only HEAD^ HEAD)
+          CHANGED=$(git diff --name-only HEAD^1 HEAD)
           if echo "$CHANGED" | grep -qE '^(datagsm-common/src/main/kotlin/(.*/)?(dto|constant)/|datagsm-ksp-processor/|datagsm-shared/)'; then
             echo "shared_changed=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/datagsm-prod-cd.yaml
+++ b/.github/workflows/datagsm-prod-cd.yaml
@@ -7,13 +7,6 @@ on:
       - completed
     branches:
       - 'master'
-  push:
-    branches: [master]
-    paths:
-      - 'datagsm-common/src/main/kotlin/**/dto/**'
-      - 'datagsm-common/src/main/kotlin/**/constant/**'
-      - 'datagsm-ksp-processor/**'
-      - 'datagsm-shared/**'
   workflow_dispatch:
     inputs:
       branch:
@@ -38,19 +31,43 @@ concurrency:
 jobs:
   generate-version:
     if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && (inputs.target == 'deploy-shared' || inputs.target == 'both'))
+      (github.event_name == 'workflow_dispatch' && (inputs.target == 'deploy-shared' || inputs.target == 'both')) ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.value }}
+      shared_changed: ${{ steps.changes.outputs.shared_changed }}
     steps:
-      - id: version
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch || github.event.workflow_run.head_sha || 'master' }}
+          fetch-depth: 0
+
+      - name: Detect Shared Changes
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "shared_changed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          CHANGED=$(git diff --name-only HEAD^ HEAD)
+          if echo "$CHANGED" | grep -qE '^(datagsm-common/src/main/kotlin/(.*/)?(dto|constant)/|datagsm-ksp-processor/|datagsm-shared/)'; then
+            echo "shared_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "shared_changed=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      - name: Generate Version
+        id: version
         run: |
           DATE=$(date +'%Y%m%d')
           echo "value=${DATE}-${{ github.run_number }}" >> $GITHUB_OUTPUT
 
   publish-jvm:
     needs: generate-version
+    if: needs.generate-version.outputs.shared_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -58,6 +75,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch || github.event.workflow_run.head_sha || 'master' }}
       - name: Setup JDK 25
         uses: actions/setup-java@v5
         with:
@@ -79,10 +98,13 @@ jobs:
 
   publish-js:
     needs: generate-version
+    if: needs.generate-version.outputs.shared_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch || github.event.workflow_run.head_sha || 'master' }}
       - name: Setup JDK 25
         uses: actions/setup-java@v5
         with:
@@ -118,7 +140,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || 'master' }}
+          ref: ${{ inputs.branch || github.event.workflow_run.head_sha || 'master' }}
 
       - name: Setup JDK 25
         uses: actions/setup-java@v5

--- a/.github/workflows/datagsm-stage-cd.yaml
+++ b/.github/workflows/datagsm-stage-cd.yaml
@@ -20,10 +20,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  CD:
+  deploy:
     runs-on: ubuntu-latest
     environment: stage
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -105,21 +107,21 @@ jobs:
       - name: Code Deploy
         run: aws deploy create-deployment --application-name datagsm-stage-server-codedeploy --deployment-config-name CodeDeployDefault.AllAtOnce --deployment-group-name datagsm-stage-server --s3-location bucket=${{ secrets.AWS_S3_BUCKET_NAME }},bundleType=zip,key=stage/$GITHUB_SHA.zip
 
-      - name: CD Success Notification
+      - name: Deploy Success Notification
         uses: sarisia/actions-status-discord@v1
         if: success()
         with:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
           color: 0x4CAF50
 
-      - name: CD Failure Notification
+      - name: Deploy Failure Notification
         uses: sarisia/actions-status-discord@v1
         if: failure()
         with:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
           color: 0xFF4C4C
 
-      - name: CD Cancelled Notification
+      - name: Deploy Cancelled Notification
         uses: sarisia/actions-status-discord@v1
         if: cancelled()
         with:

--- a/scripts/deploy/prod-deploy.sh
+++ b/scripts/deploy/prod-deploy.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 
-echo "> DataGSM Multi-Module Deployment Start" >> /home/ec2-user/deploy.log
+exec >> /home/ec2-user/deploy.log 2>&1
 
-cd /home/ec2-user/builds/
+echo "> DataGSM Multi-Module Deployment Start"
 
-echo "> Stopping and removing existing containers..." >> /home/ec2-user/deploy.log
-docker compose -f compose.prod.yaml down >> /home/ec2-user/deploy.log 2>&1
+cd /home/ec2-user/builds/ || exit 1
 
-echo "> Cleaning up unused Docker resources..." >> /home/ec2-user/deploy.log
-docker system prune -a --volumes -f >> /home/ec2-user/deploy.log 2>&1
+echo "> Stopping and removing existing containers..."
+docker compose -f compose.prod.yaml down
 
-echo "> Building and starting containers..." >> /home/ec2-user/deploy.log
-docker compose -f compose.prod.yaml up -d --build >> /home/ec2-user/deploy.log 2>&1
+echo "> Cleaning up unused Docker resources..."
+docker system prune -a --volumes -f
 
-echo "> Deployment completed successfully" >> /home/ec2-user/deploy.log
+echo "> Building and starting containers..."
+docker compose -f compose.prod.yaml up -d --build
+
+echo "> Deployment completed successfully"

--- a/scripts/deploy/prod-deploy.sh
+++ b/scripts/deploy/prod-deploy.sh
@@ -7,11 +7,10 @@ cd /home/ec2-user/builds/
 echo "> Stopping and removing existing containers..." >> /home/ec2-user/deploy.log
 docker compose -f compose.prod.yaml down >> /home/ec2-user/deploy.log 2>&1
 
-echo "> Cleaning up unused Docker resources..."
-docker system prune -a --volumes -f
+echo "> Cleaning up unused Docker resources..." >> /home/ec2-user/deploy.log
+docker system prune -a --volumes -f >> /home/ec2-user/deploy.log 2>&1
 
 echo "> Building and starting containers..." >> /home/ec2-user/deploy.log
 docker compose -f compose.prod.yaml up -d --build >> /home/ec2-user/deploy.log 2>&1
-
 
 echo "> Deployment completed successfully" >> /home/ec2-user/deploy.log

--- a/scripts/deploy/stage-deploy.sh
+++ b/scripts/deploy/stage-deploy.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-echo "> DataGSM Multi-Module Staging Deployment Start"
+echo "> DataGSM Multi-Module Staging Deployment Start" >> /home/ec2-user/deploy.log
 
 cd /home/ec2-user/builds/
 
-echo "> Stopping and removing existing containers..."
-docker compose -f compose.stage.yaml down
+echo "> Stopping and removing existing containers..." >> /home/ec2-user/deploy.log
+docker compose -f compose.stage.yaml down >> /home/ec2-user/deploy.log 2>&1
 
-echo "> Cleaning up unused Docker resources..."
-docker system prune -a --volumes -f
+echo "> Cleaning up unused Docker resources..." >> /home/ec2-user/deploy.log
+docker system prune -a --volumes -f >> /home/ec2-user/deploy.log 2>&1
 
-echo "> Building and starting containers..."
-docker compose -f compose.stage.yaml up -d --build
+echo "> Building and starting containers..." >> /home/ec2-user/deploy.log
+docker compose -f compose.stage.yaml up -d --build >> /home/ec2-user/deploy.log 2>&1
 
-echo "> Deployment completed successfully"
+echo "> Deployment completed successfully" >> /home/ec2-user/deploy.log

--- a/scripts/deploy/stage-deploy.sh
+++ b/scripts/deploy/stage-deploy.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 
-echo "> DataGSM Multi-Module Staging Deployment Start" >> /home/ec2-user/deploy.log
+exec >> /home/ec2-user/deploy.log 2>&1
 
-cd /home/ec2-user/builds/
+echo "> DataGSM Multi-Module Staging Deployment Start"
 
-echo "> Stopping and removing existing containers..." >> /home/ec2-user/deploy.log
-docker compose -f compose.stage.yaml down >> /home/ec2-user/deploy.log 2>&1
+cd /home/ec2-user/builds/ || exit 1
 
-echo "> Cleaning up unused Docker resources..." >> /home/ec2-user/deploy.log
-docker system prune -a --volumes -f >> /home/ec2-user/deploy.log 2>&1
+echo "> Stopping and removing existing containers..."
+docker compose -f compose.stage.yaml down
 
-echo "> Building and starting containers..." >> /home/ec2-user/deploy.log
-docker compose -f compose.stage.yaml up -d --build >> /home/ec2-user/deploy.log 2>&1
+echo "> Cleaning up unused Docker resources..."
+docker system prune -a --volumes -f
 
-echo "> Deployment completed successfully" >> /home/ec2-user/deploy.log
+echo "> Building and starting containers..."
+docker compose -f compose.stage.yaml up -d --build
+
+echo "> Deployment completed successfully"


### PR DESCRIPTION
## 개요

CD 파이프라인을 점검하여 JDK 버전 불일치, 트리거 분기 조건, 배포 로그 가시성, 잡·스텝 명칭 일관성 문제를 정리하였습니다. 동작 변경 없이 정합성과 일관성을 맞추는 작업입니다.

## 본문

### JDK 버전 통일

`datagsm-prod-cd.yaml`의 `publish-jvm`·`publish-js` 잡만 `JDK 21` + `setup-java@v4`를 사용하고 있어, 프로젝트 toolchain(`JavaLanguageVersion.of(25)`) 및 Dockerfile(`temurin:25-jre`)과 불일치하였습니다. 이를 `JDK 25`로 통일하고 액션 버전도 다른 잡과 동일하게 맞추었습니다.

- `java-version: '21'` → `'25'`
- `actions/setup-java@v4` → `@v5`, `actions/checkout@v4` → `@v6`, `actions/setup-node@v4` → `@v5`
- `setup-java`의 `cache: 'gradle'` 대신 다른 잡과 동일하게 `gradle/actions/setup-gradle@v5` 사용

### 트리거 분기 조건 정합

`datagsm-stage-cd.yaml`의 `if` 조건에 `github.event_name == 'workflow_run'` 체크가 빠져 있어 `prod`와 형식이 달랐습니다. `prod` 형식과 동일하게 명시하였습니다.

- 수동 실행(`workflow_dispatch`)은 CI 결과와 무관하게 동작합니다.
- 자동 실행(`workflow_run`)은 CI가 `success`이고 `push` 이벤트일 때만 동작합니다.

### 배포 로그 가시성 통일

`prod-deploy.sh`는 `docker system prune` 라인만 stdout으로 출력되어 `deploy.log`에서 누락되었고, `stage-deploy.sh`는 전체가 stdout으로만 출력되어 로그 추적이 어려웠습니다. 두 스크립트 모두 `deploy.log`로 일원화하였습니다.

### 잡·스텝 명칭 일관성

CI 워크플로우 기준에 맞춰 CD 명칭을 정리하였습니다.

- 잡 이름 `CD` → `deploy` (CI의 `build-and-test` 등 kebab-case 규칙과 일치, `prod`·`stage` 양쪽)
- `publish` 잡 스텝에 누락된 `name` 부여 (`Checkout Code`, `Setup JDK 25`, `Setup Gradle`, `Setup Node`)
- 알림 스텝 `CD Success/Failure/Cancelled Notification` → `Deploy ...`로 잡 이름과 정합

### 검증

- `prod-cd.yaml`·`stage-cd.yaml` YAML 파싱 통과
- 배포 스크립트 `bash -n` 구문 검사 통과
- 잡 이름 변경(`CD` → `deploy`)을 참조하는 `needs`가 없어 영향 없음
