### PR TITLE
[oauth] OIDC 표준 예외 엔드포인트 주석 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ out/
 PR_BODY.md
 .pr-tmp/
 /.claude/command.log
+/.codex/command.log

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/controller/UserInfoController.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/controller/UserInfoController.kt
@@ -12,6 +12,8 @@ import team.themoment.datagsm.oauth.userinfo.domain.userinfo.service.QueryUserIn
 class UserInfoController(
     private val queryUserInfoService: QueryUserInfoService,
 ) {
+    // OIDC UserInfo 표준 준수를 위한 예외 엔드포인트: 다른 공개 API와 달리 /v1 버전 prefix가 없고,
+    // CommonApiResponse로 감싸지 않은 raw 클레임 JSON을 반환한다 (application.yml의 not-wrapping-urls 참고).
     @GetMapping("/userinfo")
     @Operation(
         summary = "사용자 정보 조회",

--- a/datagsm-oauth-userinfo/src/main/resources/application.yml
+++ b/datagsm-oauth-userinfo/src/main/resources/application.yml
@@ -62,6 +62,7 @@ sdk:
     not-wrapping-urls:
       - "/v3/api-docs/**"
       - "/swagger-ui/**"
+      # OIDC UserInfo 표준 준수: 외부 클라이언트가 기대하는 raw 클레임 JSON을 반환하기 위해 CommonApiResponse 래핑 제외
       - "/userinfo"
   swagger:
     enabled: true


### PR DESCRIPTION
## 개요

`/userinfo` 엔드포인트가 다른 공개 API와 응답 형식이 다른 이유를 코드와 설정에 주석으로 명시하였습니다. 함께 `.gitignore`에 `codex` command 로그 경로를 추가하였습니다.

## 본문

`datagsm-oauth-userinfo` 모듈의 `/userinfo` 엔드포인트는 다른 공개 엔드포인트(`/v1/students`, `/v1/clubs` 등)와 달리 아래 두 가지가 다릅니다.

- `/v1` 버전 prefix가 없음
- `CommonApiResponse`로 감싸지 않은 raw 클레임 JSON을 반환 (`application.yml`의 `not-wrapping-urls`에 등록)

이는 버그가 아니라 OIDC `UserInfo` 표준 준수를 위한 의도된 예외이나, 코드만 보아서는 자명하지 않아 다음과 같이 주석을 추가하였습니다.

- `UserInfoController`의 `getUserInfo` 위에 버전 prefix 부재 및 응답 미래핑 사유를 명시
- `application.yml`의 `not-wrapping-urls` 내 `/userinfo` 항목에 래핑 제외 사유를 명시

동작 변경은 없으며 주석과 무시 경로만 추가되었습니다.
