### PR TITLE
[global] 자동 리뷰어에서 `snowykte0426` 제외

### DIFF
--- a/.github/workflows/datagsm-prod-ci.yaml
+++ b/.github/workflows/datagsm-prod-ci.yaml
@@ -78,7 +78,7 @@ jobs:
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-label "waiting for review:검토 대기"
           gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-assignee "$PR_AUTHOR"
-          ALL_REVIEWERS="wwwcomcomcomcom,ZaMan0806,hongjm0912,snowykte0426"
+          ALL_REVIEWERS="wwwcomcomcomcom,ZaMan0806,hongjm0912"
           REVIEWERS=$(echo "$ALL_REVIEWERS" | tr ',' '\n' | grep -v "^${PR_AUTHOR}$" | tr '\n' ',' | sed 's/,$//')
           if [ -n "$REVIEWERS" ]; then
             gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer "$REVIEWERS"

--- a/.github/workflows/datagsm-stage-ci.yaml
+++ b/.github/workflows/datagsm-stage-ci.yaml
@@ -76,7 +76,7 @@ jobs:
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-label "waiting for review:검토 대기"
           gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-assignee "$PR_AUTHOR"
-          ALL_REVIEWERS="wwwcomcomcomcom,ZaMan0806,hongjm0912,snowykte0426"
+          ALL_REVIEWERS="wwwcomcomcomcom,ZaMan0806,hongjm0912"
           REVIEWERS=$(echo "$ALL_REVIEWERS" | tr ',' '\n' | grep -v "^${PR_AUTHOR}$" | tr '\n' ',' | sed 's/,$//')
           if [ -n "$REVIEWERS" ]; then
             gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer "$REVIEWERS"


### PR DESCRIPTION
## 개요

`stage-ci`, `prod-ci` 워크플로우의 자동 리뷰어 목록에서 `snowykte0426`을 제외하였습니다.

## 본문

PR 생성 시 `setup-pr-metadata` 잡에서 `ALL_REVIEWERS` 목록을 기반으로 작성자를 제외한 나머지 인원을 자동으로 리뷰어에 등록하는데, 이 목록에서 `snowykte0426`을 제거하였습니다.

- `.github/workflows/datagsm-stage-ci.yaml`의 `ALL_REVIEWERS` 값 수정
- `.github/workflows/datagsm-prod-ci.yaml`의 `ALL_REVIEWERS` 값 수정
