### PR TITLE
[student] 정보 수정 요청 및 로그인 강제 수정 추가

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeSubmitReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeSubmitReqDto.kt
@@ -2,6 +2,8 @@ package team.themoment.datagsm.common.domain.oauth.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
@@ -17,4 +19,24 @@ data class OauthAuthorizeSubmitReqDto(
     @param:Schema(description = "인증 상태 토큰", example = "abc123-def456-...")
     @field:NotBlank(message = "인증 상태 토큰은 필수입니다.")
     val token: String,
+    @field:Min(value = 1)
+    @field:Max(value = 3)
+    @param:Schema(description = "학년 (1-3, 정보 수정 요청 해소용)", example = "1", minimum = "1", maximum = "3")
+    val studentGrade: Int? = null,
+    @field:Min(value = 1)
+    @field:Max(value = 4)
+    @param:Schema(description = "반 (1-4, 정보 수정 요청 해소용)", example = "1", minimum = "1", maximum = "4")
+    val studentClass: Int? = null,
+    @field:Min(value = 1)
+    @field:Max(value = 18)
+    @param:Schema(description = "번호 (1-18, 정보 수정 요청 해소용)", example = "1", minimum = "1", maximum = "18")
+    val studentNumber: Int? = null,
+    @field:Min(value = 201)
+    @field:Max(value = 518)
+    @param:Schema(description = "기숙사 호실 (201-518, 정보 수정 요청 해소용)", example = "301", minimum = "201", maximum = "518")
+    val dormitoryRoomNumber: Int? = null,
+    @param:Schema(description = "전공 동아리 ID (정보 수정 요청 해소용)", example = "1")
+    val majorClubId: Long? = null,
+    @param:Schema(description = "자율 동아리 ID (정보 수정 요청 해소용)", example = "3")
+    val autonomousClubId: Long? = null,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/request/QueryStudentDataEditRequestReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/request/QueryStudentDataEditRequestReqDto.kt
@@ -1,0 +1,17 @@
+package team.themoment.datagsm.common.domain.student.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class QueryStudentDataEditRequestReqDto(
+    @param:Schema(description = "이메일", example = "user@gsm.hs.kr")
+    @field:Email(message = "유효한 이메일 형식이어야 합니다.")
+    @field:NotBlank(message = "이메일은 필수입니다.")
+    val email: String,
+    @param:Schema(description = "비밀번호", example = "password123!", minLength = 8, maxLength = 100)
+    @field:NotBlank(message = "비밀번호는 필수입니다.")
+    @field:Size(min = 8, max = 100, message = "비밀번호는 8자 이상 100자 이하여야 합니다.")
+    val password: String,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/request/RequestStudentDataEditReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/request/RequestStudentDataEditReqDto.kt
@@ -1,0 +1,14 @@
+package team.themoment.datagsm.common.domain.student.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotEmpty
+import team.themoment.datagsm.common.domain.student.entity.constant.StudentDataEditField
+
+data class RequestStudentDataEditReqDto(
+    @field:NotEmpty(message = "대상 학생 ID는 최소 1개 이상이어야 합니다.")
+    @param:Schema(description = "정보 수정을 요청할 학생 ID 목록", example = "[1, 2, 3]")
+    val studentIds: List<Long>,
+    @field:NotEmpty(message = "수정 요청 항목은 최소 1개 이상이어야 합니다.")
+    @param:Schema(description = "수정을 요청할 필드 목록", example = "[\"STUDENT_NUMBER\", \"DORMITORY_ROOM_NUMBER\"]")
+    val fields: Set<StudentDataEditField>,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/response/StudentDataEditRequestResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/response/StudentDataEditRequestResDto.kt
@@ -1,0 +1,9 @@
+package team.themoment.datagsm.common.domain.student.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import team.themoment.datagsm.common.domain.student.entity.constant.StudentDataEditField
+
+data class StudentDataEditRequestResDto(
+    @field:Schema(description = "수정이 필요한 필드 목록", example = "[\"STUDENT_NUMBER\", \"DORMITORY_ROOM_NUMBER\"]")
+    val fields: Set<StudentDataEditField>,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/entity/StudentDataEditRequestJpaEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/entity/StudentDataEditRequestJpaEntity.kt
@@ -1,0 +1,46 @@
+package team.themoment.datagsm.common.domain.student.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.DynamicUpdate
+import java.time.LocalDateTime
+
+@Table(
+    name = "tb_student_data_edit_request",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_student_data_edit_request_student_id", columnNames = ["student_id"]),
+    ],
+)
+@Entity
+@DynamicUpdate
+class StudentDataEditRequestJpaEntity {
+    @field:Id
+    @field:GeneratedValue(strategy = GenerationType.IDENTITY)
+    @field:Column(name = "id")
+    var id: Long? = null
+
+    @field:Column(name = "student_id", nullable = false, unique = true)
+    var studentId: Long? = null
+
+    @field:Column(name = "request_student_number", nullable = false)
+    var requestStudentNumber: Boolean = false
+
+    @field:Column(name = "request_dormitory_room_number", nullable = false)
+    var requestDormitoryRoomNumber: Boolean = false
+
+    @field:Column(name = "request_major_club", nullable = false)
+    var requestMajorClub: Boolean = false
+
+    @field:Column(name = "request_autonomous_club", nullable = false)
+    var requestAutonomousClub: Boolean = false
+
+    @field:CreationTimestamp
+    @field:Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime? = null
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/entity/constant/StudentDataEditField.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/entity/constant/StudentDataEditField.kt
@@ -1,0 +1,8 @@
+package team.themoment.datagsm.common.domain.student.entity.constant
+
+enum class StudentDataEditField {
+    STUDENT_NUMBER,
+    DORMITORY_ROOM_NUMBER,
+    MAJOR_CLUB,
+    AUTONOMOUS_CLUB,
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/StudentDataEditRequestJpaRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/repository/StudentDataEditRequestJpaRepository.kt
@@ -1,0 +1,11 @@
+package team.themoment.datagsm.common.domain.student.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import team.themoment.datagsm.common.domain.student.entity.StudentDataEditRequestJpaEntity
+import java.util.Optional
+
+interface StudentDataEditRequestJpaRepository : JpaRepository<StudentDataEditRequestJpaEntity, Long> {
+    fun findByStudentId(studentId: Long): Optional<StudentDataEditRequestJpaEntity>
+
+    fun findAllByStudentIdIn(studentIds: List<Long>): List<StudentDataEditRequestJpaEntity>
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
@@ -20,10 +20,13 @@ import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeSubm
 import team.themoment.datagsm.common.domain.oauth.dto.response.JwkSetResDto
 import team.themoment.datagsm.common.domain.oauth.dto.response.Oauth2TokenResDto
 import team.themoment.datagsm.common.domain.oauth.dto.response.OauthSessionResDto
+import team.themoment.datagsm.common.domain.student.dto.request.QueryStudentDataEditRequestReqDto
+import team.themoment.datagsm.common.domain.student.dto.response.StudentDataEditRequestResDto
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthAuthorizeFlowService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.Oauth2TokenService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryJwkSetService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryOauthSessionService
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryStudentDataEditRequestService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.StartOauthAuthorizeFlowService
 
 @Tag(name = "OAuth", description = "OAuth 인증 관련 API")
@@ -35,6 +38,7 @@ class OauthController(
     val completeOauthAuthorizeFlowService: CompleteOauthAuthorizeFlowService,
     val queryOauthSessionService: QueryOauthSessionService,
     val queryJwkSetService: QueryJwkSetService,
+    val queryStudentDataEditRequestService: QueryStudentDataEditRequestService,
 ) {
     @GetMapping("/authorize")
     @Operation(
@@ -62,11 +66,29 @@ class OauthController(
             ApiResponse(responseCode = "302", description = "외부 서비스로 리다이렉트"),
             ApiResponse(responseCode = "400", description = "세션 만료 또는 잘못된 요청", content = [Content()]),
             ApiResponse(responseCode = "401", description = "인증 실패", content = [Content()]),
+            ApiResponse(responseCode = "422", description = "정보 수정 요청이 해소되지 않아 로그인할 수 없음", content = [Content()]),
         ],
     )
     fun authorizePost(
         @Valid @RequestBody reqDto: OauthAuthorizeSubmitReqDto,
     ): ResponseEntity<Void> = completeOauthAuthorizeFlowService.execute(reqDto)
+
+    @PostMapping("/authorize/data-edit-requirements")
+    @Operation(
+        summary = "정보 수정 필요 항목 조회",
+        description = "로그인이 정보 수정 요청으로 차단된 경우, 자격증명을 재검증한 뒤 입력받아야 할 필드 목록을 조회합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "조회 성공"),
+            ApiResponse(responseCode = "401", description = "인증 실패", content = [Content()]),
+            ApiResponse(responseCode = "403", description = "학생 정보가 연결되지 않은 계정", content = [Content()]),
+            ApiResponse(responseCode = "404", description = "진행 중인 수정 요청이 없음", content = [Content()]),
+        ],
+    )
+    fun queryStudentDataEditRequirements(
+        @Valid @RequestBody reqDto: QueryStudentDataEditRequestReqDto,
+    ): StudentDataEditRequestResDto = queryStudentDataEditRequestService.execute(reqDto)
 
     @GetMapping("/sessions/{token}")
     @Operation(

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryStudentDataEditRequestService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryStudentDataEditRequestService.kt
@@ -1,0 +1,8 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import team.themoment.datagsm.common.domain.student.dto.request.QueryStudentDataEditRequestReqDto
+import team.themoment.datagsm.common.domain.student.dto.response.StudentDataEditRequestResDto
+
+interface QueryStudentDataEditRequestService {
+    fun execute(reqDto: QueryStudentDataEditRequestReqDto): StudentDataEditRequestResDto
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
@@ -1,16 +1,31 @@
 package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatus
 import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
+import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
+import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
+import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
+import team.themoment.datagsm.common.domain.event.dto.payload.StudentEventObject
+import team.themoment.datagsm.common.domain.event.entity.constant.EventType
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeSubmitReqDto
 import team.themoment.datagsm.common.domain.oauth.entity.OauthCodeRedisEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
+import team.themoment.datagsm.common.domain.student.entity.DormitoryRoomNumber
+import team.themoment.datagsm.common.domain.student.entity.StudentDataEditRequestJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.StudentNumber
+import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRequestJpaRepository
+import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthAuthorizeFlowService
 import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
@@ -22,16 +37,21 @@ import java.util.Base64
 @Service
 class CompleteOauthAuthorizeFlowServiceImpl(
     private val accountJpaRepository: AccountJpaRepository,
+    private val studentJpaRepository: StudentJpaRepository,
+    private val clubJpaRepository: ClubJpaRepository,
+    private val studentDataEditRequestJpaRepository: StudentDataEditRequestJpaRepository,
     private val oauthCodeRedisRepository: OauthCodeRedisRepository,
     private val oauthAuthorizeStateRedisRepository: OauthAuthorizeStateRedisRepository,
     private val passwordEncoder: PasswordEncoder,
     private val oauthEnvironment: OauthEnvironment,
     private val oauthClientRateLimitService: OAuthClientRateLimitService,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : CompleteOauthAuthorizeFlowService {
     companion object {
         private val secureRandom = SecureRandom()
     }
 
+    @Transactional
     override fun execute(reqDto: OauthAuthorizeSubmitReqDto): ResponseEntity<Void> {
         val stateEntity =
             oauthAuthorizeStateRedisRepository
@@ -69,6 +89,10 @@ class CompleteOauthAuthorizeFlowServiceImpl(
             throw ExpectedException("아직 승인되지 않은 계정입니다.", HttpStatus.FORBIDDEN)
         }
 
+        if (account.objectType == AccountObjectType.STUDENT && account.objectId != null) {
+            resolveStudentDataEditRequestIfNeeded(account.objectId!!, reqDto)
+        }
+
         val code = generateAuthorizationCode()
 
         val oauthCodeEntity =
@@ -93,6 +117,115 @@ class CompleteOauthAuthorizeFlowServiceImpl(
             .location(URI.create(redirectUrl))
             .build()
     }
+
+    private fun resolveStudentDataEditRequestIfNeeded(
+        studentId: Long,
+        reqDto: OauthAuthorizeSubmitReqDto,
+    ) {
+        val editRequest =
+            studentDataEditRequestJpaRepository
+                .findByStudentId(studentId)
+                .orElse(null) ?: return
+
+        if (!hasAllRequestedFields(editRequest, reqDto)) {
+            throw ExpectedException("정보 수정이 필요합니다. 정보를 수정한 후 다시 로그인해주세요.", HttpStatus.UNPROCESSABLE_ENTITY)
+        }
+
+        val student =
+            studentJpaRepository
+                .findById(studentId)
+                .orElseThrow { ExpectedException("학생을 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
+
+        val old = generateStudentEventObject(student)
+        applyRequestedFields(student, editRequest, reqDto)
+        val new = generateStudentEventObject(student)
+
+        studentDataEditRequestJpaRepository.delete(editRequest)
+
+        applicationEventPublisher.publishEvent(
+            EventDispatchRequested(
+                EventType.STUDENT_UPDATED,
+                EventChangedData(
+                    old = listOf(EventChangeItem(0, old)),
+                    new = listOf(EventChangeItem(0, new)),
+                ),
+            ),
+        )
+    }
+
+    private fun hasAllRequestedFields(
+        editRequest: StudentDataEditRequestJpaEntity,
+        reqDto: OauthAuthorizeSubmitReqDto,
+    ): Boolean {
+        if (editRequest.requestStudentNumber &&
+            (reqDto.studentGrade == null || reqDto.studentClass == null || reqDto.studentNumber == null)
+        ) {
+            return false
+        }
+        if (editRequest.requestDormitoryRoomNumber && reqDto.dormitoryRoomNumber == null) {
+            return false
+        }
+        if (editRequest.requestMajorClub && reqDto.majorClubId == null) {
+            return false
+        }
+        if (editRequest.requestAutonomousClub && reqDto.autonomousClubId == null) {
+            return false
+        }
+        return true
+    }
+
+    private fun applyRequestedFields(
+        student: StudentJpaEntity,
+        editRequest: StudentDataEditRequestJpaEntity,
+        reqDto: OauthAuthorizeSubmitReqDto,
+    ) {
+        val grade = reqDto.studentGrade
+        val classNum = reqDto.studentClass
+        val number = reqDto.studentNumber
+        if (editRequest.requestStudentNumber && grade != null && classNum != null && number != null) {
+            if (studentJpaRepository.existsByStudentNumberAndNotId(grade, classNum, number, student.id!!)) {
+                throw ExpectedException("이미 존재하는 학번입니다.", HttpStatus.CONFLICT)
+            }
+            student.studentNumber = StudentNumber(grade, classNum, number)
+        }
+        if (editRequest.requestDormitoryRoomNumber) {
+            student.dormitoryRoomNumber = DormitoryRoomNumber(reqDto.dormitoryRoomNumber)
+        }
+        val majorClubId = reqDto.majorClubId
+        if (editRequest.requestMajorClub && majorClubId != null) {
+            student.majorClub =
+                clubJpaRepository
+                    .findById(majorClubId)
+                    .orElseThrow { ExpectedException("전공 동아리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
+        }
+        val autonomousClubId = reqDto.autonomousClubId
+        if (editRequest.requestAutonomousClub && autonomousClubId != null) {
+            student.autonomousClub =
+                clubJpaRepository
+                    .findById(autonomousClubId)
+                    .orElseThrow { ExpectedException("자율 동아리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
+        }
+    }
+
+    private fun generateStudentEventObject(student: StudentJpaEntity): StudentEventObject =
+        StudentEventObject(
+            studentId = student.id!!,
+            name = student.name,
+            email = student.email,
+            sex = student.sex.name,
+            grade = student.studentNumber?.studentGrade,
+            classNum = student.studentNumber?.studentClass,
+            number = student.studentNumber?.studentNumber,
+            studentNumber = student.studentNumber?.fullStudentNumber,
+            major = student.major?.name,
+            specialty = student.specialty,
+            role = student.role.name,
+            dormitoryFloor = student.dormitoryRoomNumber?.dormitoryRoomFloor,
+            dormitoryRoom = student.dormitoryRoomNumber?.dormitoryRoomNumber,
+            majorClubName = student.majorClub?.name,
+            autonomousClubName = student.autonomousClub?.name,
+            githubId = student.githubId,
+        )
 
     private fun generateAuthorizationCode(): String =
         Base64

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryStudentDataEditRequestServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryStudentDataEditRequestServiceImpl.kt
@@ -1,0 +1,50 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
+
+import org.springframework.http.HttpStatus
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
+import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
+import team.themoment.datagsm.common.domain.student.dto.request.QueryStudentDataEditRequestReqDto
+import team.themoment.datagsm.common.domain.student.dto.response.StudentDataEditRequestResDto
+import team.themoment.datagsm.common.domain.student.entity.constant.StudentDataEditField
+import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRequestJpaRepository
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryStudentDataEditRequestService
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class QueryStudentDataEditRequestServiceImpl(
+    private val accountJpaRepository: AccountJpaRepository,
+    private val studentDataEditRequestJpaRepository: StudentDataEditRequestJpaRepository,
+    private val passwordEncoder: PasswordEncoder,
+) : QueryStudentDataEditRequestService {
+    @Transactional(readOnly = true)
+    override fun execute(reqDto: QueryStudentDataEditRequestReqDto): StudentDataEditRequestResDto {
+        val account =
+            accountJpaRepository
+                .findByEmail(reqDto.email)
+                .orElseThrow { ExpectedException("이메일 또는 비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED) }
+
+        if (!passwordEncoder.matches(reqDto.password, account.password)) {
+            throw ExpectedException("이메일 또는 비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED)
+        }
+
+        if (account.objectType != AccountObjectType.STUDENT || account.objectId == null) {
+            throw ExpectedException("학생 정보가 연결되지 않은 계정입니다.", HttpStatus.FORBIDDEN)
+        }
+
+        val editRequest =
+            studentDataEditRequestJpaRepository
+                .findByStudentId(account.objectId!!)
+                .orElseThrow { ExpectedException("진행 중인 정보 수정 요청이 없습니다.", HttpStatus.NOT_FOUND) }
+
+        val fields = mutableSetOf<StudentDataEditField>()
+        if (editRequest.requestStudentNumber) fields.add(StudentDataEditField.STUDENT_NUMBER)
+        if (editRequest.requestDormitoryRoomNumber) fields.add(StudentDataEditField.DORMITORY_ROOM_NUMBER)
+        if (editRequest.requestMajorClub) fields.add(StudentDataEditField.MAJOR_CLUB)
+        if (editRequest.requestAutonomousClub) fields.add(StudentDataEditField.AUTONOMOUS_CLUB)
+
+        return StudentDataEditRequestResDto(fields = fields)
+    }
+}

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
@@ -11,17 +11,25 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import org.springframework.security.crypto.password.PasswordEncoder
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatus
 import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
+import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeSubmitReqDto
 import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
 import team.themoment.datagsm.common.domain.oauth.entity.OauthCodeRedisEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
+import team.themoment.datagsm.common.domain.student.entity.StudentDataEditRequestJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.constant.Sex
+import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRequestJpaRepository
+import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.common.global.dto.internal.RateLimitConsumeResult
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.CompleteOauthAuthorizeFlowServiceImpl
@@ -33,20 +41,28 @@ class CompleteOauthAuthorizeFlowServiceTest :
     DescribeSpec({
 
         val mockAccountJpaRepository = mockk<AccountJpaRepository>()
+        val mockStudentJpaRepository = mockk<StudentJpaRepository>()
+        val mockClubJpaRepository = mockk<ClubJpaRepository>()
+        val mockStudentDataEditRequestJpaRepository = mockk<StudentDataEditRequestJpaRepository>(relaxed = true)
         val mockOauthCodeRedisRepository = mockk<OauthCodeRedisRepository>(relaxed = true)
         val mockOauthAuthorizeStateRedisRepository = mockk<OauthAuthorizeStateRedisRepository>(relaxed = true)
         val mockPasswordEncoder = mockk<PasswordEncoder>()
         val mockOauthEnvironment = mockk<OauthEnvironment>()
         val mockOauthClientRateLimitService = mockk<OAuthClientRateLimitService>()
+        val mockApplicationEventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
 
         val completeOauthAuthorizeFlowService =
             CompleteOauthAuthorizeFlowServiceImpl(
                 mockAccountJpaRepository,
+                mockStudentJpaRepository,
+                mockClubJpaRepository,
+                mockStudentDataEditRequestJpaRepository,
                 mockOauthCodeRedisRepository,
                 mockOauthAuthorizeStateRedisRepository,
                 mockPasswordEncoder,
                 mockOauthEnvironment,
                 mockOauthClientRateLimitService,
+                mockApplicationEventPublisher,
             )
 
         afterEach {
@@ -321,6 +337,129 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         exception.statusCode shouldBe HttpStatus.FORBIDDEN
 
                         verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                    }
+                }
+
+                context("미해소 정보 수정 요청이 있고 수정 필드 없이 로그인할 때") {
+                    val reqDto =
+                        OauthAuthorizeSubmitReqDto(
+                            email = testEmail,
+                            password = "password123!",
+                            token = testToken,
+                        )
+
+                    val studentAccount =
+                        AccountJpaEntity().apply {
+                            id = 3L
+                            email = testEmail
+                            password = "hashedPassword"
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+
+                    val editRequest =
+                        StudentDataEditRequestJpaEntity().apply {
+                            studentId = 10L
+                            requestStudentNumber = true
+                        }
+
+                    val mockStateEntity =
+                        OauthAuthorizeStateRedisEntity(
+                            token = testToken,
+                            clientId = testClientId,
+                            redirectUri = testRedirectUri,
+                            state = "random-state",
+                            codeChallenge = "challenge",
+                            codeChallengeMethod = "S256",
+                            scopes = setOf("self:read"),
+                            ttl = 600,
+                        )
+
+                    beforeEach {
+                        every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns Optional.of(mockStateEntity)
+                        every { mockAccountJpaRepository.findByEmail(testEmail) } returns Optional.of(studentAccount)
+                        every { mockPasswordEncoder.matches("password123!", studentAccount.password) } returns true
+                        every { mockStudentDataEditRequestJpaRepository.findByStudentId(10L) } returns Optional.of(editRequest)
+                    }
+
+                    it("UNPROCESSABLE_ENTITY ExpectedException 예외가 발생해야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                completeOauthAuthorizeFlowService.execute(reqDto)
+                            }
+
+                        exception.message shouldBe "정보 수정이 필요합니다. 정보를 수정한 후 다시 로그인해주세요."
+                        exception.statusCode shouldBe HttpStatus.UNPROCESSABLE_ENTITY
+
+                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                    }
+                }
+
+                context("미해소 정보 수정 요청이 있고 요청된 필드를 채워 로그인할 때") {
+                    val reqDto =
+                        OauthAuthorizeSubmitReqDto(
+                            email = testEmail,
+                            password = "password123!",
+                            token = testToken,
+                            studentGrade = 2,
+                            studentClass = 1,
+                            studentNumber = 5,
+                        )
+
+                    val studentAccount =
+                        AccountJpaEntity().apply {
+                            id = 3L
+                            email = testEmail
+                            password = "hashedPassword"
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+
+                    val editRequest =
+                        StudentDataEditRequestJpaEntity().apply {
+                            studentId = 10L
+                            requestStudentNumber = true
+                        }
+
+                    val mockStudent =
+                        StudentJpaEntity().apply {
+                            id = 10L
+                            name = "홍길동"
+                            email = testEmail
+                            sex = Sex.MAN
+                        }
+
+                    val mockStateEntity =
+                        OauthAuthorizeStateRedisEntity(
+                            token = testToken,
+                            clientId = testClientId,
+                            redirectUri = testRedirectUri,
+                            state = "random-state",
+                            codeChallenge = "challenge",
+                            codeChallengeMethod = "S256",
+                            scopes = setOf("self:read"),
+                            ttl = 600,
+                        )
+
+                    beforeEach {
+                        every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns Optional.of(mockStateEntity)
+                        every { mockAccountJpaRepository.findByEmail(testEmail) } returns Optional.of(studentAccount)
+                        every { mockPasswordEncoder.matches("password123!", studentAccount.password) } returns true
+                        every { mockStudentDataEditRequestJpaRepository.findByStudentId(10L) } returns Optional.of(editRequest)
+                        every { mockStudentJpaRepository.findById(10L) } returns Optional.of(mockStudent)
+                        every { mockStudentJpaRepository.existsByStudentNumberAndNotId(2, 1, 5, 10L) } returns false
+                        every { mockOauthCodeRedisRepository.save(any()) } answers { firstArg() }
+                    }
+
+                    it("정보가 수정되고 302 리다이렉트 ResponseEntity가 반환되어야 한다") {
+                        val response = completeOauthAuthorizeFlowService.execute(reqDto)
+
+                        response.statusCode shouldBe HttpStatus.FOUND
+                        mockStudent.studentNumber?.studentGrade shouldBe 2
+                        mockStudent.studentNumber?.studentClass shouldBe 1
+                        mockStudent.studentNumber?.studentNumber shouldBe 5
+
+                        verify(exactly = 1) { mockStudentDataEditRequestJpaRepository.delete(editRequest) }
                     }
                 }
             }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/controller/StudentController.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/controller/StudentController.kt
@@ -22,6 +22,7 @@ import org.springframework.web.multipart.MultipartFile
 import team.themoment.datagsm.common.domain.student.dto.request.BatchOperationReqDto
 import team.themoment.datagsm.common.domain.student.dto.request.CreateStudentReqDto
 import team.themoment.datagsm.common.domain.student.dto.request.QueryStudentReqDto
+import team.themoment.datagsm.common.domain.student.dto.request.RequestStudentDataEditReqDto
 import team.themoment.datagsm.common.domain.student.dto.request.UpdateStudentReqDto
 import team.themoment.datagsm.common.domain.student.dto.request.UpdateStudentStatusReqDto
 import team.themoment.datagsm.common.domain.student.dto.response.GraduateStudentResDto
@@ -40,6 +41,7 @@ import team.themoment.datagsm.web.domain.student.service.ModifyStudentExcelServi
 import team.themoment.datagsm.web.domain.student.service.ModifyStudentService
 import team.themoment.datagsm.web.domain.student.service.ModifyStudentStatusService
 import team.themoment.datagsm.web.domain.student.service.QueryStudentService
+import team.themoment.datagsm.web.domain.student.service.RequestStudentDataEditService
 import team.themoment.datagsm.web.domain.student.service.WithdrawStudentService
 
 @Tag(name = "Student", description = "학생 관련 API")
@@ -58,6 +60,7 @@ class StudentController(
     private val batchOperationService: BatchOperationService,
     private val modifyMySpecialtyService: ModifyMySpecialtyService,
     private val modifyMyGithubIdService: ModifyMyGithubIdService,
+    private val requestStudentDataEditService: RequestStudentDataEditService,
 ) {
     @Operation(summary = "학생 정보 조회", description = "필터 조건에 맞는 학생 정보를 조회합니다.")
     @ApiResponses(
@@ -213,5 +216,20 @@ class StudentController(
         @RequestBody @Valid reqDto: UpdateMyGithubIdReqDto,
     ) {
         modifyMyGithubIdService.execute(reqDto)
+    }
+
+    @Operation(summary = "학생 정보 수정 요청 등록", description = "선택한 학생들에게 지정한 필드에 대한 정보 수정 요청을 등록합니다. 요청된 필드는 즉시 초기화됩니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "요청 등록 성공"),
+            ApiResponse(responseCode = "400", description = "잘못된 요청 (검증 실패)", content = [Content()]),
+            ApiResponse(responseCode = "404", description = "존재하지 않는 학생이 포함됨", content = [Content()]),
+        ],
+    )
+    @PostMapping("/data-edit-requests")
+    fun requestStudentDataEdit(
+        @RequestBody @Valid reqDto: RequestStudentDataEditReqDto,
+    ) {
+        requestStudentDataEditService.execute(reqDto)
     }
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/RequestStudentDataEditService.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/RequestStudentDataEditService.kt
@@ -1,0 +1,7 @@
+package team.themoment.datagsm.web.domain.student.service
+
+import team.themoment.datagsm.common.domain.student.dto.request.RequestStudentDataEditReqDto
+
+interface RequestStudentDataEditService {
+    fun execute(reqDto: RequestStudentDataEditReqDto)
+}

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/RequestStudentDataEditServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/student/service/impl/RequestStudentDataEditServiceImpl.kt
@@ -1,0 +1,115 @@
+package team.themoment.datagsm.web.domain.student.service.impl
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.event.dto.internal.EventDispatchRequested
+import team.themoment.datagsm.common.domain.event.dto.payload.EventChangeItem
+import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
+import team.themoment.datagsm.common.domain.event.dto.payload.StudentEventObject
+import team.themoment.datagsm.common.domain.event.entity.constant.EventType
+import team.themoment.datagsm.common.domain.student.dto.request.RequestStudentDataEditReqDto
+import team.themoment.datagsm.common.domain.student.entity.StudentDataEditRequestJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
+import team.themoment.datagsm.common.domain.student.entity.constant.StudentDataEditField
+import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRequestJpaRepository
+import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
+import team.themoment.datagsm.web.domain.student.service.RequestStudentDataEditService
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class RequestStudentDataEditServiceImpl(
+    private val studentJpaRepository: StudentJpaRepository,
+    private val studentDataEditRequestJpaRepository: StudentDataEditRequestJpaRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) : RequestStudentDataEditService {
+    @Transactional
+    override fun execute(reqDto: RequestStudentDataEditReqDto) {
+        val students = studentJpaRepository.findAllById(reqDto.studentIds)
+
+        if (students.size != reqDto.studentIds.toSet().size) {
+            throw ExpectedException("존재하지 않는 학생이 포함되어 있습니다.", HttpStatus.NOT_FOUND)
+        }
+
+        val olds =
+            students.mapIndexed { index, student ->
+                EventChangeItem(index, generateStudentEventObject(student))
+            }
+
+        students.forEach { student -> applyFieldReset(student, reqDto.fields) }
+
+        val existingRequests =
+            studentDataEditRequestJpaRepository
+                .findAllByStudentIdIn(students.mapNotNull { it.id })
+                .associateBy { it.studentId }
+
+        students.forEach { student ->
+            val request = existingRequests[student.id] ?: StudentDataEditRequestJpaEntity().apply { studentId = student.id }
+            mergeRequestedFields(request, reqDto.fields)
+            studentDataEditRequestJpaRepository.save(request)
+        }
+
+        val news =
+            students.mapIndexed { index, student ->
+                EventChangeItem(index, generateStudentEventObject(student))
+            }
+
+        if (olds.isNotEmpty()) {
+            applicationEventPublisher.publishEvent(
+                EventDispatchRequested(
+                    EventType.STUDENT_UPDATED,
+                    EventChangedData(old = olds, new = news),
+                ),
+            )
+        }
+    }
+
+    private fun applyFieldReset(
+        student: StudentJpaEntity,
+        fields: Set<StudentDataEditField>,
+    ) {
+        fields.forEach { field ->
+            when (field) {
+                StudentDataEditField.STUDENT_NUMBER -> student.studentNumber = null
+                StudentDataEditField.DORMITORY_ROOM_NUMBER -> student.dormitoryRoomNumber = null
+                StudentDataEditField.MAJOR_CLUB -> student.majorClub = null
+                StudentDataEditField.AUTONOMOUS_CLUB -> student.autonomousClub = null
+            }
+        }
+    }
+
+    private fun mergeRequestedFields(
+        request: StudentDataEditRequestJpaEntity,
+        fields: Set<StudentDataEditField>,
+    ) {
+        fields.forEach { field ->
+            when (field) {
+                StudentDataEditField.STUDENT_NUMBER -> request.requestStudentNumber = true
+                StudentDataEditField.DORMITORY_ROOM_NUMBER -> request.requestDormitoryRoomNumber = true
+                StudentDataEditField.MAJOR_CLUB -> request.requestMajorClub = true
+                StudentDataEditField.AUTONOMOUS_CLUB -> request.requestAutonomousClub = true
+            }
+        }
+    }
+
+    private fun generateStudentEventObject(student: StudentJpaEntity): StudentEventObject =
+        StudentEventObject(
+            studentId = student.id!!,
+            name = student.name,
+            email = student.email,
+            sex = student.sex.name,
+            grade = student.studentNumber?.studentGrade,
+            classNum = student.studentNumber?.studentClass,
+            number = student.studentNumber?.studentNumber,
+            studentNumber = student.studentNumber?.fullStudentNumber,
+            major = student.major?.name,
+            specialty = student.specialty,
+            role = student.role.name,
+            dormitoryFloor = student.dormitoryRoomNumber?.dormitoryRoomFloor,
+            dormitoryRoom = student.dormitoryRoomNumber?.dormitoryRoomNumber,
+            majorClubName = student.majorClub?.name,
+            autonomousClubName = student.autonomousClub?.name,
+            githubId = student.githubId,
+        )
+}


### PR DESCRIPTION
## 개요

관리자가 학번, 기숙사 호실, 전공동아리, 자율동아리 4가지 항목에 대해 학생들에게 정보 수정을 요청하고, 요청이 해소되지 않은 학생은 로그인 시 자격증명만으로는 통과할 수 없도록 강제하는 기능을 추가하였습니다.

## 본문

### 관리자 정보 수정 요청 등록

- `POST /v1/students/data-edit-requests`로 대상 학생 ID 목록과 수정 요청 필드를 받아 등록합니다.
- 요청된 필드는 `RequestStudentDataEditServiceImpl`에서 즉시 `null`로 초기화되며, `StudentDataEditRequestJpaEntity`에 요청 상태를 영구 저장합니다.
- 존재하지 않는 학생 ID가 섞여 있으면 `404`로 거부하여 부분 처리가 조용히 발생하지 않도록 하였습니다.

### 로그인 시 강제 수정

- `POST /v1/oauth/authorize`(`CompleteOauthAuthorizeFlowServiceImpl`)에서 자격증명 검증 이후, 학생 계정에 미해소된 정보 수정 요청이 있는지 확인합니다.
- 요청에 필요한 필드가 함께 전달되지 않으면 `422 UNPROCESSABLE_ENTITY`로 로그인을 차단합니다.
- 필요한 필드가 모두 채워져 있으면 같은 트랜잭션에서 학생 정보를 갱신하고 요청을 해소한 뒤 정상 로그인(`302` 리다이렉트)을 진행합니다.
- `OauthAuthorizeSubmitReqDto`에 학번/기숙사 호실/전공·자율 동아리 필드를 선택값으로 추가하였고, `UpdateStudentReqDto`와 동일한 범위 검증(`@Min`/`@Max`)을 적용하였습니다.

### 필요 필드 조회

- `POST /v1/oauth/authorize/data-edit-requirements`로 이메일과 비밀번호를 재검증한 뒤 입력이 필요한 필드 목록을 반환합니다.
- 인증 없이 이메일만으로 계정 존재 여부와 미기입 개인정보를 유추할 수 있는 문제를 막기 위해 `GET` + `email` 쿼리 대신 `POST` + 비밀번호 검증 방식으로 설계하였습니다.

### 기타

- 신규 쓰기 서비스는 모두 `EventDispatchRequested(STUDENT_UPDATED, ...)`를 발행하여 `EventDispatchConventionTest`를 통과합니다.
- `CompleteOauthAuthorizeFlowServiceTest`에 미해소 요청 차단(`422`) 및 통합 수정 로그인 케이스를 추가하였습니다.

## 테스트

- `datagsm-common`, `datagsm-web`, `datagsm-oauth-authorization` 3개 모듈 전체 테스트(470개) 통과
- `ktlintFormat` 통과
