### PR TITLE
[ci/cd] CD 알림 구조를 CI와 동일하게 통일

### DIFF
--- a/.github/workflows/datagsm-issue-validation.yaml
+++ b/.github/workflows/datagsm-issue-validation.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Validate Issue Title
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const title = context.payload.issue.title;

--- a/.github/workflows/datagsm-prod-cd.yaml
+++ b/.github/workflows/datagsm-prod-cd.yaml
@@ -39,7 +39,7 @@ jobs:
       shared_changed: ${{ steps.changes.outputs.shared_changed }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.branch || github.event.workflow_run.head_sha || 'master' }}
           fetch-depth: 0
@@ -74,7 +74,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.branch || github.event.workflow_run.head_sha || 'master' }}
       - name: Setup JDK 25
@@ -83,7 +83,7 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: false
           cache-cleanup: always
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.branch || github.event.workflow_run.head_sha || 'master' }}
       - name: Setup JDK 25
@@ -111,12 +111,12 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: false
           cache-cleanup: always
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -138,7 +138,7 @@ jobs:
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.branch || github.event.workflow_run.head_sha || 'master' }}
 
@@ -149,7 +149,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: false
           cache-cleanup: always

--- a/.github/workflows/datagsm-prod-cd.yaml
+++ b/.github/workflows/datagsm-prod-cd.yaml
@@ -217,23 +217,41 @@ jobs:
       - name: Code Deploy
         run: aws deploy create-deployment --application-name datagsm-prod-server-codedeploy --deployment-config-name CodeDeployDefault.AllAtOnce --deployment-group-name datagsm-prod-server --s3-location bucket=${{ secrets.AWS_S3_BUCKET_NAME }},bundleType=zip,key=prod/$GITHUB_SHA.zip
 
-      - name: Deploy Success Notification
-        uses: sarisia/actions-status-discord@v1
-        if: success()
-        with:
-          webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
-          color: 0x4CAF50
+  notify:
+    runs-on: ubuntu-latest
+    needs: [generate-version, publish-jvm, publish-js, deploy]
+    if: |
+      always() &&
+      (needs.generate-version.result != 'skipped' || needs.deploy.result != 'skipped')
 
-      - name: Deploy Failure Notification
-        uses: sarisia/actions-status-discord@v1
-        if: failure()
-        with:
-          webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
-          color: 0xFF4C4C
+    steps:
+      - name: Determine Status
+        id: status
+        run: |
+          if [[ "${{ needs.generate-version.result }}" == "failure" ]] || \
+             [[ "${{ needs.publish-jvm.result }}" == "failure" ]] || \
+             [[ "${{ needs.publish-js.result }}" == "failure" ]] || \
+             [[ "${{ needs.deploy.result }}" == "failure" ]]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+            echo "color=0xFF4C4C" >> $GITHUB_OUTPUT
+          elif [[ "${{ needs.deploy.result }}" == "success" ]] || \
+               [[ "${{ needs.publish-jvm.result }}" == "success" && "${{ needs.publish-js.result }}" == "success" ]]; then
+            echo "status=success" >> $GITHUB_OUTPUT
+            echo "color=0x4CAF50" >> $GITHUB_OUTPUT
+          else
+            echo "status=cancelled" >> $GITHUB_OUTPUT
+            echo "color=0xFFA500" >> $GITHUB_OUTPUT
+          fi
 
-      - name: Deploy Cancelled Notification
+      - name: Send Discord Notification
         uses: sarisia/actions-status-discord@v1
-        if: cancelled()
         with:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
-          color: 0xFFA500
+          status: ${{ steps.status.outputs.status }}
+          color: ${{ steps.status.outputs.color }}
+          title: "DataGSM Prod CD"
+          description: |
+            **Generate Version:** ${{ needs.generate-version.result }}
+            **Publish JVM:** ${{ needs.publish-jvm.result }}
+            **Publish JS:** ${{ needs.publish-js.result }}
+            **Deploy:** ${{ needs.deploy.result }}

--- a/.github/workflows/datagsm-prod-ci.yaml
+++ b/.github/workflows/datagsm-prod-ci.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Validate PR Title
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup JDK 25
         uses: actions/setup-java@v5
@@ -100,7 +100,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: false
           cache-cleanup: always
@@ -112,7 +112,7 @@ jobs:
         run: ./gradlew :datagsm-shared:assembleTsPackage --build-cache
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 

--- a/.github/workflows/datagsm-stage-cd.yaml
+++ b/.github/workflows/datagsm-stage-cd.yaml
@@ -107,23 +107,32 @@ jobs:
       - name: Code Deploy
         run: aws deploy create-deployment --application-name datagsm-stage-server-codedeploy --deployment-config-name CodeDeployDefault.AllAtOnce --deployment-group-name datagsm-stage-server --s3-location bucket=${{ secrets.AWS_S3_BUCKET_NAME }},bundleType=zip,key=stage/$GITHUB_SHA.zip
 
-      - name: Deploy Success Notification
-        uses: sarisia/actions-status-discord@v1
-        if: success()
-        with:
-          webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
-          color: 0x4CAF50
+  notify:
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    if: always() && needs.deploy.result != 'skipped'
 
-      - name: Deploy Failure Notification
-        uses: sarisia/actions-status-discord@v1
-        if: failure()
-        with:
-          webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
-          color: 0xFF4C4C
+    steps:
+      - name: Determine Status
+        id: status
+        run: |
+          if [[ "${{ needs.deploy.result }}" == "failure" ]]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+            echo "color=0xFF4C4C" >> $GITHUB_OUTPUT
+          elif [[ "${{ needs.deploy.result }}" == "success" ]]; then
+            echo "status=success" >> $GITHUB_OUTPUT
+            echo "color=0x4CAF50" >> $GITHUB_OUTPUT
+          else
+            echo "status=cancelled" >> $GITHUB_OUTPUT
+            echo "color=0xFFA500" >> $GITHUB_OUTPUT
+          fi
 
-      - name: Deploy Cancelled Notification
+      - name: Send Discord Notification
         uses: sarisia/actions-status-discord@v1
-        if: cancelled()
         with:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
-          color: 0xFFA500
+          status: ${{ steps.status.outputs.status }}
+          color: ${{ steps.status.outputs.color }}
+          title: "DataGSM Stage CD"
+          description: |
+            **Deploy:** ${{ needs.deploy.result }}

--- a/.github/workflows/datagsm-stage-cd.yaml
+++ b/.github/workflows/datagsm-stage-cd.yaml
@@ -28,7 +28,7 @@ jobs:
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.branch || github.event.workflow_run.head_branch || 'develop' }}
 
@@ -39,7 +39,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: false
           cache-cleanup: always

--- a/.github/workflows/datagsm-stage-ci.yaml
+++ b/.github/workflows/datagsm-stage-ci.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Validate PR Title
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup JDK 25
         uses: actions/setup-java@v5
@@ -98,7 +98,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: false
           cache-cleanup: always
@@ -110,7 +110,7 @@ jobs:
         run: ./gradlew :datagsm-shared:assembleTsPackage --build-cache
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ out/
 PR_BODY.md
 .pr-tmp/
 /.claude/command.log
+/.codex/command.log


### PR DESCRIPTION
## 개요

prod/stage CD 워크플로우의 Discord 알림을 CI와 동일하게 별도 `notify` 잡으로 분리하여 각 잡의 결과를 단계별로 확인할 수 있도록 개선하였습니다. 함께 GitHub Actions 액션 버전을 최신으로 업데이트하였습니다.

## 본문

### CD 알림 구조 개선

기존 CD 워크플로우는 `deploy` 잡 내부에 success/failure/cancelled 알림 스텝 3개가 인라인으로 존재하여 `deploy` 잡의 결과만 알림에 반영되었고, prod CD의 `generate-version`, `publish-jvm`, `publish-js` 잡 결과는 알림에 포함되지 않았습니다.

CI 워크플로우의 `notify` 잡 패턴과 동일하게 다음과 같이 변경하였습니다.

- `datagsm-prod-cd.yaml`: `generate-version`, `publish-jvm`, `publish-js`, `deploy` 잡을 `needs`로 참조하는 `notify` 잡을 추가하고, 각 잡의 결과를 하나의 Discord 알림에 단계별로 표기하도록 하였습니다. 실패 잡이 하나라도 있으면 failure, `deploy` 성공 또는 `publish-jvm`/`publish-js` 모두 성공 시 success, 그 외에는 cancelled로 상태를 판정합니다.
- `datagsm-stage-cd.yaml`: `deploy` 잡 결과를 표기하는 `notify` 잡을 동일한 구조로 추가하였습니다.
- 두 워크플로우 모두 배포 대상 잡이 전부 skip된 경우(CI 실패로 인한 `workflow_run` 트리거 등)에는 알림을 보내지 않도록 조건을 추가하여 불필요한 알림을 방지하였습니다.

### GitHub Actions 액션 버전 업데이트

- `actions/checkout` v6 → v7
- `actions/github-script` v8 → v9
- `gradle/actions/setup-gradle` v5 → v6
- `actions/setup-node` v5 → v6

### 기타

- `.gitignore`에 `/.codex/command.log`를 추가하였습니다.
