### PR TITLE
[global] `disender` 의존성을 `dicoshot`으로 교체

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,7 @@ subprojects {
 
         dependencies {
             "implementation"(project(":datagsm-common"))
-            "implementation"(dependency.Dependencies.DISENDER_SPRING_BOOT_STARTER)
+            "implementation"(dependency.Dependencies.DICOSHOT_SPRING_BOOT_STARTER)
 
             "developmentOnly"(dependency.Dependencies.SPRING_BOOT_DEVTOOLS)
             "developmentOnly"(dependency.Dependencies.SPRING_DOCKER_SUPPORT)

--- a/buildSrc/src/main/kotlin/dependency/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependency/Dependencies.kt
@@ -2,7 +2,7 @@ package dependency
 
 import dependency.DependencyVersions.AWS_SDK_VERSION
 import dependency.DependencyVersions.BUCKET4J_VERSION
-import dependency.DependencyVersions.DISENDER_VERSION
+import dependency.DependencyVersions.DICOSHOT_VERSION
 import dependency.DependencyVersions.JJWT_VERSION
 import dependency.DependencyVersions.KOTEST_VERSION
 import dependency.DependencyVersions.KOTLIN_COROUTINES_VERSION
@@ -69,8 +69,8 @@ object Dependencies {
     // Custom Libraries
     const val THE_MOMENT_THE_SDK = "com.github.themoment-team:the-sdk:${THE_MOMENT_THE_SDK_VERSION}"
 
-    // Disender (Discord webhook notifier)
-    const val DISENDER_SPRING_BOOT_STARTER = "io.github.zaman0806:disender-spring-boot-4-starter:${DISENDER_VERSION}"
+    // Dicoshot (Discord webhook notifier)
+    const val DICOSHOT_SPRING_BOOT_STARTER = "io.github.dicoshot:dicoshot-spring-boot-starter:${DICOSHOT_VERSION}"
 
     // Kotlin
     const val KOTLIN_REFLECT = "org.jetbrains.kotlin:kotlin-reflect"

--- a/buildSrc/src/main/kotlin/dependency/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/dependency/DependencyVersions.kt
@@ -22,5 +22,5 @@ object DependencyVersions {
 
     const val KOTLIN_POET_VERSION = "2.3.0"
 
-    const val DISENDER_VERSION = "0.1.1"
+    const val DICOSHOT_VERSION = "0.5.0"
 }


### PR DESCRIPTION
## 개요

Discord 웹훅 알림 라이브러리를 기존 `disender`에서 `dicoshot`으로 교체하였습니다. `buildSrc`의 의존성 좌표와 버전 상수를 변경하였으며, 이를 참조하는 루트 `build.gradle.kts`도 함께 수정하였습니다.

## 본문

- `DependencyVersions.kt`의 `DISENDER_VERSION`(`0.1.1`)을 `DICOSHOT_VERSION`(`0.5.0`)으로 변경하였습니다.
- `Dependencies.kt`의 의존성 좌표를 `io.github.zaman0806:disender-spring-boot-4-starter`에서 `io.github.dicoshot:dicoshot-spring-boot-starter`로 교체하고, 상수명을 `DICOSHOT_SPRING_BOOT_STARTER`로 정리하였습니다.
- 루트 `build.gradle.kts`의 `implementation` 참조를 새 상수로 변경하였습니다.
- `./gradlew build`로 전체 빌드 및 테스트가 성공하는 것을 확인하였습니다.
