### PR TITLE
[event] 이벤트 타입을 `*.updated` 단일 명칭으로 통일

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/dto/payload/ClubEventObject.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/dto/payload/ClubEventObject.kt
@@ -2,7 +2,7 @@ package team.themoment.datagsm.common.domain.event.dto.payload
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-// webhook 전송용 payload: club.changed 의 object 에 담기는 동아리 전체 정보
+// webhook 전송용 payload: club.updated 의 object 에 담기는 동아리 전체 정보
 data class ClubEventObject(
     @field:JsonProperty("club_id")
     val clubId: Long,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/dto/payload/ProjectEventObject.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/dto/payload/ProjectEventObject.kt
@@ -2,7 +2,7 @@ package team.themoment.datagsm.common.domain.event.dto.payload
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-// webhook 전송용 payload: project.changed 의 object 에 담기는 프로젝트 전체 정보
+// webhook 전송용 payload: project.updated 의 object 에 담기는 프로젝트 전체 정보
 data class ProjectEventObject(
     @field:JsonProperty("project_id")
     val projectId: Long,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/dto/payload/StudentEventObject.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/dto/payload/StudentEventObject.kt
@@ -2,7 +2,7 @@ package team.themoment.datagsm.common.domain.event.dto.payload
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-// webhook 전송용 payload: student.changed 의 object 에 담기는 학생 전체 정보
+// webhook 전송용 payload: student.updated 의 object 에 담기는 학생 전체 정보
 data class StudentEventObject(
     @field:JsonProperty("student_id")
     val studentId: Long,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/entity/constant/EventType.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/entity/constant/EventType.kt
@@ -4,7 +4,7 @@ enum class EventType(
     val eventName: String,
     val description: String,
 ) {
-    STUDENT_CHANGED("student.changed", "학생 정보 변경"),
-    CLUB_CHANGED("club.changed", "동아리 정보 변경"),
-    PROJECT_CHANGED("project.changed", "프로젝트 정보 변경"),
+    STUDENT_UPDATED("student.updated", "학생 정보 업데이트"),
+    CLUB_UPDATED("club.updated", "동아리 정보 업데이트"),
+    PROJECT_UPDATED("project.updated", "프로젝트 정보 업데이트"),
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/CreateClubServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/CreateClubServiceImpl.kt
@@ -91,7 +91,7 @@ class CreateClubServiceImpl(
 
         val newObj = generateClubEventObject(savedClub, leader, participants)
         eventPublisher.dispatch(
-            EventType.CLUB_CHANGED,
+            EventType.CLUB_UPDATED,
             EventChangedData(
                 old = listOf(EventChangeItem(0, EmptyEventObject())),
                 new = listOf(EventChangeItem(0, newObj)),

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/DeleteClubServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/DeleteClubServiceImpl.kt
@@ -43,7 +43,7 @@ class DeleteClubServiceImpl(
         clubJpaRepository.deleteAllByIdInBatch(listOf(clubId))
 
         eventPublisher.dispatch(
-            EventType.CLUB_CHANGED,
+            EventType.CLUB_UPDATED,
             EventChangedData(
                 old = listOf(EventChangeItem(0, oldObj)),
                 new = listOf(EventChangeItem(0, EmptyEventObject())),

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/ModifyClubServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/ModifyClubServiceImpl.kt
@@ -103,7 +103,7 @@ class ModifyClubServiceImpl(
 
         val newObj = generateClubEventObject(club, newLeader, participants)
         eventPublisher.dispatch(
-            EventType.CLUB_CHANGED,
+            EventType.CLUB_UPDATED,
             EventChangedData(
                 old = listOf(EventChangeItem(0, oldObj)),
                 new = listOf(EventChangeItem(0, newObj)),

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/CreateProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/CreateProjectServiceImpl.kt
@@ -87,7 +87,7 @@ class CreateProjectServiceImpl(
 
         val newObj = generateProjectEventObject(savedProjectEntity)
         eventPublisher.dispatch(
-            EventType.PROJECT_CHANGED,
+            EventType.PROJECT_UPDATED,
             EventChangedData(
                 old = listOf(EventChangeItem(0, EmptyEventObject())),
                 new = listOf(EventChangeItem(0, newObj)),

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/DeleteProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/DeleteProjectServiceImpl.kt
@@ -32,7 +32,7 @@ class DeleteProjectServiceImpl(
         projectJpaRepository.delete(project)
 
         eventPublisher.dispatch(
-            EventType.PROJECT_CHANGED,
+            EventType.PROJECT_UPDATED,
             EventChangedData(
                 old = listOf(EventChangeItem(0, oldObj)),
                 new = listOf(EventChangeItem(0, EmptyEventObject())),

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ModifyProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ModifyProjectServiceImpl.kt
@@ -79,7 +79,7 @@ class ModifyProjectServiceImpl(
 
         val newObj = generateProjectEventObject(project)
         eventPublisher.dispatch(
-            EventType.PROJECT_CHANGED,
+            EventType.PROJECT_UPDATED,
             EventChangedData(
                 old = listOf(EventChangeItem(0, oldObj)),
                 new = listOf(EventChangeItem(0, newObj)),

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/BatchOperationServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/BatchOperationServiceImpl.kt
@@ -49,7 +49,7 @@ class BatchOperationServiceImpl(
             }
         if (olds.isNotEmpty()) {
             eventPublisher.dispatch(
-                EventType.STUDENT_CHANGED,
+                EventType.STUDENT_UPDATED,
                 EventChangedData(old = olds, new = news),
             )
         }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateStudentServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateStudentServiceImpl.kt
@@ -42,7 +42,7 @@ class GraduateStudentServiceImpl(
 
         val new = generateStudentEventObject(student)
         eventPublisher.dispatch(
-            EventType.STUDENT_CHANGED,
+            EventType.STUDENT_UPDATED,
             EventChangedData(
                 old = listOf(EventChangeItem(0, old)),
                 new = listOf(EventChangeItem(0, new)),

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateThirdGradeStudentsServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateThirdGradeStudentsServiceImpl.kt
@@ -43,7 +43,7 @@ class GraduateThirdGradeStudentsServiceImpl(
             }
         if (olds.isNotEmpty()) {
             eventPublisher.dispatch(
-                EventType.STUDENT_CHANGED,
+                EventType.STUDENT_UPDATED,
                 EventChangedData(old = olds, new = news),
             )
         }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentExcelServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentExcelServiceImpl.kt
@@ -188,7 +188,7 @@ class ModifyStudentExcelServiceImpl(
             val olds = changed.mapIndexed { index, i -> EventChangeItem(index, oldObjects[i]) }
             val news = changed.mapIndexed { index, i -> EventChangeItem(index, newObjects[i]) }
             eventPublisher.dispatch(
-                EventType.STUDENT_CHANGED,
+                EventType.STUDENT_UPDATED,
                 EventChangedData(old = olds, new = news),
             )
         }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentServiceImpl.kt
@@ -90,7 +90,7 @@ class ModifyStudentServiceImpl(
             }
         val new = generateStudentEventObject(student)
         eventPublisher.dispatch(
-            EventType.STUDENT_CHANGED,
+            EventType.STUDENT_UPDATED,
             EventChangedData(
                 old = listOf(EventChangeItem(0, old)),
                 new = listOf(EventChangeItem(0, new)),

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentStatusServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentStatusServiceImpl.kt
@@ -51,7 +51,7 @@ class ModifyStudentStatusServiceImpl(
 
         val new = generateStudentEventObject(student)
         eventPublisher.dispatch(
-            EventType.STUDENT_CHANGED,
+            EventType.STUDENT_UPDATED,
             EventChangedData(
                 old = listOf(EventChangeItem(0, old)),
                 new = listOf(EventChangeItem(0, new)),

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/WithdrawStudentServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/WithdrawStudentServiceImpl.kt
@@ -44,7 +44,7 @@ class WithdrawStudentServiceImpl(
 
         val new = generateStudentEventObject(student)
         eventPublisher.dispatch(
-            EventType.STUDENT_CHANGED,
+            EventType.STUDENT_UPDATED,
             EventChangedData(
                 old = listOf(EventChangeItem(0, old)),
                 new = listOf(EventChangeItem(0, new)),

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/event/service/CreateEventServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/event/service/CreateEventServiceTest.kt
@@ -47,7 +47,7 @@ class CreateEventServiceTest :
                 val reqDto =
                     CreateEventReqDto(
                         targetUrl = "https://example.com/event",
-                        events = setOf(EventType.STUDENT_CHANGED),
+                        events = setOf(EventType.STUDENT_UPDATED),
                     )
 
                 context("등록된 Event가 최대 개수(10개)에 도달했을 때") {

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/event/service/DeleteEventServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/event/service/DeleteEventServiceTest.kt
@@ -53,7 +53,7 @@ class DeleteEventServiceTest :
                         EventJpaEntity().apply {
                             id = 1L
                             targetUrl = "https://example.com/event"
-                            events = mutableSetOf(EventType.CLUB_CHANGED)
+                            events = mutableSetOf(EventType.CLUB_UPDATED)
                             createdAt = LocalDateTime.now()
                         }
 

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/event/service/ModifyEventServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/event/service/ModifyEventServiceTest.kt
@@ -30,7 +30,7 @@ class ModifyEventServiceTest :
             EventJpaEntity().apply {
                 id = 1L
                 targetUrl = "https://old.example.com/event"
-                events = mutableSetOf(EventType.CLUB_CHANGED)
+                events = mutableSetOf(EventType.CLUB_UPDATED)
                 this.account = account
                 createdAt = LocalDateTime.now()
             }
@@ -95,13 +95,13 @@ class ModifyEventServiceTest :
                         val result = modifyEventService.execute(1L, reqDto)
 
                         result.targetUrl shouldBe "https://new.example.com"
-                        result.events shouldBe setOf(EventType.CLUB_CHANGED)
+                        result.events shouldBe setOf(EventType.CLUB_UPDATED)
                     }
                 }
 
                 context("events만 수정할 때") {
                     val reqDto =
-                        ModifyEventReqDto(targetUrl = null, events = setOf(EventType.PROJECT_CHANGED))
+                        ModifyEventReqDto(targetUrl = null, events = setOf(EventType.PROJECT_UPDATED))
 
                     beforeEach {
                         every { eventJpaRepository.findByIdAndAccount(1L, account) } returns existingEvent()
@@ -111,7 +111,7 @@ class ModifyEventServiceTest :
                         val result = modifyEventService.execute(1L, reqDto)
 
                         result.targetUrl shouldBe "https://old.example.com/event"
-                        result.events shouldBe setOf(EventType.PROJECT_CHANGED)
+                        result.events shouldBe setOf(EventType.PROJECT_UPDATED)
                     }
                 }
             }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/event/service/QueryEventServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/event/service/QueryEventServiceTest.kt
@@ -36,7 +36,7 @@ class QueryEventServiceTest :
                             EventJpaEntity().apply {
                                 id = 1L
                                 targetUrl = "https://example.com/event"
-                                events = mutableSetOf(EventType.CLUB_CHANGED)
+                                events = mutableSetOf(EventType.CLUB_UPDATED)
                                 this.account = account
                                 createdAt = LocalDateTime.now()
                             }
@@ -49,7 +49,7 @@ class QueryEventServiceTest :
                         result.events.size shouldBe 1
                         result.events[0].id shouldBe 1L
                         result.events[0].targetUrl shouldBe "https://example.com/event"
-                        result.events[0].events shouldBe setOf(EventType.CLUB_CHANGED)
+                        result.events[0].events shouldBe setOf(EventType.CLUB_UPDATED)
                     }
                 }
 

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentExcelServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentExcelServiceTest.kt
@@ -152,7 +152,7 @@ class ModifyStudentExcelServiceTest :
 
                     it("학생 정보를 수정하고 성공 메시지를 반환해야 한다") {
                         val dataSlot = slot<EventChangedData>()
-                        justRun { mockEventPublisher.dispatch(EventType.STUDENT_CHANGED, capture(dataSlot)) }
+                        justRun { mockEventPublisher.dispatch(EventType.STUDENT_UPDATED, capture(dataSlot)) }
 
                         val result = modifyStudentExcelService.execute(file)
 
@@ -174,13 +174,13 @@ class ModifyStudentExcelServiceTest :
                         verify { mockStudentRepository.bulkUpdateEmails(match { it[1L] == "hong@gsm.hs.kr" }) }
                     }
 
-                    it("STUDENT_CHANGED 이벤트의 old는 수정 전, new는 수정 후 값을 담는다") {
+                    it("STUDENT_UPDATED 이벤트의 old는 수정 전, new는 수정 후 값을 담는다") {
                         val dataSlot = slot<EventChangedData>()
-                        justRun { mockEventPublisher.dispatch(EventType.STUDENT_CHANGED, capture(dataSlot)) }
+                        justRun { mockEventPublisher.dispatch(EventType.STUDENT_UPDATED, capture(dataSlot)) }
 
                         modifyStudentExcelService.execute(file)
 
-                        verify(exactly = 1) { mockEventPublisher.dispatch(EventType.STUDENT_CHANGED, any()) }
+                        verify(exactly = 1) { mockEventPublisher.dispatch(EventType.STUDENT_UPDATED, any()) }
                         val data = dataSlot.captured
                         data.old.size shouldBe 1
                         data.new.size shouldBe 1

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/BatchOperationServiceImplTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/BatchOperationServiceImplTest.kt
@@ -54,8 +54,8 @@ class BatchOperationServiceImplTest :
                     }
                 }
 
-                Then("STUDENT_CHANGED 이벤트가 1회 발행된다") {
-                    verify(exactly = 1) { eventPublisher.dispatch(EventType.STUDENT_CHANGED, any()) }
+                Then("STUDENT_UPDATED 이벤트가 1회 발행된다") {
+                    verify(exactly = 1) { eventPublisher.dispatch(EventType.STUDENT_UPDATED, any()) }
                 }
             }
         }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateThirdGradeStudentsServiceImplTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateThirdGradeStudentsServiceImplTest.kt
@@ -66,7 +66,7 @@ class GraduateThirdGradeStudentsServiceImplTest :
 
             val dataSlot = slot<EventChangedData>()
             every { studentJpaRepository.findStudentsByGrade(3) } returns thirdGradeStudents
-            justRun { eventPublisher.dispatch(EventType.STUDENT_CHANGED, capture(dataSlot)) }
+            justRun { eventPublisher.dispatch(EventType.STUDENT_UPDATED, capture(dataSlot)) }
 
             When("모든 3학년 학생을 졸업 처리하면") {
                 val result = graduateThirdGradeStudentsService.execute()
@@ -88,8 +88,8 @@ class GraduateThirdGradeStudentsServiceImplTest :
                     verify(exactly = 1) { studentJpaRepository.findStudentsByGrade(3) }
                 }
 
-                Then("STUDENT_CHANGED 이벤트가 1회 발행되며 old/new가 index로 매핑된다") {
-                    verify(exactly = 1) { eventPublisher.dispatch(EventType.STUDENT_CHANGED, any()) }
+                Then("STUDENT_UPDATED 이벤트가 1회 발행되며 old/new가 index로 매핑된다") {
+                    verify(exactly = 1) { eventPublisher.dispatch(EventType.STUDENT_UPDATED, any()) }
                     val data = dataSlot.captured
                     data.old.size shouldBe 3
                     data.new.size shouldBe 3


### PR DESCRIPTION
## 개요

도메인 이벤트 타입의 명칭을 `*.changed` 에서 `*.updated` 로 통일하였습니다. 생성·수정·삭제를 모두 포함하는 이벤트 의미상 "변경(changed)"보다 "업데이트(updated)"가 더 직관적이라는 판단에 따른 명칭 정리입니다.

## 본문

`EventType` enum 의 세 이벤트 타입을 다음과 같이 변경하였습니다.

| 변경 전 | 변경 후 |
| --- | --- |
| `STUDENT_CHANGED` / `student.changed` | `STUDENT_UPDATED` / `student.updated` |
| `CLUB_CHANGED` / `club.changed` | `CLUB_UPDATED` / `club.updated` |
| `PROJECT_CHANGED` / `project.changed` | `PROJECT_UPDATED` / `project.updated` |

- enum 이름, `eventName`(webhook `event` 값), `description`("정보 변경" → "정보 업데이트")을 모두 갱신하였습니다.
- 해당 enum 을 참조하는 학생·동아리·프로젝트 서비스 구현체와 이벤트 서비스, 그리고 관련 테스트 코드를 일괄 수정하였습니다.
- `payload` 패키지 DTO(`StudentEventObject`, `ClubEventObject`, `ProjectEventObject`)의 설명 주석도 새 이벤트명에 맞추었습니다.

생성·수정·삭제 여부는 별도 이벤트 타입이 아니라 `old`/`new` 의 `object` 가 빈 객체(`{}`)인지로 구분하는 기존 구조를 그대로 유지합니다. 코드 동작(직렬화 형태, 발행 시점)에는 변화가 없으며, 외부로 노출되는 이벤트 이름만 바뀝니다.

## 참고

`tb_event_type.event` 컬럼은 `@Enumerated(EnumType.STRING)` 매핑이라 enum 이름이 저장됩니다. enum 이름이 바뀌므로 운영 DB 의 기존 구독 행을 새 이름으로 옮기는 마이그레이션이 배포 전에 필요합니다. (`STUDENT_CHANGED → STUDENT_UPDATED`, `CLUB_* → CLUB_UPDATED`, `PROJECT_* → PROJECT_UPDATED`)

`:datagsm-common` · `:datagsm-web` 컴파일과 이벤트 관련 테스트가 모두 통과함을 확인하였습니다.
