### PR TITLE
[club] autoSizeColumn 제거, 고정 폭 적용

### DIFF
--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/CreateClubExcelServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/CreateClubExcelServiceImpl.kt
@@ -30,6 +30,17 @@ class CreateClubExcelServiceImpl(
         private const val ABOLISHED_YEAR_COL_IDX = 5
 
         private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+
+        // 문자 단위 폭 * 256. autoSizeColumn(AWT 폰트 렌더링 기반 실측)의 CPU 비용을 피하기 위한 고정값.
+        private val COLUMN_WIDTHS =
+            mapOf(
+                CLUB_NAME_COL_IDX to 20 * 256,
+                CLUB_TYPE_COL_IDX to 14 * 256,
+                LEADER_COL_IDX to 16 * 256,
+                FOUNDED_YEAR_COL_IDX to 12 * 256,
+                STATUS_COL_IDX to 12 * 256,
+                ABOLISHED_YEAR_COL_IDX to 12 * 256,
+            )
     }
 
     @Transactional(readOnly = true)
@@ -62,9 +73,7 @@ class CreateClubExcelServiceImpl(
                 }
             }
 
-            for (i in 0..ABOLISHED_YEAR_COL_IDX) {
-                sheet.autoSizeColumn(i)
-            }
+            COLUMN_WIDTHS.forEach { (colIdx, width) -> sheet.setColumnWidth(colIdx, width) }
 
             val byteArrayFile =
                 ByteArrayOutputStream().use { outputStream ->

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/CreateClubExcelServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/club/service/impl/CreateClubExcelServiceImpl.kt
@@ -32,10 +32,11 @@ class CreateClubExcelServiceImpl(
         private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
 
         // 문자 단위 폭 * 256. autoSizeColumn(AWT 폰트 렌더링 기반 실측)의 CPU 비용을 피하기 위한 고정값.
+        // 한글은 기본 폰트 기준 반각 문자 대비 약 2배 폭을 차지하므로 한글 컬럼은 여유 있게 설정한다.
         private val COLUMN_WIDTHS =
             mapOf(
-                CLUB_NAME_COL_IDX to 20 * 256,
-                CLUB_TYPE_COL_IDX to 14 * 256,
+                CLUB_NAME_COL_IDX to 40 * 256, // name 컬럼 최대 50자(DB length) 중 한글 20자 기준
+                CLUB_TYPE_COL_IDX to 18 * 256, // AUTONOMOUS_CLUB(15자) 수용
                 LEADER_COL_IDX to 16 * 256,
                 FOUNDED_YEAR_COL_IDX to 12 * 256,
                 STATUS_COL_IDX to 12 * 256,


### PR DESCRIPTION
## 개요

`CreateClubExcelServiceImpl`의 동아리 엑셀 생성 로직에서 `autoSizeColumn` 호출을 제거하고 고정 컬럼 폭(`setColumnWidth`)으로 대체하였습니다.

## 본문

`autoSizeColumn`은 AWT 폰트 렌더링을 이용해 컬럼별로 전체 행을 순회하며 셀 너비를 실측하는 고비용 연산입니다. 동아리 엑셀은 컬럼 구성이 고정되어 있어 자동 폭 계산이 굳이 필요하지 않다고 판단하여, 각 컬럼에 적절한 고정 폭을 지정하는 방식으로 변경하였습니다.

동일한 항목을 다루는 `CreateStudentExcelServiceImpl`에는 원래 `autoSizeColumn` 호출이 없었으며, 프로젝트 전체를 검색한 결과 이번에 수정한 `CreateClubExcelServiceImpl`이 유일한 사용처였습니다.

POI `XSSFWorkbook` 생성 및 직렬화만 분리하여 측정한 결과는 다음과 같습니다.

| 행 수 | `autoSizeColumn` | `setColumnWidth` | 개선 배수 |
|---|---|---|---|
| 30 | 11.56ms | 4.14ms | 2.79배 |
| 100 | 13.95ms | 4.24ms | 3.29배 |
| 500 | 46.03ms | 14.28ms | 3.22배 |

절대 시간 자체는 크지 않아 전체 API 응답 시간(DB 조회, 네트워크 전송 포함) 대비 체감 개선은 제한적일 수 있으나, 불필요한 CPU 연산을 제거하여 확인 가능한 성능 이득을 확보하였습니다.

기존 `CreateClubExcelServiceTest` 테스트가 정상 통과함을 확인하였습니다.
