### PR TITLE
[ci/cd] npm 배포 버전 semver 정규화 로직 수정

### DIFF
--- a/datagsm-shared/build.gradle.kts
+++ b/datagsm-shared/build.gradle.kts
@@ -83,11 +83,12 @@ tasks.register("assembleTsPackage") {
         dir.mkdirs()
         tsFile.copyTo(dir.resolve("index.d.ts"), overwrite = true)
 
-        // npm requires semver; CI passes "<yyyyMMdd>-<run>" → normalize to "<yyyyMMdd>.0.0-<run>".
+        // npm requires semver; CI passes "<yyyyMMdd>-<run>" → normalize to "<yyyyMMdd>.0.<run>".
+        // Kept as a release version (no prerelease suffix) so `npm publish` doesn't require --tag.
         val npmVersion =
             Regex("""^(\d+)-(\d+)$""")
                 .find(packageVersion)
-                ?.let { "${it.groupValues[1]}.0.0-${it.groupValues[2]}" }
+                ?.let { "${it.groupValues[1]}.0.${it.groupValues[2]}" }
                 ?: packageVersion
 
         dir.resolve("package.json").writeText(

--- a/datagsm-shared/build.gradle.kts
+++ b/datagsm-shared/build.gradle.kts
@@ -87,7 +87,7 @@ tasks.register("assembleTsPackage") {
         // Kept as a release version (no prerelease suffix) so `npm publish` doesn't require --tag.
         val npmVersion =
             Regex("""^(\d+)-(\d+)$""")
-                .find(packageVersion)
+                .matchEntire(packageVersion)
                 ?.let { "${it.groupValues[1]}.0.${it.groupValues[2]}" }
                 ?: packageVersion
 


### PR DESCRIPTION
## 배경
prod CD 워크플로우의 `publish-js` job에서 `npm publish` 실패 (run: https://github.com/themoment-team/datagsm-server/actions/runs/28523784237/job/84554635517)

```
npm error You must specify a tag using --tag when publishing a prerelease version.
```

## 원인
`datagsm-shared/build.gradle.kts`의 버전 정규화 로직이 CI가 넘겨주는 `<yyyyMMdd>-<run>` 형식을 `<yyyyMMdd>.0.0-<run>`으로 변환했는데, 이 형태는 semver의 prerelease 표기(`-<run>`)로 해석됨. npm은 `--tag` 없이 prerelease 버전을 `latest`로 배포하는 것을 막기 위해 에러를 던짐.

## 변경 사항
run_number를 prerelease 자리 대신 patch 자리에 넣어 순수 release 버전(`<yyyyMMdd>.0.<run>`)으로 생성하도록 수정. 워크플로우의 `npm publish` 커맨드는 그대로 유지.

## 테스트
- 로컬 빌드 확인 필요 없음 (문자열 포맷 변경만)