### PR TITLE
[account] 어드민 계정 관리 조회 및 권한 변경 API 추가

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/request/ModifyAccountRoleReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/request/ModifyAccountRoleReqDto.kt
@@ -1,0 +1,11 @@
+package team.themoment.datagsm.common.domain.account.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
+
+data class ModifyAccountRoleReqDto(
+    @field:NotNull(message = "변경할 역할은 필수입니다.")
+    @param:Schema(description = "변경할 계정 역할 (ADMIN, USER)")
+    val role: AccountRole,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/request/QueryAccountReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/request/QueryAccountReqDto.kt
@@ -1,0 +1,28 @@
+package team.themoment.datagsm.common.domain.account.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountSortBy
+import team.themoment.datagsm.common.global.constant.SortDirection
+
+data class QueryAccountReqDto(
+    @param:Schema(description = "이메일 (부분 일치)")
+    val email: String? = null,
+    @param:Schema(description = "계정 역할 (ROOT, ADMIN, USER)")
+    val role: AccountRole? = null,
+    @param:Schema(description = "학생 연결 여부 (true: 연결 계정만, false: 미연결 계정만)")
+    val isStudent: Boolean? = null,
+    @field:Min(0)
+    @param:Schema(description = "페이지 번호", defaultValue = "0", minimum = "0")
+    val page: Int = 0,
+    @field:Min(1)
+    @field:Max(1000)
+    @param:Schema(description = "페이지 크기", defaultValue = "300", minimum = "1", maximum = "1000")
+    val size: Int = 300,
+    @param:Schema(description = "정렬 기준 (ID, EMAIL, ROLE, CREATED_AT)")
+    val sortBy: AccountSortBy? = null,
+    @param:Schema(description = "정렬 방향 (ASC, DESC)", defaultValue = "ASC")
+    val sortDirection: SortDirection = SortDirection.ASC,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountListResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountListResDto.kt
@@ -1,0 +1,12 @@
+package team.themoment.datagsm.common.domain.account.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class AccountListResDto(
+    @field:Schema(description = "전체 페이지 수", example = "1")
+    val totalPages: Int,
+    @field:Schema(description = "전체 계정 수", example = "100")
+    val totalElements: Long,
+    @field:Schema(description = "계정 목록")
+    val accounts: List<AccountResDto>,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountResDto.kt
@@ -1,0 +1,37 @@
+package team.themoment.datagsm.common.domain.account.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
+import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
+import java.time.LocalDateTime
+
+data class AccountResDto(
+    @field:Schema(description = "계정 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "계정 이메일", example = "user@gsm.hs.kr")
+    val email: String,
+    @field:Schema(description = "계정 역할 (ROOT, ADMIN, USER)", example = "USER")
+    val role: AccountRole,
+    @field:Schema(description = "학생 계정 여부", example = "true")
+    val isStudent: Boolean,
+    @field:Schema(description = "연결된 학생 정보 (학생 계정인 경우에만 포함)")
+    val student: StudentResDto?,
+    @field:Schema(description = "생성 일시")
+    val createdAt: LocalDateTime?,
+    @field:Schema(description = "수정 일시")
+    val updatedAt: LocalDateTime?,
+) {
+    companion object {
+        fun from(account: AccountJpaEntity): AccountResDto =
+            AccountResDto(
+                id = account.id!!,
+                email = account.email,
+                role = account.role,
+                isStudent = account.student != null,
+                student = account.student?.let { StudentResDto.from(it) },
+                createdAt = account.createdAt,
+                updatedAt = account.updatedAt,
+            )
+    }
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/entity/constant/AccountSortBy.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/entity/constant/AccountSortBy.kt
@@ -1,0 +1,11 @@
+package team.themoment.datagsm.common.domain.account.entity.constant
+
+import team.themoment.datagsm.ksp.annotation.SdkExport
+
+@SdkExport
+enum class AccountSortBy {
+    ID,
+    EMAIL,
+    ROLE,
+    CREATED_AT,
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/repository/AccountJpaRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/repository/AccountJpaRepository.kt
@@ -3,9 +3,12 @@ package team.themoment.datagsm.common.domain.account.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.repository.custom.AccountJpaCustomRepository
 import java.util.Optional
 
 @Repository
-interface AccountJpaRepository : JpaRepository<AccountJpaEntity, Long> {
+interface AccountJpaRepository :
+    JpaRepository<AccountJpaEntity, Long>,
+    AccountJpaCustomRepository {
     fun findByEmail(email: String): Optional<AccountJpaEntity>
 }

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/repository/custom/AccountJpaCustomRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/repository/custom/AccountJpaCustomRepository.kt
@@ -1,0 +1,19 @@
+package team.themoment.datagsm.common.domain.account.repository.custom
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountSortBy
+import team.themoment.datagsm.common.global.constant.SortDirection
+
+interface AccountJpaCustomRepository {
+    fun searchAccountsWithPaging(
+        email: String?,
+        role: AccountRole?,
+        isStudent: Boolean?,
+        pageable: Pageable,
+        sortBy: AccountSortBy?,
+        sortDirection: SortDirection,
+    ): Page<AccountJpaEntity>
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/repository/custom/impl/AccountJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/repository/custom/impl/AccountJpaCustomRepositoryImpl.kt
@@ -1,0 +1,98 @@
+package team.themoment.datagsm.common.domain.account.repository.custom.impl
+
+import com.querydsl.core.types.OrderSpecifier
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.support.PageableExecutionUtils
+import org.springframework.stereotype.Repository
+import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.QAccountJpaEntity.Companion.accountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountSortBy
+import team.themoment.datagsm.common.domain.account.repository.custom.AccountJpaCustomRepository
+import team.themoment.datagsm.common.global.constant.SortDirection
+
+@Repository
+class AccountJpaCustomRepositoryImpl(
+    val jpaQueryFactory: JPAQueryFactory,
+) : AccountJpaCustomRepository {
+    override fun searchAccountsWithPaging(
+        email: String?,
+        role: AccountRole?,
+        isStudent: Boolean?,
+        pageable: Pageable,
+        sortBy: AccountSortBy?,
+        sortDirection: SortDirection,
+    ): Page<AccountJpaEntity> {
+        val orderSpecifier = createOrderSpecifier(sortBy, sortDirection)
+
+        val accountIds =
+            jpaQueryFactory
+                .select(accountJpaEntity.id)
+                .from(accountJpaEntity)
+                .where(
+                    email?.let { accountJpaEntity.email.contains(it) },
+                    role?.let { accountJpaEntity.role.eq(it) },
+                    isStudent?.let {
+                        if (it) accountJpaEntity.student.isNotNull else accountJpaEntity.student.isNull
+                    },
+                ).apply {
+                    orderSpecifier?.let { orderBy(*it) }
+                }.offset(pageable.offset)
+                .limit(pageable.pageSize.toLong())
+                .fetch()
+
+        val content =
+            if (accountIds.isEmpty()) {
+                emptyList()
+            } else {
+                jpaQueryFactory
+                    .selectFrom(accountJpaEntity)
+                    .leftJoin(accountJpaEntity.student)
+                    .fetchJoin()
+                    .leftJoin(accountJpaEntity.student.majorClub)
+                    .fetchJoin()
+                    .leftJoin(accountJpaEntity.student.autonomousClub)
+                    .fetchJoin()
+                    .where(accountJpaEntity.id.`in`(accountIds))
+                    .apply { orderSpecifier?.let { orderBy(*it) } }
+                    .fetch()
+            }
+
+        val countQuery =
+            jpaQueryFactory
+                .select(accountJpaEntity.count())
+                .from(accountJpaEntity)
+                .where(
+                    email?.let { accountJpaEntity.email.contains(it) },
+                    role?.let { accountJpaEntity.role.eq(it) },
+                    isStudent?.let {
+                        if (it) accountJpaEntity.student.isNotNull else accountJpaEntity.student.isNull
+                    },
+                )
+
+        return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
+    }
+
+    private fun createOrderSpecifier(
+        sortBy: AccountSortBy?,
+        sortDirection: SortDirection,
+    ): Array<OrderSpecifier<*>>? {
+        if (sortBy == null) return null
+
+        val path =
+            when (sortBy) {
+                AccountSortBy.ID -> accountJpaEntity.id
+                AccountSortBy.EMAIL -> accountJpaEntity.email
+                AccountSortBy.ROLE -> accountJpaEntity.role
+                AccountSortBy.CREATED_AT -> accountJpaEntity.createdAt
+            }
+        return arrayOf(
+            when (sortDirection) {
+                SortDirection.ASC -> path.asc()
+                SortDirection.DESC -> path.desc()
+            },
+        )
+    }
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/response/StudentResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/response/StudentResDto.kt
@@ -2,6 +2,7 @@ package team.themoment.datagsm.common.domain.student.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.Major
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
@@ -43,4 +44,30 @@ data class StudentResDto(
     val githubId: String?,
     @field:Schema(description = "GitHub 프로필 URL", example = "https://github.com/torvalds")
     val githubUrl: String?,
-)
+) {
+    companion object {
+        fun from(student: StudentJpaEntity): StudentResDto =
+            StudentResDto(
+                id = student.id!!,
+                name = student.name,
+                sex = student.sex,
+                email = student.email,
+                grade = student.studentNumber?.studentGrade,
+                classNum = student.studentNumber?.studentClass,
+                number = student.studentNumber?.studentNumber,
+                studentNumber = student.studentNumber?.fullStudentNumber,
+                major = student.major,
+                specialty = student.specialty,
+                role = student.role,
+                dormitoryFloor = student.dormitoryRoomNumber?.dormitoryRoomFloor,
+                dormitoryRoom = student.dormitoryRoomNumber?.dormitoryRoomNumber,
+                majorClub = student.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
+                autonomousClub =
+                    student.autonomousClub?.let {
+                        ClubSummaryDto(id = it.id!!, name = it.name, type = it.type)
+                    },
+                githubId = student.githubId,
+                githubUrl = student.githubId?.let { "https://github.com/$it" },
+            )
+    }
+}

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/student/service/impl/QueryStudentServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/student/service/impl/QueryStudentServiceImpl.kt
@@ -3,7 +3,6 @@ package team.themoment.datagsm.openapi.domain.student.service.impl
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
 import team.themoment.datagsm.common.domain.student.dto.request.QueryStudentReqDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentListResDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
@@ -41,28 +40,7 @@ class QueryStudentServiceImpl(
         return StudentListResDto(
             totalElements = studentPage.totalElements,
             totalPages = studentPage.totalPages,
-            students =
-                studentPage.content.map { entity ->
-                    StudentResDto(
-                        id = entity.id!!,
-                        name = entity.name,
-                        sex = entity.sex,
-                        email = entity.email,
-                        grade = entity.studentNumber?.studentGrade,
-                        classNum = entity.studentNumber?.studentClass,
-                        number = entity.studentNumber?.studentNumber,
-                        studentNumber = entity.studentNumber?.fullStudentNumber,
-                        major = entity.major,
-                        specialty = entity.specialty,
-                        role = entity.role,
-                        dormitoryFloor = entity.dormitoryRoomNumber?.dormitoryRoomFloor,
-                        dormitoryRoom = entity.dormitoryRoomNumber?.dormitoryRoomNumber,
-                        majorClub = entity.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
-                        autonomousClub = entity.autonomousClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
-                        githubId = entity.githubId,
-                        githubUrl = entity.githubId?.let { "https://github.com/$it" },
-                    )
-                },
+            students = studentPage.content.map { StudentResDto.from(it) },
         )
     }
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/controller/AccountController.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/controller/AccountController.kt
@@ -8,12 +8,22 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import team.themoment.datagsm.common.domain.account.dto.request.DeleteMyAccountReqDto
+import team.themoment.datagsm.common.domain.account.dto.request.ModifyAccountRoleReqDto
+import team.themoment.datagsm.common.domain.account.dto.request.QueryAccountReqDto
 import team.themoment.datagsm.common.domain.account.dto.response.AccountInfoResDto
+import team.themoment.datagsm.common.domain.account.dto.response.AccountListResDto
+import team.themoment.datagsm.common.domain.account.dto.response.AccountResDto
 import team.themoment.datagsm.web.domain.account.service.DeleteMyAccountService
+import team.themoment.datagsm.web.domain.account.service.ModifyAccountRoleService
+import team.themoment.datagsm.web.domain.account.service.QueryAccountDetailService
+import team.themoment.datagsm.web.domain.account.service.QueryAccountService
 import team.themoment.datagsm.web.domain.account.service.QueryMyInfoService
 
 @Tag(name = "Account", description = "계정 관련 API")
@@ -22,6 +32,9 @@ import team.themoment.datagsm.web.domain.account.service.QueryMyInfoService
 class AccountController(
     private val queryMyInfoService: QueryMyInfoService,
     private val deleteMyAccountService: DeleteMyAccountService,
+    private val queryAccountService: QueryAccountService,
+    private val queryAccountDetailService: QueryAccountDetailService,
+    private val modifyAccountRoleService: ModifyAccountRoleService,
 ) {
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 계정 및 학생 정보를 조회합니다.")
     @ApiResponses(
@@ -47,4 +60,46 @@ class AccountController(
     fun deleteMyAccount(
         @Valid @RequestBody reqDto: DeleteMyAccountReqDto,
     ) = deleteMyAccountService.execute(reqDto)
+
+    @Operation(summary = "계정 목록 조회", description = "어드민이 계정 목록을 필터·페이징 조건으로 조회합니다. 각 계정에 연결된 학생 정보가 포함됩니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "계정 목록 조회 성공"),
+            ApiResponse(responseCode = "401", description = "인증 실패", content = [Content()]),
+            ApiResponse(responseCode = "403", description = "권한 없음", content = [Content()]),
+        ],
+    )
+    @GetMapping
+    fun getAccounts(
+        @Valid @ModelAttribute queryReq: QueryAccountReqDto,
+    ): AccountListResDto = queryAccountService.execute(queryReq)
+
+    @Operation(summary = "계정 단건 조회", description = "어드민이 특정 계정을 조회합니다. 연결된 학생 정보가 포함됩니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "계정 조회 성공"),
+            ApiResponse(responseCode = "401", description = "인증 실패", content = [Content()]),
+            ApiResponse(responseCode = "403", description = "권한 없음", content = [Content()]),
+            ApiResponse(responseCode = "404", description = "계정을 찾을 수 없음", content = [Content()]),
+        ],
+    )
+    @GetMapping("/{accountId}")
+    fun getAccount(
+        @PathVariable accountId: Long,
+    ): AccountResDto = queryAccountDetailService.execute(accountId)
+
+    @Operation(summary = "계정 권한 변경", description = "어드민이 특정 계정의 역할을 변경합니다. 본인 및 최고 관리자 계정은 변경할 수 없습니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "권한 변경 성공"),
+            ApiResponse(responseCode = "401", description = "인증 실패", content = [Content()]),
+            ApiResponse(responseCode = "403", description = "본인 또는 최고 관리자 계정 변경 불가", content = [Content()]),
+            ApiResponse(responseCode = "404", description = "계정을 찾을 수 없음", content = [Content()]),
+        ],
+    )
+    @PatchMapping("/{accountId}/role")
+    fun modifyAccountRole(
+        @PathVariable accountId: Long,
+        @Valid @RequestBody reqDto: ModifyAccountRoleReqDto,
+    ) = modifyAccountRoleService.execute(accountId, reqDto)
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/controller/AccountController.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/controller/AccountController.kt
@@ -1,6 +1,7 @@
 package team.themoment.datagsm.web.domain.account.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
@@ -61,12 +62,11 @@ class AccountController(
         @Valid @RequestBody reqDto: DeleteMyAccountReqDto,
     ) = deleteMyAccountService.execute(reqDto)
 
-    @Operation(summary = "계정 목록 조회", description = "어드민이 계정 목록을 필터·페이징 조건으로 조회합니다. 각 계정에 연결된 학생 정보가 포함됩니다.")
+    @Operation(summary = "계정 목록 조회", description = "필터 조건에 맞는 계정 목록을 조회합니다. 각 계정에 연결된 학생 정보가 포함됩니다.")
     @ApiResponses(
         value = [
-            ApiResponse(responseCode = "200", description = "계정 목록 조회 성공"),
-            ApiResponse(responseCode = "401", description = "인증 실패", content = [Content()]),
-            ApiResponse(responseCode = "403", description = "권한 없음", content = [Content()]),
+            ApiResponse(responseCode = "200", description = "조회 성공"),
+            ApiResponse(responseCode = "400", description = "잘못된 요청 (검증 실패)", content = [Content()]),
         ],
     )
     @GetMapping
@@ -74,32 +74,30 @@ class AccountController(
         @Valid @ModelAttribute queryReq: QueryAccountReqDto,
     ): AccountListResDto = queryAccountService.execute(queryReq)
 
-    @Operation(summary = "계정 단건 조회", description = "어드민이 특정 계정을 조회합니다. 연결된 학생 정보가 포함됩니다.")
+    @Operation(summary = "계정 단건 조회", description = "특정 계정의 정보를 조회합니다. 연결된 학생 정보가 포함됩니다.")
     @ApiResponses(
         value = [
-            ApiResponse(responseCode = "200", description = "계정 조회 성공"),
-            ApiResponse(responseCode = "401", description = "인증 실패", content = [Content()]),
-            ApiResponse(responseCode = "403", description = "권한 없음", content = [Content()]),
+            ApiResponse(responseCode = "200", description = "조회 성공"),
             ApiResponse(responseCode = "404", description = "계정을 찾을 수 없음", content = [Content()]),
         ],
     )
     @GetMapping("/{accountId}")
     fun getAccount(
-        @PathVariable accountId: Long,
+        @Parameter(description = "계정 ID") @PathVariable accountId: Long,
     ): AccountResDto = queryAccountDetailService.execute(accountId)
 
-    @Operation(summary = "계정 권한 변경", description = "어드민이 특정 계정의 역할을 변경합니다. 본인 및 최고 관리자 계정은 변경할 수 없습니다.")
+    @Operation(summary = "계정 권한 변경", description = "특정 계정의 역할을 변경합니다. 본인 및 최고 관리자 계정은 변경할 수 없습니다.")
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "권한 변경 성공"),
-            ApiResponse(responseCode = "401", description = "인증 실패", content = [Content()]),
+            ApiResponse(responseCode = "400", description = "잘못된 요청 (검증 실패)", content = [Content()]),
             ApiResponse(responseCode = "403", description = "본인 또는 최고 관리자 계정 변경 불가", content = [Content()]),
             ApiResponse(responseCode = "404", description = "계정을 찾을 수 없음", content = [Content()]),
         ],
     )
     @PatchMapping("/{accountId}/role")
     fun modifyAccountRole(
-        @PathVariable accountId: Long,
-        @Valid @RequestBody reqDto: ModifyAccountRoleReqDto,
+        @Parameter(description = "계정 ID") @PathVariable accountId: Long,
+        @RequestBody @Valid reqDto: ModifyAccountRoleReqDto,
     ) = modifyAccountRoleService.execute(accountId, reqDto)
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/ModifyAccountRoleService.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/ModifyAccountRoleService.kt
@@ -1,0 +1,10 @@
+package team.themoment.datagsm.web.domain.account.service
+
+import team.themoment.datagsm.common.domain.account.dto.request.ModifyAccountRoleReqDto
+
+interface ModifyAccountRoleService {
+    fun execute(
+        accountId: Long,
+        reqDto: ModifyAccountRoleReqDto,
+    )
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/QueryAccountDetailService.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/QueryAccountDetailService.kt
@@ -1,0 +1,7 @@
+package team.themoment.datagsm.web.domain.account.service
+
+import team.themoment.datagsm.common.domain.account.dto.response.AccountResDto
+
+interface QueryAccountDetailService {
+    fun execute(accountId: Long): AccountResDto
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/QueryAccountService.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/QueryAccountService.kt
@@ -1,0 +1,8 @@
+package team.themoment.datagsm.web.domain.account.service
+
+import team.themoment.datagsm.common.domain.account.dto.request.QueryAccountReqDto
+import team.themoment.datagsm.common.domain.account.dto.response.AccountListResDto
+
+interface QueryAccountService {
+    fun execute(queryReq: QueryAccountReqDto): AccountListResDto
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/ModifyAccountRoleServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/ModifyAccountRoleServiceImpl.kt
@@ -1,0 +1,39 @@
+package team.themoment.datagsm.web.domain.account.service.impl
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.account.dto.request.ModifyAccountRoleReqDto
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
+import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
+import team.themoment.datagsm.web.domain.account.service.ModifyAccountRoleService
+import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class ModifyAccountRoleServiceImpl(
+    private val accountJpaRepository: AccountJpaRepository,
+    private val currentUserProvider: CurrentUserProvider,
+) : ModifyAccountRoleService {
+    @Transactional
+    override fun execute(
+        accountId: Long,
+        reqDto: ModifyAccountRoleReqDto,
+    ) {
+        val account =
+            accountJpaRepository.findById(accountId).orElseThrow {
+                ExpectedException("계정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+            }
+
+        val currentAccount = currentUserProvider.getCurrentAccount()
+        if (account.id == currentAccount.id) {
+            throw ExpectedException("본인의 권한은 변경할 수 없습니다.", HttpStatus.FORBIDDEN)
+        }
+
+        if (account.role == AccountRole.ROOT) {
+            throw ExpectedException("최고 관리자 계정의 권한은 변경할 수 없습니다.", HttpStatus.FORBIDDEN)
+        }
+
+        account.role = reqDto.role
+    }
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/ModifyAccountRoleServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/ModifyAccountRoleServiceImpl.kt
@@ -34,6 +34,10 @@ class ModifyAccountRoleServiceImpl(
             throw ExpectedException("최고 관리자 계정의 권한은 변경할 수 없습니다.", HttpStatus.FORBIDDEN)
         }
 
+        if (reqDto.role == AccountRole.ROOT) {
+            throw ExpectedException("최고 관리자 권한은 부여할 수 없습니다.", HttpStatus.FORBIDDEN)
+        }
+
         account.role = reqDto.role
     }
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryAccountDetailServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryAccountDetailServiceImpl.kt
@@ -1,0 +1,24 @@
+package team.themoment.datagsm.web.domain.account.service.impl
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.account.dto.response.AccountResDto
+import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
+import team.themoment.datagsm.web.domain.account.service.QueryAccountDetailService
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class QueryAccountDetailServiceImpl(
+    private val accountJpaRepository: AccountJpaRepository,
+) : QueryAccountDetailService {
+    @Transactional(readOnly = true)
+    override fun execute(accountId: Long): AccountResDto {
+        val account =
+            accountJpaRepository.findById(accountId).orElseThrow {
+                ExpectedException("계정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+            }
+
+        return AccountResDto.from(account)
+    }
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryAccountServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryAccountServiceImpl.kt
@@ -1,0 +1,34 @@
+package team.themoment.datagsm.web.domain.account.service.impl
+
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.account.dto.request.QueryAccountReqDto
+import team.themoment.datagsm.common.domain.account.dto.response.AccountListResDto
+import team.themoment.datagsm.common.domain.account.dto.response.AccountResDto
+import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
+import team.themoment.datagsm.web.domain.account.service.QueryAccountService
+
+@Service
+class QueryAccountServiceImpl(
+    private val accountJpaRepository: AccountJpaRepository,
+) : QueryAccountService {
+    @Transactional(readOnly = true)
+    override fun execute(queryReq: QueryAccountReqDto): AccountListResDto {
+        val accountPage =
+            accountJpaRepository.searchAccountsWithPaging(
+                email = queryReq.email,
+                role = queryReq.role,
+                isStudent = queryReq.isStudent,
+                pageable = PageRequest.of(queryReq.page, queryReq.size),
+                sortBy = queryReq.sortBy,
+                sortDirection = queryReq.sortDirection,
+            )
+
+        return AccountListResDto(
+            totalElements = accountPage.totalElements,
+            totalPages = accountPage.totalPages,
+            accounts = accountPage.content.map { AccountResDto.from(it) },
+        )
+    }
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
@@ -3,9 +3,7 @@ package team.themoment.datagsm.web.domain.account.service.impl
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.account.dto.response.AccountInfoResDto
-import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
-import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.web.domain.account.service.QueryMyInfoService
 import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
 
@@ -22,31 +20,7 @@ class QueryMyInfoServiceImpl(
             email = account.email,
             role = account.role,
             isStudent = account.student != null,
-            student =
-                account.student?.let { student ->
-                    generateStudentResDto(student)
-                },
+            student = account.student?.let { StudentResDto.from(it) },
         )
     }
-
-    private fun generateStudentResDto(student: StudentJpaEntity): StudentResDto =
-        StudentResDto(
-            id = student.id!!,
-            name = student.name,
-            sex = student.sex,
-            email = student.email,
-            grade = student.studentNumber?.studentGrade,
-            classNum = student.studentNumber?.studentClass,
-            number = student.studentNumber?.studentNumber,
-            studentNumber = student.studentNumber?.fullStudentNumber,
-            major = student.major,
-            specialty = student.specialty,
-            role = student.role,
-            dormitoryFloor = student.dormitoryRoomNumber?.dormitoryRoomFloor,
-            dormitoryRoom = student.dormitoryRoomNumber?.dormitoryRoomNumber,
-            majorClub = student.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
-            autonomousClub = student.autonomousClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
-            githubId = student.githubId,
-            githubUrl = student.githubId?.let { "https://github.com/$it" },
-        )
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/QueryStudentServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/QueryStudentServiceImpl.kt
@@ -3,7 +3,6 @@ package team.themoment.datagsm.web.domain.student.service.impl
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
 import team.themoment.datagsm.common.domain.student.dto.request.QueryStudentReqDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentListResDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
@@ -41,28 +40,7 @@ class QueryStudentServiceImpl(
         return StudentListResDto(
             totalElements = studentPage.totalElements,
             totalPages = studentPage.totalPages,
-            students =
-                studentPage.content.map { entity ->
-                    StudentResDto(
-                        id = entity.id!!,
-                        name = entity.name,
-                        sex = entity.sex,
-                        email = entity.email,
-                        grade = entity.studentNumber?.studentGrade,
-                        classNum = entity.studentNumber?.studentClass,
-                        number = entity.studentNumber?.studentNumber,
-                        studentNumber = entity.studentNumber?.fullStudentNumber,
-                        major = entity.major,
-                        specialty = entity.specialty,
-                        role = entity.role,
-                        dormitoryFloor = entity.dormitoryRoomNumber?.dormitoryRoomFloor,
-                        dormitoryRoom = entity.dormitoryRoomNumber?.dormitoryRoomNumber,
-                        majorClub = entity.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
-                        autonomousClub = entity.autonomousClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
-                        githubId = entity.githubId,
-                        githubUrl = entity.githubId?.let { "https://github.com/$it" },
-                    )
-                },
+            students = studentPage.content.map { StudentResDto.from(it) },
         )
     }
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/global/security/config/SecurityConfig.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/global/security/config/SecurityConfig.kt
@@ -50,6 +50,14 @@ class SecurityConfig(
                     .permitAll()
                     .requestMatchers(HttpMethod.PATCH, "/v1/students/me/specialty", "/v1/students/me/github-id")
                     .authenticated()
+                    .requestMatchers(HttpMethod.GET, "/v1/accounts/my")
+                    .authenticated()
+                    .requestMatchers(HttpMethod.DELETE, "/v1/accounts/my")
+                    .authenticated()
+                    .requestMatchers(HttpMethod.GET, "/v1/accounts", "/v1/accounts/{accountId}")
+                    .hasAnyRole(AccountRole.ADMIN.name, AccountRole.ROOT.name)
+                    .requestMatchers(HttpMethod.PATCH, "/v1/accounts/{accountId}/role")
+                    .hasAnyRole(AccountRole.ADMIN.name, AccountRole.ROOT.name)
                     .requestMatchers(
                         "/v1/students/**",
                         "/v1/projects/**",

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/ModifyAccountRoleServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/ModifyAccountRoleServiceTest.kt
@@ -1,0 +1,115 @@
+package team.themoment.datagsm.web.domain.account.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.http.HttpStatus
+import team.themoment.datagsm.common.domain.account.dto.request.ModifyAccountRoleReqDto
+import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
+import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
+import team.themoment.datagsm.web.domain.account.service.impl.ModifyAccountRoleServiceImpl
+import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
+import team.themoment.sdk.exception.ExpectedException
+import java.util.Optional
+
+class ModifyAccountRoleServiceTest :
+    DescribeSpec({
+
+        val mockAccountRepository = mockk<AccountJpaRepository>()
+        val mockCurrentUserProvider = mockk<CurrentUserProvider>()
+
+        val modifyAccountRoleService =
+            ModifyAccountRoleServiceImpl(mockAccountRepository, mockCurrentUserProvider)
+
+        afterEach {
+            clearAllMocks()
+        }
+
+        fun account(
+            accountId: Long,
+            accountRole: AccountRole,
+        ): AccountJpaEntity =
+            AccountJpaEntity().apply {
+                id = accountId
+                email = "user$accountId@gsm.hs.kr"
+                password = "encoded"
+                role = accountRole
+            }
+
+        describe("ModifyAccountRoleService 클래스의") {
+            describe("execute 메서드는") {
+
+                context("어드민이 다른 USER 계정의 권한을 ADMIN으로 변경할 때") {
+                    val target = account(2L, AccountRole.USER)
+                    val admin = account(1L, AccountRole.ADMIN)
+
+                    beforeEach {
+                        every { mockAccountRepository.findById(2L) } returns Optional.of(target)
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns admin
+                    }
+
+                    it("대상 계정의 role이 변경되어야 한다") {
+                        modifyAccountRoleService.execute(2L, ModifyAccountRoleReqDto(AccountRole.ADMIN))
+
+                        target.role shouldBe AccountRole.ADMIN
+                    }
+                }
+
+                context("존재하지 않는 계정의 권한을 변경할 때") {
+                    beforeEach {
+                        every { mockAccountRepository.findById(999L) } returns Optional.empty()
+                    }
+
+                    it("NOT_FOUND ExpectedException이 발생해야 한다") {
+                        val ex =
+                            shouldThrow<ExpectedException> {
+                                modifyAccountRoleService.execute(999L, ModifyAccountRoleReqDto(AccountRole.ADMIN))
+                            }
+                        ex.message shouldBe "계정을 찾을 수 없습니다."
+                        ex.statusCode shouldBe HttpStatus.NOT_FOUND
+                    }
+                }
+
+                context("본인의 권한을 변경하려 할 때") {
+                    val admin = account(1L, AccountRole.ADMIN)
+
+                    beforeEach {
+                        every { mockAccountRepository.findById(1L) } returns Optional.of(admin)
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns admin
+                    }
+
+                    it("FORBIDDEN ExpectedException이 발생해야 한다") {
+                        val ex =
+                            shouldThrow<ExpectedException> {
+                                modifyAccountRoleService.execute(1L, ModifyAccountRoleReqDto(AccountRole.USER))
+                            }
+                        ex.message shouldBe "본인의 권한은 변경할 수 없습니다."
+                        ex.statusCode shouldBe HttpStatus.FORBIDDEN
+                    }
+                }
+
+                context("대상 계정이 ROOT일 때") {
+                    val target = account(2L, AccountRole.ROOT)
+                    val admin = account(1L, AccountRole.ADMIN)
+
+                    beforeEach {
+                        every { mockAccountRepository.findById(2L) } returns Optional.of(target)
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns admin
+                    }
+
+                    it("FORBIDDEN ExpectedException이 발생해야 한다") {
+                        val ex =
+                            shouldThrow<ExpectedException> {
+                                modifyAccountRoleService.execute(2L, ModifyAccountRoleReqDto(AccountRole.USER))
+                            }
+                        ex.message shouldBe "최고 관리자 계정의 권한은 변경할 수 없습니다."
+                        ex.statusCode shouldBe HttpStatus.FORBIDDEN
+                    }
+                }
+            }
+        }
+    })

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/ModifyAccountRoleServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/ModifyAccountRoleServiceTest.kt
@@ -92,6 +92,25 @@ class ModifyAccountRoleServiceTest :
                     }
                 }
 
+                context("대상 계정에 ROOT 권한을 부여하려 할 때") {
+                    val target = account(2L, AccountRole.USER)
+                    val admin = account(1L, AccountRole.ADMIN)
+
+                    beforeEach {
+                        every { mockAccountRepository.findById(2L) } returns Optional.of(target)
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns admin
+                    }
+
+                    it("FORBIDDEN ExpectedException이 발생해야 한다") {
+                        val ex =
+                            shouldThrow<ExpectedException> {
+                                modifyAccountRoleService.execute(2L, ModifyAccountRoleReqDto(AccountRole.ROOT))
+                            }
+                        ex.message shouldBe "최고 관리자 권한은 부여할 수 없습니다."
+                        ex.statusCode shouldBe HttpStatus.FORBIDDEN
+                    }
+                }
+
                 context("대상 계정이 ROOT일 때") {
                     val target = account(2L, AccountRole.ROOT)
                     val admin = account(1L, AccountRole.ADMIN)

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/QueryAccountDetailServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/QueryAccountDetailServiceTest.kt
@@ -1,0 +1,109 @@
+package team.themoment.datagsm.web.domain.account.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.http.HttpStatus
+import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
+import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
+import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.StudentNumber
+import team.themoment.datagsm.common.domain.student.entity.constant.Major
+import team.themoment.datagsm.common.domain.student.entity.constant.Sex
+import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
+import team.themoment.datagsm.web.domain.account.service.impl.QueryAccountDetailServiceImpl
+import team.themoment.sdk.exception.ExpectedException
+import java.util.Optional
+
+class QueryAccountDetailServiceTest :
+    DescribeSpec({
+
+        val mockAccountRepository = mockk<AccountJpaRepository>()
+
+        val queryAccountDetailService = QueryAccountDetailServiceImpl(mockAccountRepository)
+
+        afterEach {
+            clearAllMocks()
+        }
+
+        describe("QueryAccountDetailService 클래스의") {
+            describe("execute 메서드는") {
+
+                context("학생과 연결된 계정을 조회할 때") {
+                    val linkedStudent =
+                        StudentJpaEntity().apply {
+                            id = 10L
+                            name = "홍길동"
+                            sex = Sex.MAN
+                            email = "hong@gsm.hs.kr"
+                            studentNumber = StudentNumber(1, 1, 1)
+                            major = Major.SW_DEVELOPMENT
+                            role = StudentRole.GENERAL_STUDENT
+                        }
+                    val studentAccount =
+                        AccountJpaEntity().apply {
+                            id = 1L
+                            email = "hong@gsm.hs.kr"
+                            password = "encoded"
+                            role = AccountRole.USER
+                            student = linkedStudent
+                        }
+
+                    beforeEach {
+                        every { mockAccountRepository.findById(1L) } returns Optional.of(studentAccount)
+                    }
+
+                    it("연결된 학생 정보가 포함되어야 한다") {
+                        val result = queryAccountDetailService.execute(1L)
+
+                        result.id shouldBe 1L
+                        result.isStudent shouldBe true
+                        result.student?.id shouldBe 10L
+                        result.student?.name shouldBe "홍길동"
+                    }
+                }
+
+                context("학생과 연결되지 않은 계정을 조회할 때") {
+                    val teacherAccount =
+                        AccountJpaEntity().apply {
+                            id = 2L
+                            email = "teacher@gsm.hs.kr"
+                            password = "encoded"
+                            role = AccountRole.USER
+                            student = null
+                        }
+
+                    beforeEach {
+                        every { mockAccountRepository.findById(2L) } returns Optional.of(teacherAccount)
+                    }
+
+                    it("학생 정보가 null이어야 한다") {
+                        val result = queryAccountDetailService.execute(2L)
+
+                        result.id shouldBe 2L
+                        result.isStudent shouldBe false
+                        result.student shouldBe null
+                    }
+                }
+
+                context("존재하지 않는 계정을 조회할 때") {
+                    beforeEach {
+                        every { mockAccountRepository.findById(999L) } returns Optional.empty()
+                    }
+
+                    it("NOT_FOUND ExpectedException이 발생해야 한다") {
+                        val ex =
+                            shouldThrow<ExpectedException> {
+                                queryAccountDetailService.execute(999L)
+                            }
+                        ex.message shouldBe "계정을 찾을 수 없습니다."
+                        ex.statusCode shouldBe HttpStatus.NOT_FOUND
+                    }
+                }
+            }
+        }
+    })

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/QueryAccountServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/QueryAccountServiceTest.kt
@@ -1,0 +1,139 @@
+package team.themoment.datagsm.web.domain.account.service
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import team.themoment.datagsm.common.domain.account.dto.request.QueryAccountReqDto
+import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
+import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
+import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.StudentNumber
+import team.themoment.datagsm.common.domain.student.entity.constant.Major
+import team.themoment.datagsm.common.domain.student.entity.constant.Sex
+import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
+import team.themoment.datagsm.web.domain.account.service.impl.QueryAccountServiceImpl
+
+class QueryAccountServiceTest :
+    DescribeSpec({
+
+        val mockAccountRepository = mockk<AccountJpaRepository>()
+
+        val queryAccountService = QueryAccountServiceImpl(mockAccountRepository)
+
+        afterEach {
+            clearAllMocks()
+        }
+
+        val linkedStudent =
+            StudentJpaEntity().apply {
+                id = 10L
+                name = "홍길동"
+                sex = Sex.MAN
+                email = "hong@gsm.hs.kr"
+                studentNumber = StudentNumber(1, 1, 1)
+                major = Major.SW_DEVELOPMENT
+                role = StudentRole.GENERAL_STUDENT
+            }
+
+        val studentAccount =
+            AccountJpaEntity().apply {
+                id = 1L
+                email = "hong@gsm.hs.kr"
+                password = "encoded"
+                role = AccountRole.USER
+                student = linkedStudent
+            }
+
+        val teacherAccount =
+            AccountJpaEntity().apply {
+                id = 2L
+                email = "teacher@gsm.hs.kr"
+                password = "encoded"
+                role = AccountRole.USER
+                student = null
+            }
+
+        describe("QueryAccountService 클래스의") {
+            describe("execute 메서드는") {
+
+                context("학생과 연결된 계정을 조회할 때") {
+                    beforeEach {
+                        every {
+                            mockAccountRepository.searchAccountsWithPaging(
+                                email = null,
+                                role = null,
+                                isStudent = true,
+                                pageable = PageRequest.of(0, 300),
+                                sortBy = any(),
+                                sortDirection = any(),
+                            )
+                        } returns PageImpl(listOf(studentAccount), PageRequest.of(0, 300), 1L)
+                    }
+
+                    it("연결된 학생 정보가 포함되어야 한다") {
+                        val result = queryAccountService.execute(QueryAccountReqDto(isStudent = true))
+
+                        result.totalElements shouldBe 1L
+                        val account = result.accounts[0]
+                        account.id shouldBe 1L
+                        account.isStudent shouldBe true
+                        account.student?.id shouldBe 10L
+                        account.student?.name shouldBe "홍길동"
+                    }
+                }
+
+                context("학생과 연결되지 않은 계정을 조회할 때") {
+                    beforeEach {
+                        every {
+                            mockAccountRepository.searchAccountsWithPaging(
+                                email = null,
+                                role = null,
+                                isStudent = false,
+                                pageable = PageRequest.of(0, 300),
+                                sortBy = any(),
+                                sortDirection = any(),
+                            )
+                        } returns PageImpl(listOf(teacherAccount), PageRequest.of(0, 300), 1L)
+                    }
+
+                    it("학생 정보가 null이어야 한다") {
+                        val result = queryAccountService.execute(QueryAccountReqDto(isStudent = false))
+
+                        result.totalElements shouldBe 1L
+                        val account = result.accounts[0]
+                        account.id shouldBe 2L
+                        account.isStudent shouldBe false
+                        account.student shouldBe null
+                    }
+                }
+
+                context("조건에 맞는 계정이 없을 때") {
+                    beforeEach {
+                        every {
+                            mockAccountRepository.searchAccountsWithPaging(
+                                email = "nobody",
+                                role = null,
+                                isStudent = null,
+                                pageable = PageRequest.of(0, 300),
+                                sortBy = any(),
+                                sortDirection = any(),
+                            )
+                        } returns PageImpl(emptyList(), PageRequest.of(0, 300), 0L)
+                    }
+
+                    it("빈 결과가 반환되어야 한다") {
+                        val result = queryAccountService.execute(QueryAccountReqDto(email = "nobody"))
+
+                        result.totalElements shouldBe 0L
+                        result.totalPages shouldBe 0
+                        result.accounts.size shouldBe 0
+                    }
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## 개요

어드민 웹 클라이언트에서 사용할 계정 관리 API를 추가하였습니다. 어드민이 계정 목록과 단건을 조회하고, 각 계정에 연결된 학생 정보를 함께 확인할 수 있으며, 계정의 권한을 변경할 수 있습니다. (#387)

## 본문

### 배경

`tb_student` 정보가 없는 교원·운영팀 계정이 늘어남에 따라, 어드민이 "어떤 계정이 어떤 학생과 연결되어 있는지"를 한눈에 파악하고 권한을 부여할 수 있는 관리 기능이 필요하였습니다. 기존에는 본인(`/my`) 조회만 가능하였고, 계정 권한 변경은 개발용 `UtilityController`(`@Profile("!prod")`)에만 존재하여 운영 환경에서 사용할 수 없었습니다.

### 추가된 엔드포인트

모두 어드민 전용(`ADMIN`, `ROOT`)이며 `datagsm-web` 모듈에 추가하였습니다.

| Method | Path | 설명 |
|---|---|---|
| `GET` | `/v1/accounts` | 계정 목록 조회 (`email`·`role`·`isStudent` 필터, 페이징) |
| `GET` | `/v1/accounts/{accountId}` | 계정 단건 조회 |
| `PATCH` | `/v1/accounts/{accountId}/role` | 계정 권한 변경 |

각 계정 응답(`AccountResDto`)에는 연결된 학생 정보(`StudentResDto?`)가 포함되며, 연결된 학생이 없는 경우 `null`을 반환합니다.

### 주요 변경 사항

- **DTO 추가** (`datagsm-common`): `QueryAccountReqDto`, `AccountResDto`, `AccountListResDto`, `ModifyAccountRoleReqDto`, `AccountSortBy`를 추가하였습니다. `AccountResDto.from()` 팩토리에서 연결 학생 매핑을 처리합니다.
- **조회 리포지토리 추가**: `AccountJpaCustomRepository`와 QueryDSL 구현체를 추가하였습니다. 학생 조회와 동일하게 2단계 쿼리(ID 페이징 → `IN`절 `fetchJoin`)로 구성하였고, 연결 학생과 동아리를 `fetchJoin`하여 N+1을 방지하였습니다. `isStudent` 필터는 `student.isNotNull` / `student.isNull`로 처리합니다.
- **서비스 추가**: `QueryAccountService`, `QueryAccountDetailService`, `ModifyAccountRoleService`를 인터페이스와 `impl`로 분리하여 추가하였습니다. 권한 변경 시 **본인 계정 변경 금지**와 **`ROOT` 계정 보호** 안전장치를 적용하였습니다.
- **인가 규칙 수정**: `SecurityConfig`에서 본인 경로(`/v1/accounts/my`)는 `authenticated`로 유지하고, 신규 어드민 경로는 `hasAnyRole(ADMIN, ROOT)`로 메서드·경로 단위로 선언하였습니다.
- **리팩터링**: 3곳에 중복되던 학생 엔티티 → `StudentResDto` 변환 로직을 `StudentResDto.from()` 팩토리로 추출하여 `QueryMyInfoServiceImpl`, `datagsm-web` / `datagsm-openapi`의 `QueryStudentServiceImpl`에 적용하였습니다.

### 테스트

`ModifyAccountRoleServiceTest`, `QueryAccountServiceTest`, `QueryAccountDetailServiceTest`를 추가하였습니다. 정상 조회·변경, 계정 미존재(`NOT_FOUND`), 본인·`ROOT` 대상 변경 금지(`FORBIDDEN`), 학생 연결/미연결 매핑을 검증하였습니다. 전체 빌드(`ktlintCheck` 포함)와 `datagsm-web` 350개, `datagsm-openapi` 140개 테스트가 모두 통과하였습니다.
