### PR TITLE
[event] 트랜잭션 커밋 전 webhook 발행 문제 수정

### DIFF
--- a/datagsm-common/build.gradle.kts
+++ b/datagsm-common/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
     testImplementation(dependency.Dependencies.KOTEST_ASSERTIONS)
     testImplementation(dependency.Dependencies.KOTEST_RUNNER)
     testImplementation(dependency.Dependencies.KOTEST_FRAMEWORK)
+    testImplementation(dependency.Dependencies.MOCKK)
     testRuntimeOnly(dependency.Dependencies.JUNIT_PLATFORM_LAUNCHER)
 }
 

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/dto/internal/EventDispatchRequested.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/dto/internal/EventDispatchRequested.kt
@@ -1,0 +1,8 @@
+package team.themoment.datagsm.common.domain.event.dto.internal
+
+import team.themoment.datagsm.common.domain.event.entity.constant.EventType
+
+data class EventDispatchRequested(
+    val eventType: EventType,
+    val data: Any,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/listener/EventDispatchListener.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/listener/EventDispatchListener.kt
@@ -1,0 +1,17 @@
+package team.themoment.datagsm.common.domain.event.listener
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
+import team.themoment.datagsm.common.domain.event.service.EventPublisher
+
+@Component
+class EventDispatchListener(
+    private val eventPublisher: EventPublisher,
+) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    fun handleDispatchRequested(request: EventDispatchRequested) {
+        eventPublisher.dispatch(request.eventType, request.data)
+    }
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/service/EventSender.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/service/EventSender.kt
@@ -2,18 +2,19 @@ package team.themoment.datagsm.common.domain.event.service
 
 import org.apache.hc.client5.http.DnsResolver
 import org.apache.hc.client5.http.SystemDefaultDnsResolver
+import org.apache.hc.client5.http.config.ConnectionConfig
+import org.apache.hc.client5.http.config.RequestConfig
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
 import org.apache.hc.client5.http.impl.classic.HttpClients
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
+import org.apache.hc.core5.util.Timeout
 import org.springframework.http.MediaType
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.retry.annotation.Backoff
-import org.springframework.retry.annotation.Recover
 import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 import team.themoment.datagsm.common.domain.event.validator.EventUrlValidator
-import team.themoment.sdk.logging.logger.logger
 import java.net.InetAddress
 import java.net.UnknownHostException
 import javax.crypto.Mac
@@ -27,6 +28,14 @@ class EventSender {
             .requestFactory(HttpComponentsClientHttpRequestFactory(buildSsrfSafeHttpClient()))
             .build()
 
+    companion object {
+        private val CONNECT_TIMEOUT = Timeout.ofSeconds(3)
+        private val RESPONSE_TIMEOUT = Timeout.ofSeconds(5)
+        private val CONNECTION_LEASE_TIMEOUT = Timeout.ofSeconds(3)
+    }
+
+    // @Recover를 두지 않아 재시도 소진 시 마지막 예외가 그대로 전파된다.
+    // 실패 원인 분류와 알림은 대상별 격리를 담당하는 EventPublisher가 처리한다.
     @Retryable(maxAttempts = 3, backoff = Backoff(delay = 1000, multiplier = 10.0))
     fun send(
         targetUrl: String,
@@ -44,16 +53,6 @@ class EventSender {
             .toBodilessEntity()
     }
 
-    @Recover
-    fun recover(
-        e: Exception,
-        targetUrl: String,
-        secret: String,
-        payloadJson: String,
-    ) {
-        logger().warn("Failed to deliver event after 3 attempts url {} error {}", targetUrl, e.message)
-    }
-
     private fun buildSsrfSafeHttpClient(): CloseableHttpClient {
         val ssrfSafeDnsResolver =
             object : DnsResolver {
@@ -61,7 +60,7 @@ class EventSender {
                     val resolved: Array<InetAddress> =
                         try {
                             SystemDefaultDnsResolver.INSTANCE.resolve(host)
-                        } catch (e: UnknownHostException) {
+                        } catch (_: UnknownHostException) {
                             emptyArray()
                         }
                     if (resolved.any { EventUrlValidator.isPrivateAddress(it) }) {
@@ -73,15 +72,28 @@ class EventSender {
                 override fun resolveCanonicalHostname(host: String): String =
                     SystemDefaultDnsResolver.INSTANCE.resolveCanonicalHostname(host)
             }
+        // 타임아웃이 없으면 응답하지 않는 소비자 하나가 @Async 스레드를 무기한 점유한다.
         val connectionManager =
             PoolingHttpClientConnectionManagerBuilder
                 .create()
                 .setDnsResolver(ssrfSafeDnsResolver)
-                .build()
+                .setDefaultConnectionConfig(
+                    ConnectionConfig
+                        .custom()
+                        .setConnectTimeout(CONNECT_TIMEOUT)
+                        .setSocketTimeout(RESPONSE_TIMEOUT)
+                        .build(),
+                ).build()
         return HttpClients
             .custom()
             .setConnectionManager(connectionManager)
-            .build()
+            .setDefaultRequestConfig(
+                RequestConfig
+                    .custom()
+                    .setConnectionRequestTimeout(CONNECTION_LEASE_TIMEOUT)
+                    .setResponseTimeout(RESPONSE_TIMEOUT)
+                    .build(),
+            ).build()
     }
 
     private fun computeHmacSha256(

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/service/impl/EventPublisherImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/service/impl/EventPublisherImpl.kt
@@ -2,7 +2,7 @@ package team.themoment.datagsm.common.domain.event.service.impl
 
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.client.RestClientException
 import team.themoment.datagsm.common.domain.event.dto.payload.EventPayload
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
 import team.themoment.datagsm.common.domain.event.entity.constant.EventVerificationStatus
@@ -21,33 +21,52 @@ class EventPublisherImpl(
 ) : EventPublisher {
     private val objectMapper = JsonMapper.builder().build()
 
+    // 재시도를 포함한 전송 구간이 길어 트랜잭션을 열어두지 않는다. 대상 조회는 리포지토리 자체 트랜잭션으로 처리된다.
     @Async
-    @Transactional(readOnly = true)
     override fun dispatch(
         event: EventType,
         data: Any,
     ) {
-        runCatching {
-            val targets =
-                eventJpaRepository.findAllByEventsContainsAndIsActiveTrueAndVerificationStatus(
-                    event,
-                    EventVerificationStatus.VERIFIED,
-                )
-            if (targets.isEmpty()) return
+        val targets =
+            eventJpaRepository.findAllByEventsContainsAndIsActiveTrueAndVerificationStatus(
+                event,
+                EventVerificationStatus.VERIFIED,
+            )
+        if (targets.isEmpty()) return
 
-            val payload =
-                EventPayload(
-                    id = "evt_${UUID.randomUUID().toString().replace("-", "")}",
-                    event = event.eventName,
-                    timestamp = Instant.now().toString(),
-                    data = data,
-                )
-            val payloadJson = objectMapper.writeValueAsString(payload)
-            targets.forEach { target ->
+        val payload =
+            EventPayload(
+                id = "evt_${UUID.randomUUID().toString().replace("-", "")}",
+                event = event.eventName,
+                timestamp = Instant.now().toString(),
+                data = data,
+            )
+        val payloadJson = objectMapper.writeValueAsString(payload)
+
+        var internalFailure: Throwable? = null
+        targets.forEach { target ->
+            runCatching {
                 eventSender.send(target.targetUrl, target.secret, payloadJson)
+            }.onFailure { e ->
+                if (e is RestClientException) {
+                    logger().warn(
+                        "Failed to deliver event {} after 3 attempts url {} error {}",
+                        event.eventName,
+                        target.targetUrl,
+                        e.message,
+                    )
+                } else {
+                    logger().error(
+                        "Failed to deliver event {} due to an internal error url {}",
+                        event.eventName,
+                        target.targetUrl,
+                    )
+                    val firstFailure = internalFailure
+                    if (firstFailure == null) internalFailure = e else firstFailure.addSuppressed(e)
+                }
             }
-        }.onFailure { e ->
-            logger().error("Failed to dispatch event {} error {}", event, e.message, e)
         }
+
+        internalFailure?.let { throw it }
     }
 }

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/service/impl/EventPublisherImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/service/impl/EventPublisherImpl.kt
@@ -21,7 +21,8 @@ class EventPublisherImpl(
 ) : EventPublisher {
     private val objectMapper = JsonMapper.builder().build()
 
-    // 재시도를 포함한 전송 구간이 길어 트랜잭션을 열어두지 않는다. 대상 조회는 리포지토리 자체 트랜잭션으로 처리된다.
+    // 재시도를 포함한 전송 구간 내내 커넥션을 점유하지 않도록 @Transactional을 두지 않는다.
+    // 대상 조회는 리포지토리 자체 트랜잭션으로 처리된다.
     @Async
     override fun dispatch(
         event: EventType,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/config/AsyncConfig.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/config/AsyncConfig.kt
@@ -1,0 +1,38 @@
+package team.themoment.datagsm.common.global.config
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.Environment
+import org.springframework.scheduling.annotation.AsyncConfigurer
+import org.springframework.scheduling.annotation.EnableAsync
+import team.themoment.datagsm.common.global.common.discord.error.DiscordErrorNotificationService
+import team.themoment.sdk.logging.logger.logger
+
+@Configuration
+@EnableAsync
+class AsyncConfig(
+    private val discordErrorNotificationProvider: ObjectProvider<DiscordErrorNotificationService>,
+    private val environment: Environment,
+) : AsyncConfigurer {
+    override fun getAsyncUncaughtExceptionHandler(): AsyncUncaughtExceptionHandler =
+        AsyncUncaughtExceptionHandler { ex, method, _ ->
+            val methodName = "${method.declaringClass.simpleName}.${method.name}"
+            logger().error("Unexpected exception occurred in async method {}", methodName, ex)
+
+            discordErrorNotificationProvider.ifAvailable { discordErrorNotificationService ->
+                discordErrorNotificationService.notifyError(
+                    exception = ex,
+                    context = "An unexpected exception occurred in an async method.",
+                    additionalInfo =
+                        mapOf(
+                            "Thread" to Thread.currentThread().name,
+                            "Method" to methodName,
+                            "Profile" to getActiveProfile(),
+                        ),
+                )
+            }
+        }
+
+    private fun getActiveProfile(): String = environment.activeProfiles.firstOrNull() ?: "default"
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/config/RetryConfig.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/config/RetryConfig.kt
@@ -1,4 +1,4 @@
-package team.themoment.datagsm.oauth.authorization.global.config
+package team.themoment.datagsm.common.global.config
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.retry.annotation.EnableRetry

--- a/datagsm-common/src/test/kotlin/team/themoment/datagsm/common/domain/event/service/EventPublisherTest.kt
+++ b/datagsm-common/src/test/kotlin/team/themoment/datagsm/common/domain/event/service/EventPublisherTest.kt
@@ -1,0 +1,147 @@
+package team.themoment.datagsm.common.domain.event.service
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.web.client.ResourceAccessException
+import team.themoment.datagsm.common.domain.event.entity.EventJpaEntity
+import team.themoment.datagsm.common.domain.event.entity.constant.EventType
+import team.themoment.datagsm.common.domain.event.entity.constant.EventVerificationStatus
+import team.themoment.datagsm.common.domain.event.repository.EventJpaRepository
+import team.themoment.datagsm.common.domain.event.service.impl.EventPublisherImpl
+
+class EventPublisherTest :
+    DescribeSpec({
+
+        lateinit var eventJpaRepository: EventJpaRepository
+        lateinit var eventSender: EventSender
+        lateinit var eventPublisher: EventPublisher
+
+        val payloadData = mapOf("studentId" to 1)
+
+        fun target(
+            targetId: Long,
+            url: String,
+        ) = EventJpaEntity().apply {
+            id = targetId
+            targetUrl = url
+            secret = "secret-$targetId"
+        }
+
+        fun givenTargets(vararg targets: EventJpaEntity) {
+            every {
+                eventJpaRepository.findAllByEventsContainsAndIsActiveTrueAndVerificationStatus(
+                    EventType.STUDENT_UPDATED,
+                    EventVerificationStatus.VERIFIED,
+                )
+            } returns targets.toList()
+        }
+
+        beforeEach {
+            eventJpaRepository = mockk()
+            eventSender = mockk()
+            eventPublisher = EventPublisherImpl(eventJpaRepository, eventSender)
+        }
+
+        describe("EventPublisher 클래스의") {
+            describe("dispatch 메서드는") {
+                context("전송 대상이 없을 때") {
+                    beforeEach {
+                        givenTargets()
+                    }
+
+                    it("전송을 시도하지 않아야 한다") {
+                        eventPublisher.dispatch(EventType.STUDENT_UPDATED, payloadData)
+
+                        verify(exactly = 0) { eventSender.send(any(), any(), any()) }
+                    }
+                }
+
+                context("소비자 쪽 문제로 전송이 실패할 때") {
+                    beforeEach {
+                        givenTargets(target(1L, "https://first.example.com"), target(2L, "https://second.example.com"))
+                        every {
+                            eventSender.send("https://first.example.com", any(), any())
+                        } throws ResourceAccessException("Connection timed out")
+                        every { eventSender.send("https://second.example.com", any(), any()) } just Runs
+                    }
+
+                    it("예외를 던지지 않고 나머지 대상에 계속 전송해야 한다") {
+                        shouldNotThrowAny {
+                            eventPublisher.dispatch(EventType.STUDENT_UPDATED, payloadData)
+                        }
+
+                        verify(exactly = 1) { eventSender.send("https://second.example.com", any(), any()) }
+                    }
+                }
+
+                context("우리 쪽 문제로 전송이 실패할 때") {
+                    beforeEach {
+                        givenTargets(target(1L, "https://first.example.com"), target(2L, "https://second.example.com"))
+                        every {
+                            eventSender.send("https://first.example.com", any(), any())
+                        } throws IllegalStateException("Failed to compute signature")
+                        every { eventSender.send("https://second.example.com", any(), any()) } just Runs
+                    }
+
+                    it("나머지 대상에 전송을 마친 뒤 예외를 전파해야 한다") {
+                        shouldThrow<IllegalStateException> {
+                            eventPublisher.dispatch(EventType.STUDENT_UPDATED, payloadData)
+                        }
+
+                        verify(exactly = 1) { eventSender.send("https://second.example.com", any(), any()) }
+                    }
+                }
+
+                context("우리 쪽 문제가 여러 대상에서 발생할 때") {
+                    beforeEach {
+                        givenTargets(target(1L, "https://first.example.com"), target(2L, "https://second.example.com"))
+                        every {
+                            eventSender.send("https://first.example.com", any(), any())
+                        } throws IllegalStateException("First failure")
+                        every {
+                            eventSender.send("https://second.example.com", any(), any())
+                        } throws IllegalStateException("Second failure")
+                    }
+
+                    it("첫 예외에 나머지 예외를 suppressed로 붙여 전파해야 한다") {
+                        val thrown =
+                            shouldThrow<IllegalStateException> {
+                                eventPublisher.dispatch(EventType.STUDENT_UPDATED, payloadData)
+                            }
+
+                        thrown.message shouldBe "First failure"
+                        thrown.suppressed.size shouldBe 1
+                        thrown.suppressed
+                            .first()
+                            .message shouldBe "Second failure"
+                    }
+                }
+
+                context("전송 대상 조회가 실패할 때") {
+                    beforeEach {
+                        every {
+                            eventJpaRepository.findAllByEventsContainsAndIsActiveTrueAndVerificationStatus(
+                                EventType.STUDENT_UPDATED,
+                                EventVerificationStatus.VERIFIED,
+                            )
+                        } throws IllegalStateException("Database is unreachable")
+                    }
+
+                    it("예외를 전파해야 한다") {
+                        shouldThrow<IllegalStateException> {
+                            eventPublisher.dispatch(EventType.STUDENT_UPDATED, payloadData)
+                        }
+
+                        verify(exactly = 0) { eventSender.send(any(), any(), any()) }
+                    }
+                }
+            }
+        }
+    })

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/config/AsyncConfig.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/config/AsyncConfig.kt
@@ -1,8 +1,0 @@
-package team.themoment.datagsm.oauth.authorization.global.config
-
-import org.springframework.context.annotation.Configuration
-import org.springframework.scheduling.annotation.EnableAsync
-
-@Configuration
-@EnableAsync
-class AsyncConfig

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/global/config/AsyncConfig.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/global/config/AsyncConfig.kt
@@ -1,8 +1,0 @@
-package team.themoment.datagsm.openapi.global.config
-
-import org.springframework.context.annotation.Configuration
-import org.springframework.scheduling.annotation.EnableAsync
-
-@Configuration
-@EnableAsync
-class AsyncConfig

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/global/config/RetryConfig.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/global/config/RetryConfig.kt
@@ -1,8 +1,0 @@
-package team.themoment.datagsm.openapi.global.config
-
-import org.springframework.context.annotation.Configuration
-import org.springframework.retry.annotation.EnableRetry
-
-@Configuration
-@EnableRetry
-class RetryConfig

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/CreateClubServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/CreateClubServiceImpl.kt
@@ -1,5 +1,6 @@
 package team.themoment.datagsm.web.domain.club.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
@@ -9,13 +10,13 @@ import team.themoment.datagsm.common.domain.club.dto.response.ClubResDto
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubStatus
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.ClubEventObject
 import team.themoment.datagsm.common.domain.event.dto.payload.EmptyEventObject
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.EventStudentRef
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.student.dto.internal.ParticipantInfoDto
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
@@ -26,7 +27,7 @@ import team.themoment.sdk.exception.ExpectedException
 class CreateClubServiceImpl(
     private val clubJpaRepository: ClubJpaRepository,
     private val studentJpaRepository: StudentJpaRepository,
-    private val eventPublisher: EventPublisher,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : CreateClubService {
     @Transactional
     override fun execute(clubReqDto: ClubReqDto): ClubResDto {
@@ -90,11 +91,13 @@ class CreateClubServiceImpl(
         studentJpaRepository.bulkAssignClub(participantIdsForBulkAssign, savedClub, clubReqDto.type)
 
         val newObj = generateClubEventObject(savedClub, leader, participants)
-        eventPublisher.dispatch(
-            EventType.CLUB_UPDATED,
-            EventChangedData(
-                old = listOf(EventChangeItem(0, EmptyEventObject())),
-                new = listOf(EventChangeItem(0, newObj)),
+        applicationEventPublisher.publishEvent(
+            EventDispatchRequested(
+                EventType.CLUB_UPDATED,
+                EventChangedData(
+                    old = listOf(EventChangeItem(0, EmptyEventObject())),
+                    new = listOf(EventChangeItem(0, newObj)),
+                ),
             ),
         )
 

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/DeleteClubServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/DeleteClubServiceImpl.kt
@@ -1,18 +1,19 @@
 package team.themoment.datagsm.web.domain.club.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.ClubEventObject
 import team.themoment.datagsm.common.domain.event.dto.payload.EmptyEventObject
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.EventStudentRef
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.web.domain.club.service.DeleteClubService
@@ -22,7 +23,7 @@ import team.themoment.sdk.exception.ExpectedException
 class DeleteClubServiceImpl(
     private val clubJpaRepository: ClubJpaRepository,
     private val studentJpaRepository: StudentJpaRepository,
-    private val eventPublisher: EventPublisher,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : DeleteClubService {
     @Transactional
     override fun execute(clubId: Long) {
@@ -42,11 +43,13 @@ class DeleteClubServiceImpl(
         studentJpaRepository.bulkClearClubReferences(listOf(club))
         clubJpaRepository.deleteAllByIdInBatch(listOf(clubId))
 
-        eventPublisher.dispatch(
-            EventType.CLUB_UPDATED,
-            EventChangedData(
-                old = listOf(EventChangeItem(0, oldObj)),
-                new = listOf(EventChangeItem(0, EmptyEventObject())),
+        applicationEventPublisher.publishEvent(
+            EventDispatchRequested(
+                EventType.CLUB_UPDATED,
+                EventChangedData(
+                    old = listOf(EventChangeItem(0, oldObj)),
+                    new = listOf(EventChangeItem(0, EmptyEventObject())),
+                ),
             ),
         )
     }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/ModifyClubServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/ModifyClubServiceImpl.kt
@@ -1,5 +1,6 @@
 package team.themoment.datagsm.web.domain.club.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
@@ -10,12 +11,12 @@ import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubStatus
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.ClubEventObject
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.EventStudentRef
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.student.dto.internal.ParticipantInfoDto
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
@@ -26,7 +27,7 @@ import team.themoment.sdk.exception.ExpectedException
 class ModifyClubServiceImpl(
     private val clubJpaRepository: ClubJpaRepository,
     private val studentJpaRepository: StudentJpaRepository,
-    private val eventPublisher: EventPublisher,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : ModifyClubService {
     @Transactional
     override fun execute(
@@ -102,11 +103,13 @@ class ModifyClubServiceImpl(
         }
 
         val newObj = generateClubEventObject(club, newLeader, participants)
-        eventPublisher.dispatch(
-            EventType.CLUB_UPDATED,
-            EventChangedData(
-                old = listOf(EventChangeItem(0, oldObj)),
-                new = listOf(EventChangeItem(0, newObj)),
+        applicationEventPublisher.publishEvent(
+            EventDispatchRequested(
+                EventType.CLUB_UPDATED,
+                EventChangedData(
+                    old = listOf(EventChangeItem(0, oldObj)),
+                    new = listOf(EventChangeItem(0, newObj)),
+                ),
             ),
         )
 

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/event/dto/internal/EventVerificationRequested.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/event/dto/internal/EventVerificationRequested.kt
@@ -1,0 +1,5 @@
+package team.themoment.datagsm.web.domain.event.dto.internal
+
+data class EventVerificationRequested(
+    val eventId: Long,
+)

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/event/listener/EventVerificationListener.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/event/listener/EventVerificationListener.kt
@@ -1,0 +1,17 @@
+package team.themoment.datagsm.web.domain.event.listener
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import team.themoment.datagsm.web.domain.event.dto.internal.EventVerificationRequested
+import team.themoment.datagsm.web.domain.event.service.VerifyEventService
+
+@Component
+class EventVerificationListener(
+    private val verifyEventService: VerifyEventService,
+) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    fun handleVerificationRequested(event: EventVerificationRequested) {
+        verifyEventService.verifyAsync(event.eventId)
+    }
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/event/service/impl/CreateEventServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/event/service/impl/CreateEventServiceImpl.kt
@@ -1,16 +1,15 @@
 package team.themoment.datagsm.web.domain.event.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.themoment.datagsm.common.domain.event.dto.request.CreateEventReqDto
 import team.themoment.datagsm.common.domain.event.dto.response.CreateEventResDto
 import team.themoment.datagsm.common.domain.event.entity.EventJpaEntity
 import team.themoment.datagsm.common.domain.event.repository.EventJpaRepository
+import team.themoment.datagsm.web.domain.event.dto.internal.EventVerificationRequested
 import team.themoment.datagsm.web.domain.event.service.CreateEventService
-import team.themoment.datagsm.web.domain.event.service.VerifyEventService
 import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
 import java.security.SecureRandom
@@ -19,7 +18,7 @@ import java.security.SecureRandom
 class CreateEventServiceImpl(
     private val eventJpaRepository: EventJpaRepository,
     private val currentUserProvider: CurrentUserProvider,
-    private val verifyEventService: VerifyEventService,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : CreateEventService {
     @Transactional
     override fun execute(reqDto: CreateEventReqDto): CreateEventResDto {
@@ -39,7 +38,7 @@ class CreateEventServiceImpl(
             }
         val saved = eventJpaRepository.save(event)
 
-        triggerVerificationAfterCommit(saved.id!!)
+        applicationEventPublisher.publishEvent(EventVerificationRequested(saved.id!!))
 
         return CreateEventResDto(
             id = saved.id!!,
@@ -52,20 +51,7 @@ class CreateEventServiceImpl(
         )
     }
 
-    private fun triggerVerificationAfterCommit(eventId: Long) {
-        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-            verifyEventService.verifyAsync(eventId)
-            return
-        }
-        TransactionSynchronizationManager.registerSynchronization(
-            object : TransactionSynchronization {
-                override fun afterCommit() {
-                    verifyEventService.verifyAsync(eventId)
-                }
-            },
-        )
-    }
-
+    // todo: Is there no way to improve this crazy, somewhat messy, slow-looking code? If there isn’t any, then just leave it as it is and feel disappointed...
     private fun generateSecret(): String {
         val bytes = ByteArray(32)
         secureRandom.nextBytes(bytes)

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/event/service/impl/ModifyEventServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/event/service/impl/ModifyEventServiceImpl.kt
@@ -1,16 +1,15 @@
 package team.themoment.datagsm.web.domain.event.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.themoment.datagsm.common.domain.event.dto.request.ModifyEventReqDto
 import team.themoment.datagsm.common.domain.event.dto.response.EventResDto
 import team.themoment.datagsm.common.domain.event.entity.constant.EventVerificationStatus
 import team.themoment.datagsm.common.domain.event.repository.EventJpaRepository
+import team.themoment.datagsm.web.domain.event.dto.internal.EventVerificationRequested
 import team.themoment.datagsm.web.domain.event.service.ModifyEventService
-import team.themoment.datagsm.web.domain.event.service.VerifyEventService
 import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
 
@@ -18,7 +17,7 @@ import team.themoment.sdk.exception.ExpectedException
 class ModifyEventServiceImpl(
     private val eventJpaRepository: EventJpaRepository,
     private val currentUserProvider: CurrentUserProvider,
-    private val verifyEventService: VerifyEventService,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : ModifyEventService {
     @Transactional
     override fun execute(
@@ -44,7 +43,7 @@ class ModifyEventServiceImpl(
         }
 
         if (revalidationNeeded) {
-            triggerVerificationAfterCommit(event.id!!)
+            applicationEventPublisher.publishEvent(EventVerificationRequested(event.id!!))
         }
 
         return EventResDto(
@@ -54,20 +53,6 @@ class ModifyEventServiceImpl(
             isActive = event.isActive,
             createdAt = event.createdAt!!,
             verificationStatus = event.verificationStatus,
-        )
-    }
-
-    private fun triggerVerificationAfterCommit(eventId: Long) {
-        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-            verifyEventService.verifyAsync(eventId)
-            return
-        }
-        TransactionSynchronizationManager.registerSynchronization(
-            object : TransactionSynchronization {
-                override fun afterCommit() {
-                    verifyEventService.verifyAsync(eventId)
-                }
-            },
         )
     }
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/event/service/impl/VerifyEventServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/event/service/impl/VerifyEventServiceImpl.kt
@@ -1,5 +1,6 @@
 package team.themoment.datagsm.web.domain.event.service.impl
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,23 +17,18 @@ class VerifyEventServiceImpl(
     @Async
     @Transactional
     override fun verifyAsync(eventId: Long) {
-        runCatching {
-            val event =
-                eventJpaRepository.findById(eventId).orElse(null)
-                    ?: run {
-                        logger().warn("Skipped event verification for missing eventId {}", eventId)
-                        return
-                    }
-
-            event.verificationStatus =
-                if (EventUrlValidator.isPrivateOrLocalUrl(event.targetUrl)) {
-                    logger().warn("Failed to verify event url for eventId {}", eventId)
-                    EventVerificationStatus.FAILED
-                } else {
-                    EventVerificationStatus.VERIFIED
-                }
-        }.onFailure { e ->
-            logger().error("Failed to execute async event verification for eventId {}", eventId, e)
+        val event = eventJpaRepository.findByIdOrNull(eventId)
+        if (event == null) {
+            logger().warn("Skipped event verification for missing eventId {}", eventId)
+            return
         }
+
+        event.verificationStatus =
+            if (EventUrlValidator.isPrivateOrLocalUrl(event.targetUrl)) {
+                logger().warn("Failed to verify event url for eventId {}", eventId)
+                EventVerificationStatus.FAILED
+            } else {
+                EventVerificationStatus.VERIFIED
+            }
     }
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/CreateProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/CreateProjectServiceImpl.kt
@@ -1,10 +1,12 @@
 package team.themoment.datagsm.web.domain.project.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.EmptyEventObject
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
@@ -12,7 +14,6 @@ import team.themoment.datagsm.common.domain.event.dto.payload.EventClubRef
 import team.themoment.datagsm.common.domain.event.dto.payload.EventStudentRef
 import team.themoment.datagsm.common.domain.event.dto.payload.ProjectEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.project.dto.request.ProjectReqDto
 import team.themoment.datagsm.common.domain.project.dto.response.ProjectResDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
@@ -28,7 +29,7 @@ class CreateProjectServiceImpl(
     private val projectJpaRepository: ProjectJpaRepository,
     private val clubJpaRepository: ClubJpaRepository,
     private val studentJpaRepository: StudentJpaRepository,
-    private val eventPublisher: EventPublisher,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : CreateProjectService {
     @Transactional
     override fun execute(projectReqDto: ProjectReqDto): ProjectResDto {
@@ -86,11 +87,13 @@ class CreateProjectServiceImpl(
         val savedProjectEntity = projectJpaRepository.save(projectEntity)
 
         val newObj = generateProjectEventObject(savedProjectEntity)
-        eventPublisher.dispatch(
-            EventType.PROJECT_UPDATED,
-            EventChangedData(
-                old = listOf(EventChangeItem(0, EmptyEventObject())),
-                new = listOf(EventChangeItem(0, newObj)),
+        applicationEventPublisher.publishEvent(
+            EventDispatchRequested(
+                EventType.PROJECT_UPDATED,
+                EventChangedData(
+                    old = listOf(EventChangeItem(0, EmptyEventObject())),
+                    new = listOf(EventChangeItem(0, newObj)),
+                ),
             ),
         )
 

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/DeleteProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/DeleteProjectServiceImpl.kt
@@ -1,8 +1,10 @@
 package team.themoment.datagsm.web.domain.project.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.EmptyEventObject
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
@@ -10,7 +12,6 @@ import team.themoment.datagsm.common.domain.event.dto.payload.EventClubRef
 import team.themoment.datagsm.common.domain.event.dto.payload.EventStudentRef
 import team.themoment.datagsm.common.domain.event.dto.payload.ProjectEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
 import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
 import team.themoment.datagsm.web.domain.project.service.DeleteProjectService
@@ -19,7 +20,7 @@ import team.themoment.sdk.exception.ExpectedException
 @Service
 class DeleteProjectServiceImpl(
     private val projectJpaRepository: ProjectJpaRepository,
-    private val eventPublisher: EventPublisher,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : DeleteProjectService {
     @Transactional
     override fun execute(projectId: Long) {
@@ -31,11 +32,13 @@ class DeleteProjectServiceImpl(
         val oldObj = generateProjectEventObject(project)
         projectJpaRepository.delete(project)
 
-        eventPublisher.dispatch(
-            EventType.PROJECT_UPDATED,
-            EventChangedData(
-                old = listOf(EventChangeItem(0, oldObj)),
-                new = listOf(EventChangeItem(0, EmptyEventObject())),
+        applicationEventPublisher.publishEvent(
+            EventDispatchRequested(
+                EventType.PROJECT_UPDATED,
+                EventChangedData(
+                    old = listOf(EventChangeItem(0, oldObj)),
+                    new = listOf(EventChangeItem(0, EmptyEventObject())),
+                ),
             ),
         )
     }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ModifyProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ModifyProjectServiceImpl.kt
@@ -1,17 +1,18 @@
 package team.themoment.datagsm.web.domain.project.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.EventClubRef
 import team.themoment.datagsm.common.domain.event.dto.payload.EventStudentRef
 import team.themoment.datagsm.common.domain.event.dto.payload.ProjectEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.project.dto.request.ProjectReqDto
 import team.themoment.datagsm.common.domain.project.dto.response.ProjectResDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
@@ -26,7 +27,7 @@ class ModifyProjectServiceImpl(
     private val projectJpaRepository: ProjectJpaRepository,
     private val clubJpaRepository: ClubJpaRepository,
     private val studentJpaRepository: StudentJpaRepository,
-    private val eventPublisher: EventPublisher,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : ModifyProjectService {
     @Transactional
     override fun execute(
@@ -78,11 +79,13 @@ class ModifyProjectServiceImpl(
         project.participants = newParticipants
 
         val newObj = generateProjectEventObject(project)
-        eventPublisher.dispatch(
-            EventType.PROJECT_UPDATED,
-            EventChangedData(
-                old = listOf(EventChangeItem(0, oldObj)),
-                new = listOf(EventChangeItem(0, newObj)),
+        applicationEventPublisher.publishEvent(
+            EventDispatchRequested(
+                EventType.PROJECT_UPDATED,
+                EventChangedData(
+                    old = listOf(EventChangeItem(0, oldObj)),
+                    new = listOf(EventChangeItem(0, newObj)),
+                ),
             ),
         )
 

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/BatchOperationServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/BatchOperationServiceImpl.kt
@@ -1,12 +1,13 @@
 package team.themoment.datagsm.web.domain.student.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.StudentEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.student.dto.internal.BatchOperationType
 import team.themoment.datagsm.common.domain.student.dto.request.BatchOperationReqDto
 import team.themoment.datagsm.common.domain.student.dto.response.GraduateStudentResDto
@@ -18,7 +19,7 @@ import team.themoment.datagsm.web.domain.student.service.BatchOperationService
 @Service
 class BatchOperationServiceImpl(
     private val studentJpaRepository: StudentJpaRepository,
-    private val eventPublisher: EventPublisher,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : BatchOperationService {
     @Transactional
     override fun execute(reqDto: BatchOperationReqDto): GraduateStudentResDto =
@@ -48,9 +49,11 @@ class BatchOperationServiceImpl(
                 EventChangeItem(index, generateStudentEventObject(student))
             }
         if (olds.isNotEmpty()) {
-            eventPublisher.dispatch(
-                EventType.STUDENT_UPDATED,
-                EventChangedData(old = olds, new = news),
+            applicationEventPublisher.publishEvent(
+                EventDispatchRequested(
+                    EventType.STUDENT_UPDATED,
+                    EventChangedData(old = olds, new = news),
+                ),
             )
         }
 

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateStudentServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateStudentServiceImpl.kt
@@ -1,15 +1,16 @@
 package team.themoment.datagsm.web.domain.student.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.StudentEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
@@ -20,7 +21,7 @@ import team.themoment.sdk.exception.ExpectedException
 class GraduateStudentServiceImpl(
     private val studentJpaRepository: StudentJpaRepository,
     private val clubJpaRepository: ClubJpaRepository,
-    private val eventPublisher: EventPublisher,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : GraduateStudentService {
     @Transactional
     override fun execute(studentId: Long) {
@@ -41,11 +42,13 @@ class GraduateStudentServiceImpl(
         student.autonomousClub = null
 
         val new = generateStudentEventObject(student)
-        eventPublisher.dispatch(
-            EventType.STUDENT_UPDATED,
-            EventChangedData(
-                old = listOf(EventChangeItem(0, old)),
-                new = listOf(EventChangeItem(0, new)),
+        applicationEventPublisher.publishEvent(
+            EventDispatchRequested(
+                EventType.STUDENT_UPDATED,
+                EventChangedData(
+                    old = listOf(EventChangeItem(0, old)),
+                    new = listOf(EventChangeItem(0, new)),
+                ),
             ),
         )
     }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateThirdGradeStudentsServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateThirdGradeStudentsServiceImpl.kt
@@ -1,12 +1,13 @@
 package team.themoment.datagsm.web.domain.student.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.StudentEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.student.dto.response.GraduateStudentResDto
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
@@ -16,7 +17,7 @@ import team.themoment.datagsm.web.domain.student.service.GraduateThirdGradeStude
 @Service
 class GraduateThirdGradeStudentsServiceImpl(
     private val studentJpaRepository: StudentJpaRepository,
-    private val eventPublisher: EventPublisher,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : GraduateThirdGradeStudentsService {
     @Transactional
     override fun execute(): GraduateStudentResDto {
@@ -42,9 +43,11 @@ class GraduateThirdGradeStudentsServiceImpl(
                 EventChangeItem(index, generateStudentEventObject(student))
             }
         if (olds.isNotEmpty()) {
-            eventPublisher.dispatch(
-                EventType.STUDENT_UPDATED,
-                EventChangedData(old = olds, new = news),
+            applicationEventPublisher.publishEvent(
+                EventDispatchRequested(
+                    EventType.STUDENT_UPDATED,
+                    EventChangedData(old = olds, new = news),
+                ),
             )
         }
 

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentExcelServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentExcelServiceImpl.kt
@@ -4,17 +4,18 @@ import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.apache.poi.ss.usermodel.DataFormatter
 import org.apache.poi.ss.usermodel.Row
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.StudentEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.student.dto.internal.ExcelColumnDto
 import team.themoment.datagsm.common.domain.student.dto.internal.ExcelRowDto
 import team.themoment.datagsm.common.domain.student.dto.internal.StudentBulkUpdateDto
@@ -32,7 +33,7 @@ import team.themoment.sdk.response.CommonApiResponse
 class ModifyStudentExcelServiceImpl(
     private val studentJpaRepository: StudentJpaRepository,
     private val clubJpaRepository: ClubJpaRepository,
-    private val eventPublisher: EventPublisher,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : ModifyStudentExcelService {
     private val dataFormatter = DataFormatter()
 
@@ -187,9 +188,11 @@ class ModifyStudentExcelServiceImpl(
         if (changed.isNotEmpty()) {
             val olds = changed.mapIndexed { index, i -> EventChangeItem(index, oldObjects[i]) }
             val news = changed.mapIndexed { index, i -> EventChangeItem(index, newObjects[i]) }
-            eventPublisher.dispatch(
-                EventType.STUDENT_UPDATED,
-                EventChangedData(old = olds, new = news),
+            applicationEventPublisher.publishEvent(
+                EventDispatchRequested(
+                    EventType.STUDENT_UPDATED,
+                    EventChangedData(old = olds, new = news),
+                ),
             )
         }
 

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentServiceImpl.kt
@@ -1,15 +1,16 @@
 package team.themoment.datagsm.web.domain.student.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.StudentEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.student.dto.request.UpdateStudentReqDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
 import team.themoment.datagsm.common.domain.student.entity.DormitoryRoomNumber
@@ -25,7 +26,7 @@ import team.themoment.sdk.exception.ExpectedException
 class ModifyStudentServiceImpl(
     private val studentJpaRepository: StudentJpaRepository,
     private val clubJpaRepository: ClubJpaRepository,
-    private val eventPublisher: EventPublisher,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : ModifyStudentService {
     @Transactional
     override fun execute(
@@ -89,11 +90,13 @@ class ModifyStudentServiceImpl(
                 clubs[clubId] ?: throw ExpectedException("자율 동아리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
             }
         val new = generateStudentEventObject(student)
-        eventPublisher.dispatch(
-            EventType.STUDENT_UPDATED,
-            EventChangedData(
-                old = listOf(EventChangeItem(0, old)),
-                new = listOf(EventChangeItem(0, new)),
+        applicationEventPublisher.publishEvent(
+            EventDispatchRequested(
+                EventType.STUDENT_UPDATED,
+                EventChangedData(
+                    old = listOf(EventChangeItem(0, old)),
+                    new = listOf(EventChangeItem(0, new)),
+                ),
             ),
         )
 

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentStatusServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentStatusServiceImpl.kt
@@ -1,15 +1,16 @@
 package team.themoment.datagsm.web.domain.student.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.StudentEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.student.dto.request.UpdateStudentStatusReqDto
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
@@ -21,7 +22,7 @@ import team.themoment.sdk.exception.ExpectedException
 class ModifyStudentStatusServiceImpl(
     private val studentJpaRepository: StudentJpaRepository,
     private val clubJpaRepository: ClubJpaRepository,
-    private val eventPublisher: EventPublisher,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : ModifyStudentStatusService {
     @Transactional
     override fun execute(
@@ -50,11 +51,13 @@ class ModifyStudentStatusServiceImpl(
         }
 
         val new = generateStudentEventObject(student)
-        eventPublisher.dispatch(
-            EventType.STUDENT_UPDATED,
-            EventChangedData(
-                old = listOf(EventChangeItem(0, old)),
-                new = listOf(EventChangeItem(0, new)),
+        applicationEventPublisher.publishEvent(
+            EventDispatchRequested(
+                EventType.STUDENT_UPDATED,
+                EventChangedData(
+                    old = listOf(EventChangeItem(0, old)),
+                    new = listOf(EventChangeItem(0, new)),
+                ),
             ),
         )
     }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/WithdrawStudentServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/WithdrawStudentServiceImpl.kt
@@ -1,15 +1,16 @@
 package team.themoment.datagsm.web.domain.student.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.StudentEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
@@ -20,7 +21,7 @@ import team.themoment.sdk.exception.ExpectedException
 class WithdrawStudentServiceImpl(
     private val studentJpaRepository: StudentJpaRepository,
     private val clubJpaRepository: ClubJpaRepository,
-    private val eventPublisher: EventPublisher,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : WithdrawStudentService {
     @Transactional
     override fun execute(studentId: Long) {
@@ -43,11 +44,13 @@ class WithdrawStudentServiceImpl(
         }
 
         val new = generateStudentEventObject(student)
-        eventPublisher.dispatch(
-            EventType.STUDENT_UPDATED,
-            EventChangedData(
-                old = listOf(EventChangeItem(0, old)),
-                new = listOf(EventChangeItem(0, new)),
+        applicationEventPublisher.publishEvent(
+            EventDispatchRequested(
+                EventType.STUDENT_UPDATED,
+                EventChangedData(
+                    old = listOf(EventChangeItem(0, old)),
+                    new = listOf(EventChangeItem(0, new)),
+                ),
             ),
         )
     }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/global/config/AsyncConfig.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/global/config/AsyncConfig.kt
@@ -1,8 +1,0 @@
-package team.themoment.datagsm.web.global.config
-
-import org.springframework.context.annotation.Configuration
-import org.springframework.scheduling.annotation.EnableAsync
-
-@Configuration
-@EnableAsync
-class AsyncConfig

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/global/config/RetryConfig.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/global/config/RetryConfig.kt
@@ -1,8 +1,0 @@
-package team.themoment.datagsm.web.global.config
-
-import org.springframework.context.annotation.Configuration
-import org.springframework.retry.annotation.EnableRetry
-
-@Configuration
-@EnableRetry
-class RetryConfig

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/club/service/CreateClubServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/club/service/CreateClubServiceTest.kt
@@ -9,12 +9,13 @@ import io.mockk.just
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import team.themoment.datagsm.common.domain.club.dto.request.ClubReqDto
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubStatus
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentNumber
 import team.themoment.datagsm.common.domain.student.entity.constant.Major
@@ -29,15 +30,15 @@ class CreateClubServiceTest :
 
         lateinit var mockClubRepository: ClubJpaRepository
         lateinit var mockStudentRepository: StudentJpaRepository
-        lateinit var eventPublisher: EventPublisher
+        lateinit var applicationEventPublisher: ApplicationEventPublisher
         lateinit var createClubService: CreateClubService
 
         beforeEach {
             mockClubRepository = mockk<ClubJpaRepository>()
             mockStudentRepository = mockk<StudentJpaRepository>()
-            eventPublisher = mockk<EventPublisher>()
-            justRun { eventPublisher.dispatch(any(), any()) }
-            createClubService = CreateClubServiceImpl(mockClubRepository, mockStudentRepository, eventPublisher)
+            applicationEventPublisher = mockk<ApplicationEventPublisher>()
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
+            createClubService = CreateClubServiceImpl(mockClubRepository, mockStudentRepository, applicationEventPublisher)
         }
 
         describe("CreateClubService 클래스의") {

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/club/service/DeleteClubServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/club/service/DeleteClubServiceTest.kt
@@ -9,11 +9,12 @@ import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubStatus
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.web.domain.club.service.impl.DeleteClubServiceImpl
 import team.themoment.sdk.exception.ExpectedException
@@ -24,15 +25,15 @@ class DeleteClubServiceTest :
 
         lateinit var mockClubRepository: ClubJpaRepository
         lateinit var mockStudentRepository: StudentJpaRepository
-        lateinit var eventPublisher: EventPublisher
+        lateinit var applicationEventPublisher: ApplicationEventPublisher
         lateinit var deleteClubService: DeleteClubService
 
         beforeEach {
             mockClubRepository = mockk<ClubJpaRepository>()
             mockStudentRepository = mockk<StudentJpaRepository>()
-            eventPublisher = mockk<EventPublisher>()
-            justRun { eventPublisher.dispatch(any(), any()) }
-            deleteClubService = DeleteClubServiceImpl(mockClubRepository, mockStudentRepository, eventPublisher)
+            applicationEventPublisher = mockk<ApplicationEventPublisher>()
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
+            deleteClubService = DeleteClubServiceImpl(mockClubRepository, mockStudentRepository, applicationEventPublisher)
         }
 
         describe("DeleteClubService 클래스의") {

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/club/service/ModifyClubServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/club/service/ModifyClubServiceTest.kt
@@ -9,12 +9,13 @@ import io.mockk.just
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import team.themoment.datagsm.common.domain.club.dto.request.ClubReqDto
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubStatus
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentNumber
 import team.themoment.datagsm.common.domain.student.entity.constant.Major
@@ -29,15 +30,15 @@ class ModifyClubServiceTest :
 
         lateinit var mockClubRepository: ClubJpaRepository
         lateinit var mockStudentRepository: StudentJpaRepository
-        lateinit var eventPublisher: EventPublisher
+        lateinit var applicationEventPublisher: ApplicationEventPublisher
         lateinit var modifyClubService: ModifyClubServiceImpl
 
         beforeEach {
             mockClubRepository = mockk<ClubJpaRepository>()
             mockStudentRepository = mockk<StudentJpaRepository>()
-            eventPublisher = mockk<EventPublisher>()
-            justRun { eventPublisher.dispatch(any(), any()) }
-            modifyClubService = ModifyClubServiceImpl(mockClubRepository, mockStudentRepository, eventPublisher)
+            applicationEventPublisher = mockk<ApplicationEventPublisher>()
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
+            modifyClubService = ModifyClubServiceImpl(mockClubRepository, mockStudentRepository, applicationEventPublisher)
         }
 
         describe("ModifyClubService 클래스의") {

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/event/service/CreateEventServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/event/service/CreateEventServiceTest.kt
@@ -7,12 +7,14 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.event.dto.request.CreateEventReqDto
 import team.themoment.datagsm.common.domain.event.entity.EventJpaEntity
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
 import team.themoment.datagsm.common.domain.event.entity.constant.EventVerificationStatus
 import team.themoment.datagsm.common.domain.event.repository.EventJpaRepository
+import team.themoment.datagsm.web.domain.event.dto.internal.EventVerificationRequested
 import team.themoment.datagsm.web.domain.event.service.impl.CreateEventServiceImpl
 import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
@@ -23,18 +25,18 @@ class CreateEventServiceTest :
 
         lateinit var eventJpaRepository: EventJpaRepository
         lateinit var currentUserProvider: CurrentUserProvider
-        lateinit var verifyEventService: VerifyEventService
+        lateinit var applicationEventPublisher: ApplicationEventPublisher
         lateinit var createEventService: CreateEventService
         lateinit var account: AccountJpaEntity
 
         beforeEach {
             eventJpaRepository = mockk()
             currentUserProvider = mockk()
-            verifyEventService = mockk(relaxed = true)
+            applicationEventPublisher = mockk(relaxed = true)
             account = mockk()
             every { currentUserProvider.getCurrentAccount() } returns account
             createEventService =
-                CreateEventServiceImpl(eventJpaRepository, currentUserProvider, verifyEventService)
+                CreateEventServiceImpl(eventJpaRepository, currentUserProvider, applicationEventPublisher)
         }
 
         describe("CreateEventService 클래스의") {
@@ -56,7 +58,7 @@ class CreateEventServiceTest :
                                 createEventService.execute(reqDto)
                             }
                         ex.message shouldBe "Event는 최대 10개까지 등록할 수 있습니다."
-                        verify(exactly = 0) { verifyEventService.verifyAsync(any()) }
+                        verify(exactly = 0) { applicationEventPublisher.publishEvent(any<EventVerificationRequested>()) }
                     }
                 }
 
@@ -87,7 +89,7 @@ class CreateEventServiceTest :
                     it("저장 후 비동기 URL 검증을 트리거해야 한다") {
                         createEventService.execute(reqDto)
 
-                        verify(exactly = 1) { verifyEventService.verifyAsync(1L) }
+                        verify(exactly = 1) { applicationEventPublisher.publishEvent(EventVerificationRequested(1L)) }
                     }
                 }
             }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/event/service/ModifyEventServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/event/service/ModifyEventServiceTest.kt
@@ -6,12 +6,14 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.event.dto.request.ModifyEventReqDto
 import team.themoment.datagsm.common.domain.event.entity.EventJpaEntity
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
 import team.themoment.datagsm.common.domain.event.entity.constant.EventVerificationStatus
 import team.themoment.datagsm.common.domain.event.repository.EventJpaRepository
+import team.themoment.datagsm.web.domain.event.dto.internal.EventVerificationRequested
 import team.themoment.datagsm.web.domain.event.service.impl.ModifyEventServiceImpl
 import team.themoment.datagsm.web.global.security.provider.CurrentUserProvider
 import team.themoment.sdk.exception.ExpectedException
@@ -22,7 +24,7 @@ class ModifyEventServiceTest :
 
         lateinit var eventJpaRepository: EventJpaRepository
         lateinit var currentUserProvider: CurrentUserProvider
-        lateinit var verifyEventService: VerifyEventService
+        lateinit var applicationEventPublisher: ApplicationEventPublisher
         lateinit var modifyEventService: ModifyEventService
         lateinit var account: AccountJpaEntity
 
@@ -39,11 +41,11 @@ class ModifyEventServiceTest :
         beforeEach {
             eventJpaRepository = mockk()
             currentUserProvider = mockk()
-            verifyEventService = mockk(relaxed = true)
+            applicationEventPublisher = mockk(relaxed = true)
             account = mockk()
             every { currentUserProvider.getCurrentAccount() } returns account
             modifyEventService =
-                ModifyEventServiceImpl(eventJpaRepository, currentUserProvider, verifyEventService)
+                ModifyEventServiceImpl(eventJpaRepository, currentUserProvider, applicationEventPublisher)
         }
 
         describe("ModifyEventService 클래스의") {
@@ -61,7 +63,7 @@ class ModifyEventServiceTest :
                                 modifyEventService.execute(1L, reqDto)
                             }
                         ex.message shouldBe "Event를 찾을 수 없습니다."
-                        verify(exactly = 0) { verifyEventService.verifyAsync(any()) }
+                        verify(exactly = 0) { applicationEventPublisher.publishEvent(any<EventVerificationRequested>()) }
                     }
                 }
 
@@ -83,7 +85,7 @@ class ModifyEventServiceTest :
                     it("비동기 URL 검증을 트리거해야 한다") {
                         modifyEventService.execute(1L, reqDto)
 
-                        verify(exactly = 1) { verifyEventService.verifyAsync(1L) }
+                        verify(exactly = 1) { applicationEventPublisher.publishEvent(EventVerificationRequested(1L)) }
                     }
                 }
 
@@ -99,7 +101,7 @@ class ModifyEventServiceTest :
                         val result = modifyEventService.execute(1L, reqDto)
 
                         result.verificationStatus shouldBe EventVerificationStatus.VERIFIED
-                        verify(exactly = 0) { verifyEventService.verifyAsync(any()) }
+                        verify(exactly = 0) { applicationEventPublisher.publishEvent(any<EventVerificationRequested>()) }
                     }
                 }
 
@@ -116,7 +118,7 @@ class ModifyEventServiceTest :
                         val result = modifyEventService.execute(1L, reqDto)
 
                         result.verificationStatus shouldBe EventVerificationStatus.PENDING
-                        verify(exactly = 1) { verifyEventService.verifyAsync(1L) }
+                        verify(exactly = 1) { applicationEventPublisher.publishEvent(EventVerificationRequested(1L)) }
                     }
                 }
 
@@ -133,7 +135,7 @@ class ModifyEventServiceTest :
 
                         result.targetUrl shouldBe "https://old.example.com/event"
                         result.events shouldBe setOf(EventType.PROJECT_UPDATED)
-                        verify(exactly = 0) { verifyEventService.verifyAsync(any()) }
+                        verify(exactly = 0) { applicationEventPublisher.publishEvent(any<EventVerificationRequested>()) }
                     }
                 }
             }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/CreateProjectServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/CreateProjectServiceTest.kt
@@ -8,10 +8,11 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.project.dto.request.ProjectReqDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
 import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
@@ -28,13 +29,13 @@ class CreateProjectServiceTest :
         val mockProjectRepository = mockk<ProjectJpaRepository>()
         val mockClubRepository = mockk<ClubJpaRepository>()
         val mockStudentRepository = mockk<team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository>()
-        val eventPublisher = mockk<EventPublisher>()
+        val applicationEventPublisher = mockk<ApplicationEventPublisher>()
 
         val createProjectService =
-            CreateProjectServiceImpl(mockProjectRepository, mockClubRepository, mockStudentRepository, eventPublisher)
+            CreateProjectServiceImpl(mockProjectRepository, mockClubRepository, mockStudentRepository, applicationEventPublisher)
 
         beforeEach {
-            justRun { eventPublisher.dispatch(any(), any()) }
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
         }
 
         afterEach {

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/DeleteProjectServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/DeleteProjectServiceTest.kt
@@ -8,9 +8,10 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
 import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
@@ -22,12 +23,12 @@ class DeleteProjectServiceTest :
     DescribeSpec({
 
         val mockProjectRepository = mockk<ProjectJpaRepository>()
-        val eventPublisher = mockk<EventPublisher>()
+        val applicationEventPublisher = mockk<ApplicationEventPublisher>()
 
-        val deleteProjectService = DeleteProjectServiceImpl(mockProjectRepository, eventPublisher)
+        val deleteProjectService = DeleteProjectServiceImpl(mockProjectRepository, applicationEventPublisher)
 
         beforeEach {
-            justRun { eventPublisher.dispatch(any(), any()) }
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
         }
 
         afterEach {

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/ModifyProjectServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/ModifyProjectServiceTest.kt
@@ -7,10 +7,11 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.project.dto.request.ProjectReqDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
 import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
@@ -27,17 +28,17 @@ class ModifyProjectServiceTest :
         lateinit var mockProjectRepository: ProjectJpaRepository
         lateinit var mockClubRepository: ClubJpaRepository
         lateinit var mockStudentRepository: team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
-        lateinit var eventPublisher: EventPublisher
+        lateinit var applicationEventPublisher: ApplicationEventPublisher
         lateinit var modifyProjectService: ModifyProjectService
 
         beforeEach {
             mockProjectRepository = mockk<ProjectJpaRepository>()
             mockClubRepository = mockk<ClubJpaRepository>()
             mockStudentRepository = mockk<team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository>()
-            eventPublisher = mockk<EventPublisher>()
-            justRun { eventPublisher.dispatch(any(), any()) }
+            applicationEventPublisher = mockk<ApplicationEventPublisher>()
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
             modifyProjectService =
-                ModifyProjectServiceImpl(mockProjectRepository, mockClubRepository, mockStudentRepository, eventPublisher)
+                ModifyProjectServiceImpl(mockProjectRepository, mockClubRepository, mockStudentRepository, applicationEventPublisher)
         }
 
         describe("ModifyProjectService 클래스의") {

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentExcelServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentExcelServiceTest.kt
@@ -11,15 +11,16 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import org.springframework.mock.web.MockMultipartFile
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.StudentEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.student.dto.internal.StudentBulkUpdateDto
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentNumber
@@ -46,16 +47,16 @@ class ModifyStudentExcelServiceTest :
 
         lateinit var mockStudentRepository: StudentJpaRepository
         lateinit var mockClubRepository: ClubJpaRepository
-        lateinit var mockEventPublisher: EventPublisher
+        lateinit var mockApplicationEventPublisher: ApplicationEventPublisher
         lateinit var modifyStudentExcelService: ModifyStudentExcelService
 
         beforeEach {
             mockStudentRepository = mockk<StudentJpaRepository>()
             mockClubRepository = mockk<ClubJpaRepository>()
-            mockEventPublisher = mockk<EventPublisher>()
-            justRun { mockEventPublisher.dispatch(any(), any()) }
+            mockApplicationEventPublisher = mockk<ApplicationEventPublisher>()
+            justRun { mockApplicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
             modifyStudentExcelService =
-                ModifyStudentExcelServiceImpl(mockStudentRepository, mockClubRepository, mockEventPublisher)
+                ModifyStudentExcelServiceImpl(mockStudentRepository, mockClubRepository, mockApplicationEventPublisher)
         }
 
         fun createValidExcelFile(): ByteArray {
@@ -151,8 +152,10 @@ class ModifyStudentExcelServiceTest :
                     }
 
                     it("학생 정보를 수정하고 성공 메시지를 반환해야 한다") {
-                        val dataSlot = slot<EventChangedData>()
-                        justRun { mockEventPublisher.dispatch(EventType.STUDENT_UPDATED, capture(dataSlot)) }
+                        val eventSlot = slot<EventDispatchRequested>()
+                        justRun {
+                            mockApplicationEventPublisher.publishEvent(capture(eventSlot))
+                        }
 
                         val result = modifyStudentExcelService.execute(file)
 
@@ -175,13 +178,24 @@ class ModifyStudentExcelServiceTest :
                     }
 
                     it("STUDENT_UPDATED 이벤트의 old는 수정 전, new는 수정 후 값을 담는다") {
-                        val dataSlot = slot<EventChangedData>()
-                        justRun { mockEventPublisher.dispatch(EventType.STUDENT_UPDATED, capture(dataSlot)) }
+                        val eventSlot = slot<EventDispatchRequested>()
+                        justRun {
+                            mockApplicationEventPublisher.publishEvent(capture(eventSlot))
+                        }
 
                         modifyStudentExcelService.execute(file)
 
-                        verify(exactly = 1) { mockEventPublisher.dispatch(EventType.STUDENT_UPDATED, any()) }
-                        val data = dataSlot.captured
+                        verify(
+                            exactly = 1,
+                        ) {
+                            mockApplicationEventPublisher.publishEvent(
+                                match<EventDispatchRequested> {
+                                    it.eventType ==
+                                        EventType.STUDENT_UPDATED
+                                },
+                            )
+                        }
+                        val data = eventSlot.captured.data as EventChangedData
                         data.old.size shouldBe 1
                         data.new.size shouldBe 1
 

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/ModifyStudentServiceTest.kt
@@ -7,10 +7,11 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.student.dto.request.UpdateStudentReqDto
 import team.themoment.datagsm.common.domain.student.entity.DormitoryRoomNumber
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
@@ -28,15 +29,15 @@ class ModifyStudentServiceTest :
 
         lateinit var mockStudentRepository: StudentJpaRepository
         lateinit var mockClubRepository: ClubJpaRepository
-        lateinit var mockEventPublisher: EventPublisher
+        lateinit var mockApplicationEventPublisher: ApplicationEventPublisher
         lateinit var modifyStudentService: ModifyStudentService
 
         beforeEach {
             mockStudentRepository = mockk<StudentJpaRepository>()
             mockClubRepository = mockk<ClubJpaRepository>()
-            mockEventPublisher = mockk<EventPublisher>()
-            justRun { mockEventPublisher.dispatch(any(), any()) }
-            modifyStudentService = ModifyStudentServiceImpl(mockStudentRepository, mockClubRepository, mockEventPublisher)
+            mockApplicationEventPublisher = mockk<ApplicationEventPublisher>()
+            justRun { mockApplicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
+            modifyStudentService = ModifyStudentServiceImpl(mockStudentRepository, mockClubRepository, mockApplicationEventPublisher)
         }
 
         describe("ModifyStudentService 클래스의") {

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/BatchOperationServiceImplTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/BatchOperationServiceImplTest.kt
@@ -6,8 +6,9 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.student.dto.internal.BatchOperationFilter
 import team.themoment.datagsm.common.domain.student.dto.internal.BatchOperationType
 import team.themoment.datagsm.common.domain.student.dto.request.BatchOperationReqDto
@@ -19,8 +20,8 @@ import team.themoment.datagsm.common.domain.student.repository.StudentJpaReposit
 class BatchOperationServiceImplTest :
     BehaviorSpec({
         val studentJpaRepository = mockk<StudentJpaRepository>()
-        val eventPublisher = mockk<EventPublisher>()
-        val service = BatchOperationServiceImpl(studentJpaRepository, eventPublisher)
+        val applicationEventPublisher = mockk<ApplicationEventPublisher>()
+        val service = BatchOperationServiceImpl(studentJpaRepository, applicationEventPublisher)
 
         Given("3학년 학생들이 10명 있을 때") {
             val thirdGradeStudents =
@@ -35,7 +36,7 @@ class BatchOperationServiceImplTest :
                 }
 
             every { studentJpaRepository.findStudentsByGrade(3) } returns thirdGradeStudents
-            justRun { eventPublisher.dispatch(any(), any()) }
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
 
             When("3학년 일괄 졸업을 요청하면") {
                 val reqDto =
@@ -55,7 +56,14 @@ class BatchOperationServiceImplTest :
                 }
 
                 Then("STUDENT_UPDATED 이벤트가 1회 발행된다") {
-                    verify(exactly = 1) { eventPublisher.dispatch(EventType.STUDENT_UPDATED, any()) }
+                    verify(exactly = 1) {
+                        applicationEventPublisher.publishEvent(
+                            match<EventDispatchRequested> {
+                                it.eventType ==
+                                    EventType.STUDENT_UPDATED
+                            },
+                        )
+                    }
                 }
             }
         }
@@ -91,7 +99,7 @@ class BatchOperationServiceImplTest :
                 }
 
             every { studentJpaRepository.findStudentsByGrade(3) } returns defaultThirdGradeStudents
-            justRun { eventPublisher.dispatch(any(), any()) }
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
 
             When("일괄 졸업을 요청하면") {
                 val reqDto =

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateStudentServiceImplTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateStudentServiceImplTest.kt
@@ -7,8 +7,9 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.student.entity.DormitoryRoomNumber
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentNumber
@@ -23,8 +24,8 @@ class GraduateStudentServiceImplTest :
     BehaviorSpec({
         val studentJpaRepository = mockk<StudentJpaRepository>()
         val clubJpaRepository = mockk<ClubJpaRepository>()
-        val eventPublisher = mockk<EventPublisher>()
-        val graduateStudentService = GraduateStudentServiceImpl(studentJpaRepository, clubJpaRepository, eventPublisher)
+        val applicationEventPublisher = mockk<ApplicationEventPublisher>()
+        val graduateStudentService = GraduateStudentServiceImpl(studentJpaRepository, clubJpaRepository, applicationEventPublisher)
 
         Given("3학년 학생이 존재하는 경우") {
             val studentId = 1L
@@ -42,7 +43,7 @@ class GraduateStudentServiceImplTest :
 
             every { studentJpaRepository.findById(studentId) } returns Optional.of(student)
             every { clubJpaRepository.findAllByLeader(student) } returns emptyList()
-            justRun { eventPublisher.dispatch(any(), any()) }
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
 
             When("해당 학생을 졸업 처리하면") {
                 graduateStudentService.execute(studentId)

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateThirdGradeStudentsServiceImplTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/GraduateThirdGradeStudentsServiceImplTest.kt
@@ -7,10 +7,11 @@ import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.StudentEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
 import team.themoment.datagsm.common.domain.student.entity.DormitoryRoomNumber
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentNumber
@@ -22,8 +23,8 @@ import team.themoment.datagsm.common.domain.student.repository.StudentJpaReposit
 class GraduateThirdGradeStudentsServiceImplTest :
     BehaviorSpec({
         val studentJpaRepository = mockk<StudentJpaRepository>()
-        val eventPublisher = mockk<EventPublisher>()
-        val graduateThirdGradeStudentsService = GraduateThirdGradeStudentsServiceImpl(studentJpaRepository, eventPublisher)
+        val applicationEventPublisher = mockk<ApplicationEventPublisher>()
+        val graduateThirdGradeStudentsService = GraduateThirdGradeStudentsServiceImpl(studentJpaRepository, applicationEventPublisher)
 
         Given("3학년 학생들이 존재하는 경우") {
             val student1 =
@@ -64,9 +65,9 @@ class GraduateThirdGradeStudentsServiceImplTest :
 
             val thirdGradeStudents = listOf(student1, student2, student3)
 
-            val dataSlot = slot<EventChangedData>()
+            val eventSlot = slot<EventDispatchRequested>()
             every { studentJpaRepository.findStudentsByGrade(3) } returns thirdGradeStudents
-            justRun { eventPublisher.dispatch(EventType.STUDENT_UPDATED, capture(dataSlot)) }
+            justRun { applicationEventPublisher.publishEvent(capture(eventSlot)) }
 
             When("모든 3학년 학생을 졸업 처리하면") {
                 val result = graduateThirdGradeStudentsService.execute()
@@ -89,8 +90,15 @@ class GraduateThirdGradeStudentsServiceImplTest :
                 }
 
                 Then("STUDENT_UPDATED 이벤트가 1회 발행되며 old/new가 index로 매핑된다") {
-                    verify(exactly = 1) { eventPublisher.dispatch(EventType.STUDENT_UPDATED, any()) }
-                    val data = dataSlot.captured
+                    verify(exactly = 1) {
+                        applicationEventPublisher.publishEvent(
+                            match<EventDispatchRequested> {
+                                it.eventType ==
+                                    EventType.STUDENT_UPDATED
+                            },
+                        )
+                    }
+                    val data = eventSlot.captured.data as EventChangedData
                     data.old.size shouldBe 3
                     data.new.size shouldBe 3
                     data.old.map { it.index } shouldBe listOf(0, 1, 2)

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentStatusServiceImplTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/ModifyStudentStatusServiceImplTest.kt
@@ -7,9 +7,10 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.student.dto.request.UpdateStudentStatusReqDto
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
@@ -21,8 +22,8 @@ class ModifyStudentStatusServiceImplTest :
     BehaviorSpec({
         val studentJpaRepository = mockk<StudentJpaRepository>()
         val clubJpaRepository = mockk<ClubJpaRepository>()
-        val eventPublisher = mockk<EventPublisher>()
-        val service = ModifyStudentStatusServiceImpl(studentJpaRepository, clubJpaRepository, eventPublisher)
+        val applicationEventPublisher = mockk<ApplicationEventPublisher>()
+        val service = ModifyStudentStatusServiceImpl(studentJpaRepository, clubJpaRepository, applicationEventPublisher)
 
         Given("존재하지 않는 학생 ID로") {
             val studentId = 999L
@@ -56,7 +57,7 @@ class ModifyStudentStatusServiceImplTest :
 
             every { studentJpaRepository.findByIdOrNull(studentId) } returns student
             every { clubJpaRepository.findAllByLeader(student) } returns emptyList()
-            justRun { eventPublisher.dispatch(any(), any()) }
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
 
             When("상태 변경을 요청하면") {
                 service.execute(studentId, reqDto)
@@ -86,7 +87,7 @@ class ModifyStudentStatusServiceImplTest :
 
             every { studentJpaRepository.findByIdOrNull(studentId) } returns student
             every { clubJpaRepository.findAllByLeader(student) } returns emptyList()
-            justRun { eventPublisher.dispatch(any(), any()) }
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
 
             When("상태 변경을 요청하면") {
                 service.execute(studentId, reqDto)
@@ -113,7 +114,7 @@ class ModifyStudentStatusServiceImplTest :
             val reqDto = UpdateStudentStatusReqDto(status = StudentRole.GENERAL_STUDENT)
 
             every { studentJpaRepository.findByIdOrNull(studentId) } returns student
-            justRun { eventPublisher.dispatch(any(), any()) }
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
 
             When("상태 변경을 요청하면") {
                 service.execute(studentId, reqDto)
@@ -137,7 +138,7 @@ class ModifyStudentStatusServiceImplTest :
             val reqDto = UpdateStudentStatusReqDto(status = StudentRole.STUDENT_COUNCIL)
 
             every { studentJpaRepository.findByIdOrNull(studentId) } returns student
-            justRun { eventPublisher.dispatch(any(), any()) }
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
 
             When("상태 변경을 요청하면") {
                 service.execute(studentId, reqDto)
@@ -161,7 +162,7 @@ class ModifyStudentStatusServiceImplTest :
             val reqDto = UpdateStudentStatusReqDto(status = StudentRole.DORMITORY_MANAGER)
 
             every { studentJpaRepository.findByIdOrNull(studentId) } returns student
-            justRun { eventPublisher.dispatch(any(), any()) }
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
 
             When("상태 변경을 요청하면") {
                 service.execute(studentId, reqDto)

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/WithdrawStudentServiceImplTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/student/service/impl/WithdrawStudentServiceImplTest.kt
@@ -7,9 +7,10 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
-import team.themoment.datagsm.common.domain.event.service.EventPublisher
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
 import team.themoment.datagsm.common.domain.student.entity.DormitoryRoomNumber
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentNumber
@@ -24,8 +25,8 @@ class WithdrawStudentServiceImplTest :
     BehaviorSpec({
         val studentJpaRepository = mockk<StudentJpaRepository>()
         val clubJpaRepository = mockk<ClubJpaRepository>()
-        val eventPublisher = mockk<EventPublisher>()
-        val withdrawStudentService = WithdrawStudentServiceImpl(studentJpaRepository, clubJpaRepository, eventPublisher)
+        val applicationEventPublisher = mockk<ApplicationEventPublisher>()
+        val withdrawStudentService = WithdrawStudentServiceImpl(studentJpaRepository, clubJpaRepository, applicationEventPublisher)
 
         Given("일반 학생이 존재하는 경우") {
             val studentId = 1L
@@ -47,7 +48,7 @@ class WithdrawStudentServiceImplTest :
             every { mockClub.name } returns "동아리"
             every { studentJpaRepository.findById(studentId) } returns Optional.of(student)
             every { clubJpaRepository.findAllByLeader(student) } returns emptyList()
-            justRun { eventPublisher.dispatch(any(), any()) }
+            justRun { applicationEventPublisher.publishEvent(any<EventDispatchRequested>()) }
 
             When("해당 학생을 자퇴 처리하면") {
                 withdrawStudentService.execute(studentId)


### PR DESCRIPTION
## 개요

`@Transactional` 서비스 내부에서 `@Async`로 webhook을 발행하고 있어 커밋 전에 이벤트가 전송되는 문제를 수정하였습니다. 발행 트리거를 `@TransactionalEventListener`로 옮겨 커밋 이후에만 전송되도록 하였으며, 전송 실패 처리와 비동기 미처리 예외 알림 경로를 함께 정비하였습니다.

## 본문

### 커밋 전 webhook 발행 수정

13개 서비스가 모두 `@Transactional` 내부에서 `eventPublisher.dispatch()`를 호출하고 있었고, `dispatch()`가 `@Async`이므로 커밋 전에 webhook이 전송되었습니다. `BatchOperationServiceImpl`처럼 더티 체킹으로만 변경하는 경우 실제 `UPDATE`는 커밋 시점 flush에서 발생하므로, flush가 실패하면 롤백된 변경 사항이 이미 소비자에게 통보된 상태가 됩니다. 롤백이 없더라도 소비자가 알림 직후 조회하면 커밋 전 데이터를 읽게 됩니다.

호출부가 `EventDispatchRequested`를 발행하고 `EventDispatchListener`가 `AFTER_COMMIT` 단계에서 `EventPublisher`에 위임하도록 변경하였습니다.

### 전송 실패 처리

- `EventSender`에 타임아웃을 추가하였습니다. 기존에는 제한이 없어 응답하지 않는 소비자 하나가 비동기 스레드를 무기한 점유할 수 있었습니다.
- `@Recover`를 제거하여 재시도 소진 시 예외가 전파되도록 하였습니다. 재시도 정책 자체는 기존과 동일합니다.
- `EventPublisherImpl`이 대상별로 실패를 격리하며, `RestClientException`은 소비자 문제로 보아 경고만 남기고 그 외 예외는 `addSuppressed`로 모아 전파합니다.
- 전송 구간 전체를 감싸던 `@Transactional(readOnly = true)`을 제거하였습니다. 기존에는 webhook 전송이 끝날 때까지 DB 커넥션을 점유하였습니다.

### 비동기 미처리 예외 알림

`GlobalExceptionHandler`가 웹 요청 경계를 담당하는 것과 대응되도록, `AsyncConfigurer`를 구현한 `AsyncConfig`가 `@Async` 경계를 벗어난 예외를 받아 Discord로 알립니다. 모듈마다 중복되어 있던 `AsyncConfig`와 `RetryConfig`를 `datagsm-common`으로 통합하였으며, 이 과정에서 `datagsm-oauth-userinfo`에만 `@EnableAsync`와 `@EnableRetry`가 누락되어 있던 문제도 해소되었습니다.

### 검증 트리거 전환

`CreateEventServiceImpl`과 `ModifyEventServiceImpl`에 동일하게 중복되어 있던 `TransactionSynchronizationManager` 수동 등록 코드를 `EventVerificationRequested`와 `EventVerificationListener`로 대체하였습니다.

### 기타

`EventPublisherImpl` 테스트를 추가하였고(`datagsm-common`에 `MockK` 의존성 추가), 전체 테스트 607개가 통과합니다.

작업 중 `student`, `club`, `project` 도메인의 쓰기 서비스 19개 중 6개가 이벤트 발행을 누락하고 있음을 확인하여 별도 이슈로 등록하였습니다. (#405, #406, #407, #408, #409, #410, #411)
