### PR TITLE
[account] `userinfo` 응답 `isStudent` 필드 복원해 하위 호환 유지

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountInfoResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountInfoResDto.kt
@@ -18,6 +18,8 @@ data class AccountInfoResDto(
     val status: AccountStatus,
     @field:Schema(description = "연결 대상 종류 (STUDENT, TEACHER)", example = "STUDENT")
     val objectType: AccountObjectType?,
+    @field:Schema(description = "학생 계정 여부 (하위 호환용, objectType == STUDENT)", example = "true")
+    val isStudent: Boolean,
     @field:Schema(description = "학생 정보 (학생인 경우에만 포함)")
     val student: StudentResDto?,
     @field:Schema(description = "선생님 정보 (선생님인 경우에만 포함)")

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountInfoResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountInfoResDto.kt
@@ -18,7 +18,8 @@ data class AccountInfoResDto(
     val status: AccountStatus,
     @field:Schema(description = "연결 대상 종류 (STUDENT, TEACHER)", example = "STUDENT")
     val objectType: AccountObjectType?,
-    @field:Schema(description = "학생 계정 여부 (하위 호환용, objectType == STUDENT)", example = "true")
+    @Deprecated("objectType == STUDENT 으로 대체 예정, 하위 호환을 위해 임시 유지", ReplaceWith("objectType == AccountObjectType.STUDENT"))
+    @field:Schema(description = "학생 계정 여부 (Deprecated, objectType == STUDENT 으로 대체 예정)", example = "true", deprecated = true)
     val isStudent: Boolean,
     @field:Schema(description = "학생 정보 (학생인 경우에만 포함)")
     val student: StudentResDto?,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountResDto.kt
@@ -20,6 +20,8 @@ data class AccountResDto(
     val status: AccountStatus,
     @field:Schema(description = "연결 대상 종류 (STUDENT, TEACHER)", example = "STUDENT")
     val objectType: AccountObjectType?,
+    @field:Schema(description = "학생 계정 여부 (하위 호환용, objectType == STUDENT)", example = "true")
+    val isStudent: Boolean,
     @field:Schema(description = "연결된 학생 정보 (학생 계정인 경우에만 포함)")
     val student: StudentResDto?,
     @field:Schema(description = "연결된 선생님 정보 (선생님 계정인 경우에만 포함)")
@@ -41,6 +43,7 @@ data class AccountResDto(
                 role = account.role,
                 status = account.status,
                 objectType = account.objectType,
+                isStudent = account.objectType == AccountObjectType.STUDENT,
                 student = student,
                 teacher = teacher,
                 createdAt = account.createdAt,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountResDto.kt
@@ -20,7 +20,8 @@ data class AccountResDto(
     val status: AccountStatus,
     @field:Schema(description = "연결 대상 종류 (STUDENT, TEACHER)", example = "STUDENT")
     val objectType: AccountObjectType?,
-    @field:Schema(description = "학생 계정 여부 (하위 호환용, objectType == STUDENT)", example = "true")
+    @Deprecated("objectType == STUDENT 으로 대체 예정, 하위 호환을 위해 임시 유지", ReplaceWith("objectType == AccountObjectType.STUDENT"))
+    @field:Schema(description = "학생 계정 여부 (Deprecated, objectType == STUDENT 으로 대체 예정)", example = "true", deprecated = true)
     val isStudent: Boolean,
     @field:Schema(description = "연결된 학생 정보 (학생 계정인 경우에만 포함)")
     val student: StudentResDto?,

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
@@ -3,6 +3,7 @@ package team.themoment.datagsm.oauth.userinfo.domain.userinfo.service.impl
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.account.dto.response.AccountInfoResDto
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.resolver.AccountObjectResolver
 import team.themoment.datagsm.oauth.userinfo.domain.userinfo.service.QueryUserInfoService
 import team.themoment.datagsm.oauth.userinfo.global.security.provider.CurrentUserProvider
@@ -23,6 +24,7 @@ class QueryUserInfoServiceImpl(
             role = account.role,
             status = account.status,
             objectType = account.objectType,
+            isStudent = account.objectType == AccountObjectType.STUDENT,
             student = resolved.student,
             teacher = resolved.teacher,
         )

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
@@ -3,6 +3,7 @@ package team.themoment.datagsm.web.domain.account.service.impl
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.account.dto.response.AccountInfoResDto
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.resolver.AccountObjectResolver
 import team.themoment.datagsm.web.domain.account.service.QueryMyInfoService
 import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
@@ -23,6 +24,7 @@ class QueryMyInfoServiceImpl(
             role = account.role,
             status = account.status,
             objectType = account.objectType,
+            isStudent = account.objectType == AccountObjectType.STUDENT,
             student = resolved.student,
             teacher = resolved.teacher,
         )


### PR DESCRIPTION
## 개요

선생님 회원가입 지원 변경(#401)에서 `AccountInfoResDto`와 `AccountResDto`의 기존 `isStudent` 필드가 제거되어, `/userinfo` 응답을 소비하는 외부 OAuth 클라이언트들이 역직렬화에 실패하며 500 오류가 발생하였습니다. 하위 호환을 위해 `isStudent` 필드를 다시 추가하였습니다.

## 본문

### 문제

`GET /userinfo`가 반환하는 `AccountInfoResDto`에서 `isStudent: Boolean` 필드가 제거되고 `status`, `objectType`, `teacher` 필드로 대체되었습니다. DataGSM OAuth를 사용하는 외부 프로젝트들은 이 응답을 자체 DTO로 역직렬화하는데, `isStudent`를 필수 필드로 기대하고 있어 필드 누락으로 파싱에 실패하고 외부 서비스에서 500이 발생하였습니다.

### 해결

- `AccountInfoResDto`(`/userinfo`, `/v1/accounts/my`)와 `AccountResDto`(`/v1/accounts`, `/v1/accounts/{accountId}`)에 `isStudent` 필드를 다시 추가하였습니다.
- 값은 `objectType == STUDENT` 파생값으로 계산하여 기존 의미를 그대로 유지합니다.
- `status`, `objectType`, `teacher` 등 신규 필드는 그대로 유지되므로 기존 클라이언트와 신규 클라이언트 모두 정상 동작합니다.

### 변경 파일

- `AccountInfoResDto` — `isStudent` 필드 복원
- `AccountResDto` — `isStudent` 필드 복원 및 `from()` 팩토리에서 파생 계산
- `QueryUserInfoServiceImpl`, `QueryMyInfoServiceImpl` — 응답 조립부에 `isStudent = objectType == STUDENT` 추가

전체 테스트를 통과하는 것을 확인하였습니다.
