### PR TITLE
[ci/cd] `datagsm-shared` JVM 배포 실패 및 빈 아티팩트 발행 수정

### DIFF
--- a/.github/workflows/datagsm-prod-cd.yaml
+++ b/.github/workflows/datagsm-prod-cd.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Publish JVM artifact to GitHub Packages
         run: >
           ./gradlew :datagsm-common:kspKotlin
-          :datagsm-shared:publishJvmPublicationToGitHubPackagesRepository
+          :datagsm-shared:publishMavenPublicationToGitHubPackagesRepository
           -PSHARED_VERSION=${{ needs.generate-version.outputs.version }}
         env:
           GITHUB_ACTOR: ${{ github.actor }}

--- a/datagsm-common/build.gradle.kts
+++ b/datagsm-common/build.gradle.kts
@@ -91,3 +91,13 @@ ksp {
     arg("sdkOutputDir", "${layout.buildDirectory.get().asFile}/generated/sdk-export/main/kotlin")
     arg("tsOutputDir", "${layout.buildDirectory.get().asFile}/generated/sdk-export/main/ts")
 }
+
+// sdkOutputDir/tsOutputDir are plain processor arguments, so Gradle does not know the
+// generated directory is a task output: it stays UP-TO-DATE when the directory is missing,
+// and a build cache hit restores only the declared outputs. Both cases let datagsm-shared
+// compile with zero sources and publish an empty artifact without failing. Declaring the
+// directory as an output makes staleness and cache restoration correct.
+// `tasks.named` is not usable here — KSP registers kspKotlin after this block is evaluated.
+tasks.matching { it.name == "kspKotlin" }.configureEach {
+    outputs.dir(layout.buildDirectory.dir("generated/sdk-export"))
+}

--- a/datagsm-shared/build.gradle.kts
+++ b/datagsm-shared/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
+    withSourcesJar()
 }
 
 sourceSets {
@@ -98,7 +99,14 @@ tasks.register("assembleTsPackage") {
     }
 }
 
+// The KMP plugin used to register the `jvm` publication implicitly; after the KMP layer was
+// removed the `kotlin("jvm")` plugin registers none, so it must be declared explicitly.
 publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+        }
+    }
     repositories {
         maven {
             name = "GitHubPackages"

--- a/datagsm-shared/build.gradle.kts
+++ b/datagsm-shared/build.gradle.kts
@@ -46,6 +46,12 @@ tasks.named("compileKotlin") {
     dependsOn(":datagsm-common:kspKotlin")
 }
 
+// The only source root is KSP-generated, so sourcesJar silently produces an empty archive
+// unless the generator has already run. Gradle infers no dependency from srcDir alone.
+tasks.named("sourcesJar") {
+    dependsOn(":datagsm-common:kspKotlin")
+}
+
 // Assembles a runtime-free, type-only npm package from the KSP-generated index.d.ts.
 // Replaces the former Kotlin/JS IR output (see plan-04): no kotlinx-serialization /
 // kotlinx-datetime / @js-joda runtime dependency, plain TypeScript types only.


### PR DESCRIPTION
## 개요

`master` 브랜치의 prod CD 워크플로우에서 `publish-jvm` 잡이 계속 실패하고 있었습니다. `datagsm-shared` 모듈이 Kotlin Multiplatform에서 `kotlin("jvm")`으로 전환되면서 Maven publication이 등록되지 않게 된 것이 원인입니다. 이를 수정하는 과정에서 배포 산출물이 조용히 비어버리는 결함 2건을 추가로 발견하여 함께 수정하였습니다.

## 본문

### 1. 배포 실패 원인 — publication 미등록

`813edc94` 커밋에서 KMP 레이어가 제거되며 `datagsm-shared`의 플러그인이 `kotlin("multiplatform")`에서 `kotlin("jvm")`으로 변경되었습니다.

- KMP 플러그인은 `maven-publish`와 함께 사용될 때 타깃별 publication(`jvm`, `js`, `kotlinMultiplatform`)을 암묵적으로 등록하므로 `publishJvmPublicationToGitHubPackagesRepository` 태스크가 존재하였습니다.
- 반면 `kotlin("jvm")` 플러그인은 publication을 자동 등록하지 않습니다. `publishing` 블록에 `repositories`만 선언되어 있어 publication이 하나도 없는 상태였습니다.

```
Cannot locate tasks that match ':datagsm-shared:publishJvmPublicationToGitHubPackagesRepository'
as task 'publishJvmPublicationToGitHubPackagesRepository' not found in project ':datagsm-shared'.
```

같은 워크플로우의 `publish-js` 잡은 publication과 무관한 `assembleTsPackage`와 `npm publish`만 사용하므로 정상 동작하였습니다. 즉 npm 배포는 정상이었고 GitHub Packages 대상 Maven 배포만 중단된 상태였습니다.

`maven` 이름의 `MavenPublication`을 명시적으로 등록하고, 워크플로우의 태스크명을 `publishMavenPublicationToGitHubPackagesRepository`로 변경하였습니다. KMP가 기본 제공하던 sources jar를 유지하기 위해 `withSourcesJar()`도 추가하였습니다.

### 2. `sourcesJar`의 KSP 의존성 누락

`datagsm-shared`의 유일한 소스 루트는 KSP 생성물이지만, `sourcesJar`에는 `compileKotlin`과 달리 `kspKotlin` 의존성이 없었습니다. `kotlin.srcDir(...)` 선언만으로는 Gradle이 태스크 의존성을 추론하지 못합니다. `org.gradle.parallel=true`이므로 `sourcesJar`가 생성 태스크보다 먼저 실행되면 빈 아카이브가 만들어집니다. `dependsOn`을 명시하였습니다.

### 3. KSP 생성 디렉터리가 태스크 출력으로 선언되지 않음

`datagsm-common`에서 생성 경로를 `arg("sdkOutputDir", ...)`처럼 프로세서 인자로만 전달하고 있어, Gradle은 해당 디렉터리를 `kspKotlin`의 출력으로 인식하지 못했습니다. 이로 인해 두 가지 문제가 발생합니다.

- 디렉터리가 없어도 `kspKotlin`이 `UP-TO-DATE`로 판정되어 재생성되지 않습니다.
- `org.gradle.caching=true` 환경에서 빌드 캐시가 적중하면 선언된 출력만 복원되므로 생성 디렉터리가 복원되지 않습니다.

두 경우 모두 `datagsm-shared`가 소스 0개로 컴파일되며, **빌드는 성공하지만 빈 아티팩트가 발행됩니다.**

```
$ rm -rf datagsm-common/build/generated/sdk-export
$ ./gradlew :datagsm-common:kspKotlin :datagsm-shared:jar
> Task :datagsm-common:kspKotlin UP-TO-DATE
> Task :datagsm-shared:compileKotlin
BUILD SUCCESSFUL
→ jar: 2 files / 25 bytes
```

특히 `datagsm-shared/`만 변경된 커밋은 `shared_changed=true`를 만들면서도 `kspKotlin`의 입력은 그대로여서 캐시 적중 가능성이 높습니다. 생성 디렉터리를 `outputs.dir`로 선언하여 최신성 판정과 캐시 복원이 모두 올바르게 동작하도록 하였습니다.

### 검증

CD와 동일한 커맨드 형태로 로컬 `MavenLocal` 저장소에 배포하여 확인하였습니다. 빌드 캐시가 적중하는 상황(`kspKotlin FROM-CACHE`)에서도 정상 산출물이 나오는 것을 확인하였습니다.

- jar: 106 files / 347KB
- sources jar: 64 files
- pom, module 파일 정상 생성, `kotlinx-serialization-json-jvm`과 `kotlinx-datetime-jvm` 의존성 포함
- `assembleTsPackage`의 npm 산출물도 캐시 복원 후 정상
- `ktlintCheck` 통과

### 참고 사항

- **아티팩트 좌표 변경**: KMP 시절 `jvm` publication은 artifactId가 `datagsm-shared-jvm`이었으나, 순수 JVM 모듈이 된 현재 구성에서는 `datagsm-shared`로 발행됩니다. 기존 소비자는 좌표를 갱신해야 합니다.
- **의존성 스코프**: `kotlinx-serialization-json`과 `kotlinx-datetime`이 `implementation`으로 선언되어 POM에 `runtime` 스코프로 기록됩니다. 생성된 타입이 `@Serializable`과 `LocalDate`를 공개 API에 노출하므로 소비자의 컴파일 클래스패스에는 포함되지 않습니다. 본 PR 범위 밖이라 별도 논의가 필요합니다.
