### PR TITLE
[global] docker가 있는 인스턴스 실행 시 기존 컨테이너 삭제 방지

### DIFF
--- a/scripts/deploy/stage-deploy.sh
+++ b/scripts/deploy/stage-deploy.sh
@@ -10,7 +10,7 @@ echo "> Stopping and removing existing containers..."
 docker compose -f compose.stage.yaml down
 
 echo "> Cleaning up unused Docker resources..."
-docker system prune -a --volumes -f
+docker system prune -a -f
 
 echo "> Building and starting containers..."
 docker compose -f compose.stage.yaml up -d --build


### PR DESCRIPTION
## 개요

AWS의 EC2를 주기적으로 재부팅함에 따라 `docker system prune -a --volumes -f` 명령어로 인해 mysql, redis 컨테이너가 어떤 이유로든 꺼져있다면 그 볼륨이 미사용으로 판단되어 데이터베이스 데이터가 통째로 날라갑니다.

그래서 볼륨을 건드리지 않도록 `docker system prune -a -f`로 수정하였습니다.