### PR TITLE
[global] LLM 하네스 훅 `kotest`를 `gradle-test`로 명칭 변경

### DIFF
--- a/.harness/sync.yml
+++ b/.harness/sync.yml
@@ -15,14 +15,14 @@ overrides:
   claude/hooks/logging: true
   claude/hooks/command-guard: true
   claude/hooks/ktlint: true
-  claude/hooks/kotest: true
+  claude/hooks/gradle-test: true
   claude/hooks/secret-guard: true
   codex/hooks/dispatcher: true
   codex/hooks-json: true
   codex/hooks/logging: true
   codex/hooks/command-guard: true
   codex/hooks/ktlint: true
-  codex/hooks/kotest: true
+  codex/hooks/gradle-test: true
   codex/hooks/secret-guard: true
 
 branch_prefix: update/


### PR DESCRIPTION
## 변경 사항

`.harness/sync.yml`의 하네스 훅 활성화 키를 `kotest` → `gradle-test`로 변경합니다.

- `claude/hooks/kotest` → `claude/hooks/gradle-test`
- `codex/hooks/kotest` → `codex/hooks/gradle-test`

## 배경

ai-harness에서 해당 훅이 특정 테스트 프레임워크에 종속되지 않도록 `kotest` → `gradle-test`로 이름이 변경되었습니다. 훅 동작 자체는 `*ServiceImpl.kt` 저장 시 대응 Gradle 테스트 태스크를 자동 실행하는 것으로 동일하며, 단일/멀티/중첩 모듈 구조를 모두 처리하도록 개선되었습니다.

다음 하네스 sync에서 `gradle-test` 훅 디렉터리가 배포되고 구 `kotest` 디렉터리는 자동 정리됩니다.