### PR TITLE
[event] 존재하지 않는 도메인 URL 검증 우회 버그 수정

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/validator/EventUrlValidator.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/validator/EventUrlValidator.kt
@@ -21,7 +21,7 @@ object EventUrlValidator {
         try {
             val host = URI(url).host ?: return true
             val addresses = resolveWithTimeout(host) ?: return true
-            addresses.isEmpty() || addresses.any { isPrivateAddress(it) }
+            addresses.any { isPrivateAddress(it) }
         } catch (e: Exception) {
             logger().warn("Blocked event url due to unexpected parse error {}", e.message)
             true

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/validator/EventUrlValidator.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/validator/EventUrlValidator.kt
@@ -21,13 +21,13 @@ object EventUrlValidator {
         try {
             val host = URI(url).host ?: return true
             val addresses = resolveWithTimeout(host) ?: return true
-            addresses.any { isPrivateAddress(it) }
+            addresses.isEmpty() || addresses.any { isPrivateAddress(it) }
         } catch (e: Exception) {
             logger().warn("Blocked event url due to unexpected parse error {}", e.message)
             true
         }
 
-    // null = 차단 (타임아웃 또는 예상치 못한 오류), emptyArray = 존재하지 않는 도메인 (허용)
+    // null = 차단 (타임아웃 또는 예상치 못한 오류)
     private fun resolveWithTimeout(host: String): Array<InetAddress>? =
         try {
             CompletableFuture
@@ -39,7 +39,8 @@ object EventUrlValidator {
         } catch (e: Exception) {
             val cause = e.cause
             if (cause is UnknownHostException) {
-                emptyArray()
+                logger().warn("Blocked event url due to unknown host {}", host)
+                null
             } else {
                 logger().warn("Blocked event url due to DNS resolution failure for host {} error {}", host, e.message)
                 null

--- a/datagsm-common/src/test/kotlin/team/themoment/datagsm/common/domain/event/validator/EventUrlValidatorTest.kt
+++ b/datagsm-common/src/test/kotlin/team/themoment/datagsm/common/domain/event/validator/EventUrlValidatorTest.kt
@@ -151,7 +151,7 @@ class EventUrlValidatorTest :
                 }
 
                 context("존재하지 않는 도메인이 주어질 때") {
-                    it("false를 반환해야 한다") {
+                    it("true를 반환해야 한다") {
                         // Given
                         val url = "http://this-domain-does-not-exist-datagsm.invalid/hook"
 
@@ -159,7 +159,7 @@ class EventUrlValidatorTest :
                         val result = EventUrlValidator.isPrivateOrLocalUrl(url)
 
                         // Then
-                        result shouldBe false
+                        result shouldBe true
                     }
                 }
             }


### PR DESCRIPTION
## 개요

`EventUrlValidator`에서 존재하지 않는 도메인이 URL 검증을 우회하여 `VERIFIED`로 잘못 처리되는 버그를 수정하였습니다.

## 본문

### 문제

`EventUrlValidator.resolveWithTimeout()`은 DNS 조회 시 `UnknownHostException`이 발생하면 `emptyArray()`를 반환하였고, 상위 `isPrivateOrLocalUrl()`에서 빈 배열에 대한 `any { isPrivateAddress(it) }` 검사는 항상 `false`를 반환하였습니다. 그 결과 `https://dkwpdkwsdwdpdkpw.kwd`처럼 실제로 존재하지 않는 도메인도 사설/로컬 주소 검사를 통과한 것으로 간주되어, `Event` 생성·수정 시 `PENDING`으로 저장된 뒤 비동기 검증 과정에서 곧바로 `VERIFIED`로 전환되었습니다.

### 변경 사항

- `resolveWithTimeout()`: `UnknownHostException` 발생 시에도 다른 DNS 조회 실패와 동일하게 `null`(차단)을 반환하도록 통일하였습니다.
- `isPrivateOrLocalUrl()`: `addresses.isEmpty()` 조건을 추가하여, 향후 빈 주소 목록이 반환되더라도 검증을 통과하지 못하도록 방어 로직을 추가하였습니다.
- `EventUrlValidatorTest`: 존재하지 않는 도메인이 주어졌을 때의 기대값을 `false`에서 `true`(차단)로 수정하였습니다.

### 테스트

- `datagsm-common` 모듈 `EventUrlValidatorTest` 12개, `datagsm-web` 모듈 340개 테스트가 모두 통과함을 확인하였습니다.
