### PR TITLE
[project] ProjectJpaEntity 리포지토리·기술 스택 추가

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/dto/payload/ProjectEventObject.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/event/dto/payload/ProjectEventObject.kt
@@ -20,4 +20,8 @@ data class ProjectEventObject(
     val club: EventClubRef?,
     @field:JsonProperty("participants")
     val participants: List<EventStudentRef>,
+    @field:JsonProperty("repositories")
+    val repositories: List<String>,
+    @field:JsonProperty("tech_stacks")
+    val techStacks: List<String>,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/request/ProjectReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/request/ProjectReqDto.kt
@@ -27,4 +27,16 @@ data class ProjectReqDto(
     @field:Positive
     @param:Schema(description = "프로젝트 종료 연도 (ENDED 시 설정)", example = "2025")
     val endYear: Int? = null,
+    @field:Size(max = 20)
+    @param:Schema(description = "프로젝트 리포지토리 URL 목록", example = "[\"https://github.com/team/repo\"]")
+    val repositories: List<
+        @Size(max = 300)
+        String,
+    > = emptyList(),
+    @field:Size(max = 20)
+    @param:Schema(description = "프로젝트 기술 스택 목록", example = "[\"Kotlin\", \"Spring Boot\"]")
+    val techStacks: List<
+        @Size(max = 50)
+        String,
+    > = emptyList(),
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/response/ProjectResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/response/ProjectResDto.kt
@@ -24,4 +24,8 @@ data class ProjectResDto(
     val club: ClubSummaryDto?,
     @field:Schema(description = "프로젝트 참가자 목록")
     val participants: List<ParticipantInfoDto>,
+    @field:Schema(description = "프로젝트 리포지토리 URL 목록")
+    val repositories: List<String>,
+    @field:Schema(description = "프로젝트 기술 스택 목록")
+    val techStacks: List<String>,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/entity/ProjectJpaEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/entity/ProjectJpaEntity.kt
@@ -1,9 +1,12 @@
 package team.themoment.datagsm.common.domain.project.entity
 
+import jakarta.persistence.CollectionTable
 import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -53,4 +56,14 @@ class ProjectJpaEntity {
         inverseJoinColumns = [JoinColumn(name = "student_id")],
     )
     var participants: MutableSet<StudentJpaEntity> = mutableSetOf()
+
+    @field:ElementCollection(fetch = FetchType.LAZY)
+    @field:CollectionTable(name = "tb_project_repository", joinColumns = [JoinColumn(name = "project_id")])
+    @field:Column(name = "repository_url", nullable = false, length = 300)
+    var repositories: MutableSet<String> = mutableSetOf()
+
+    @field:ElementCollection(fetch = FetchType.LAZY)
+    @field:CollectionTable(name = "tb_project_tech_stack", joinColumns = [JoinColumn(name = "project_id")])
+    @field:Column(name = "tech_stack_name", nullable = false, length = 50)
+    var techStacks: MutableSet<String> = mutableSetOf()
 }

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/impl/ProjectJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/impl/ProjectJpaCustomRepositoryImpl.kt
@@ -63,7 +63,7 @@ class ProjectJpaCustomRepositoryImpl(
                 .limit(pageable.pageSize.toLong())
                 .fetch()
 
-        // 2쿼리: ID IN절로 club + participants 한 번에 fetchJoin
+        // 2쿼리: ID IN절로 club + participants + repositories + techStacks 한 번에 fetchJoin
         val content =
             if (projectIds.isEmpty()) {
                 emptyList()
@@ -73,6 +73,10 @@ class ProjectJpaCustomRepositoryImpl(
                     .leftJoin(projectJpaEntity.club)
                     .fetchJoin()
                     .leftJoin(projectJpaEntity.participants)
+                    .fetchJoin()
+                    .leftJoin(projectJpaEntity.repositories)
+                    .fetchJoin()
+                    .leftJoin(projectJpaEntity.techStacks)
                     .fetchJoin()
                     .where(projectJpaEntity.id.`in`(projectIds))
                     .apply { orderSpecifier?.let { orderBy(it) } }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/CreateProjectServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/CreateProjectServiceImpl.kt
@@ -81,6 +81,8 @@ class CreateProjectServiceImpl(
                 endYear = projectReqDto.endYear
                 this.club = ownerClub
                 this.participants = participants
+                this.repositories = projectReqDto.repositories.toMutableSet()
+                this.techStacks = projectReqDto.techStacks.toMutableSet()
             }
         val savedProjectEntity = projectJpaRepository.save(projectEntity)
 
@@ -114,6 +116,8 @@ class CreateProjectServiceImpl(
                         sex = student.sex,
                     )
                 },
+            repositories = savedProjectEntity.repositories.toList(),
+            techStacks = savedProjectEntity.techStacks.toList(),
         )
     }
 
@@ -128,5 +132,7 @@ class CreateProjectServiceImpl(
             club = project.club?.let { EventClubRef(it.id!!, it.name) },
             participants =
                 project.participants.map { EventStudentRef(it.studentNumber?.fullStudentNumber, it.name) },
+            repositories = project.repositories.toList(),
+            techStacks = project.techStacks.toList(),
         )
 }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/DeleteProjectServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/DeleteProjectServiceImpl.kt
@@ -56,5 +56,7 @@ class DeleteProjectServiceImpl(
             club = project.club?.let { EventClubRef(it.id!!, it.name) },
             participants =
                 project.participants.map { EventStudentRef(it.studentNumber?.fullStudentNumber, it.name) },
+            repositories = project.repositories.toList(),
+            techStacks = project.techStacks.toList(),
         )
 }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/EndProjectServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/EndProjectServiceImpl.kt
@@ -64,5 +64,7 @@ class EndProjectServiceImpl(
             club = project.club?.let { EventClubRef(it.id!!, it.name) },
             participants =
                 project.participants.map { EventStudentRef(it.studentNumber?.fullStudentNumber, it.name) },
+            repositories = project.repositories.toList(),
+            techStacks = project.techStacks.toList(),
         )
 }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/ModifyProjectServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/ModifyProjectServiceImpl.kt
@@ -75,6 +75,8 @@ class ModifyProjectServiceImpl(
         project.startYear = reqDto.startYear
         project.club = ownerClub
         project.participants = newParticipants
+        project.repositories = reqDto.repositories.toMutableSet()
+        project.techStacks = reqDto.techStacks.toMutableSet()
 
         val newObj = generateProjectEventObject(project)
         applicationEventPublisher.publishEvent(
@@ -106,6 +108,8 @@ class ModifyProjectServiceImpl(
                         sex = student.sex,
                     )
                 },
+            repositories = project.repositories.toList(),
+            techStacks = project.techStacks.toList(),
         )
     }
 
@@ -120,5 +124,7 @@ class ModifyProjectServiceImpl(
             club = project.club?.let { EventClubRef(it.id!!, it.name) },
             participants =
                 project.participants.map { EventStudentRef(it.studentNumber?.fullStudentNumber, it.name) },
+            repositories = project.repositories.toList(),
+            techStacks = project.techStacks.toList(),
         )
 }

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/QueryProjectServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/QueryProjectServiceImpl.kt
@@ -52,6 +52,8 @@ class QueryProjectServiceImpl(
                                     sex = student.sex,
                                 )
                             },
+                        repositories = project.repositories.toList(),
+                        techStacks = project.techStacks.toList(),
                     )
                 },
         )

--- a/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/ReactivateProjectServiceImpl.kt
+++ b/datagsm-openapi/src/main/kotlin/team/themoment/datagsm/openapi/domain/project/service/impl/ReactivateProjectServiceImpl.kt
@@ -57,5 +57,7 @@ class ReactivateProjectServiceImpl(
             club = project.club?.let { EventClubRef(it.id!!, it.name) },
             participants =
                 project.participants.map { EventStudentRef(it.studentNumber?.fullStudentNumber, it.name) },
+            repositories = project.repositories.toList(),
+            techStacks = project.techStacks.toList(),
         )
 }

--- a/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/CreateProjectServiceTest.kt
+++ b/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/CreateProjectServiceTest.kt
@@ -2,6 +2,7 @@ package team.themoment.datagsm.openapi.domain.project.service
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.clearAllMocks
@@ -100,6 +101,8 @@ class CreateProjectServiceTest :
                         result.club?.name shouldBe "SW개발동아리"
                         result.club?.type shouldBe ClubType.MAJOR_CLUB
                         result.participants shouldBe emptyList()
+                        result.repositories shouldBe emptyList()
+                        result.techStacks shouldBe emptyList()
 
                         verify(exactly = 1) { mockProjectRepository.existsByName(createRequest.name) }
                         verify(exactly = 1) { mockClubRepository.findById(createRequest.clubId!!) }
@@ -115,6 +118,44 @@ class CreateProjectServiceTest :
                         data.new.size shouldBe 1
                         data.old[0].obj.shouldBeInstanceOf<EmptyEventObject>()
                         data.new[0].obj.shouldBeInstanceOf<ProjectEventObject>()
+                    }
+                }
+
+                context("리포지토리와 기술 스택 정보를 포함하여 생성 요청할 때") {
+                    val createRequest =
+                        ProjectReqDto(
+                            name = "기술스택 프로젝트",
+                            description = "리포지토리와 기술 스택이 있는 프로젝트입니다",
+                            startYear = 2024,
+                            clubId = null,
+                            participantIds = emptyList(),
+                            repositories = listOf("https://github.com/team/repo"),
+                            techStacks = listOf("Kotlin", "Spring Boot"),
+                        )
+
+                    val savedProject =
+                        ProjectJpaEntity().apply {
+                            id = 4L
+                            name = createRequest.name
+                            description = createRequest.description
+                            startYear = createRequest.startYear
+                            status = ProjectStatus.ACTIVE
+                            repositories = createRequest.repositories.toMutableSet()
+                            techStacks = createRequest.techStacks.toMutableSet()
+                        }
+
+                    beforeEach {
+                        every { mockProjectRepository.existsByName(createRequest.name) } returns false
+                        every { mockProjectRepository.save(any()) } returns savedProject
+                    }
+
+                    it("리포지토리와 기술 스택이 포함된 프로젝트가 생성되어야 한다") {
+                        val result = createProjectService.execute(createRequest)
+
+                        result.repositories shouldContainExactlyInAnyOrder listOf("https://github.com/team/repo")
+                        result.techStacks shouldContainExactlyInAnyOrder listOf("Kotlin", "Spring Boot")
+
+                        verify(exactly = 1) { mockProjectRepository.save(any()) }
                     }
                 }
 

--- a/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/ModifyProjectServiceTest.kt
+++ b/datagsm-openapi/src/test/kotlin/team/themoment/datagsm/openapi/domain/project/service/ModifyProjectServiceTest.kt
@@ -2,6 +2,7 @@ package team.themoment.datagsm.openapi.domain.project.service
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks
 import io.mockk.every
@@ -122,6 +123,40 @@ class ModifyProjectServiceTest :
                         data.old.size shouldBe 1
                         data.new.size shouldBe 1
                         (data.new[0].obj as ProjectEventObject).name shouldBe "수정된프로젝트"
+                    }
+                }
+
+                context("리포지토리와 기술 스택을 전체 교체할 때") {
+                    val updateRequest =
+                        ProjectReqDto(
+                            name = "기존프로젝트",
+                            description = "기존 설명",
+                            startYear = 2023,
+                            clubId = 1L,
+                            participantIds = emptyList(),
+                            repositories = listOf("https://github.com/team/new-repo"),
+                            techStacks = listOf("Kotlin"),
+                        )
+
+                    beforeEach {
+                        existingProject.repositories = mutableSetOf("https://github.com/team/old-repo")
+                        existingProject.techStacks = mutableSetOf("Java", "Spring")
+
+                        every { mockProjectRepository.findById(projectId) } returns Optional.of(existingProject)
+                        every {
+                            mockProjectRepository.existsByNameAndIdNot(
+                                updateRequest.name,
+                                projectId,
+                            )
+                        } returns false
+                        every { mockClubRepository.findById(1L) } returns Optional.of(ownerClub)
+                    }
+
+                    it("리포지토리와 기술 스택이 새 값으로 완전히 교체되어야 한다") {
+                        val result = modifyProjectService.execute(projectId, updateRequest)
+
+                        result.repositories shouldContainExactlyInAnyOrder listOf("https://github.com/team/new-repo")
+                        result.techStacks shouldContainExactlyInAnyOrder listOf("Kotlin")
                     }
                 }
 

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/CreateProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/CreateProjectServiceImpl.kt
@@ -83,6 +83,8 @@ class CreateProjectServiceImpl(
                 endYear = projectReqDto.endYear
                 this.club = ownerClub
                 this.participants = participants
+                this.repositories = projectReqDto.repositories.toMutableSet()
+                this.techStacks = projectReqDto.techStacks.toMutableSet()
             }
         val savedProjectEntity = projectJpaRepository.save(projectEntity)
 
@@ -116,6 +118,8 @@ class CreateProjectServiceImpl(
                         sex = student.sex,
                     )
                 },
+            repositories = savedProjectEntity.repositories.toList(),
+            techStacks = savedProjectEntity.techStacks.toList(),
         )
     }
 
@@ -130,5 +134,7 @@ class CreateProjectServiceImpl(
             club = project.club?.let { EventClubRef(it.id!!, it.name) },
             participants =
                 project.participants.map { EventStudentRef(it.studentNumber?.fullStudentNumber, it.name) },
+            repositories = project.repositories.toList(),
+            techStacks = project.techStacks.toList(),
         )
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/DeleteProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/DeleteProjectServiceImpl.kt
@@ -54,5 +54,7 @@ class DeleteProjectServiceImpl(
             club = project.club?.let { EventClubRef(it.id!!, it.name) },
             participants =
                 project.participants.map { EventStudentRef(it.studentNumber?.fullStudentNumber, it.name) },
+            repositories = project.repositories.toList(),
+            techStacks = project.techStacks.toList(),
         )
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/EndProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/EndProjectServiceImpl.kt
@@ -64,5 +64,7 @@ class EndProjectServiceImpl(
             club = project.club?.let { EventClubRef(it.id!!, it.name) },
             participants =
                 project.participants.map { EventStudentRef(it.studentNumber?.fullStudentNumber, it.name) },
+            repositories = project.repositories.toList(),
+            techStacks = project.techStacks.toList(),
         )
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ModifyProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ModifyProjectServiceImpl.kt
@@ -77,6 +77,8 @@ class ModifyProjectServiceImpl(
         project.startYear = reqDto.startYear
         project.club = ownerClub
         project.participants = newParticipants
+        project.repositories = reqDto.repositories.toMutableSet()
+        project.techStacks = reqDto.techStacks.toMutableSet()
 
         val newObj = generateProjectEventObject(project)
         applicationEventPublisher.publishEvent(
@@ -108,6 +110,8 @@ class ModifyProjectServiceImpl(
                         sex = student.sex,
                     )
                 },
+            repositories = project.repositories.toList(),
+            techStacks = project.techStacks.toList(),
         )
     }
 
@@ -122,5 +126,7 @@ class ModifyProjectServiceImpl(
             club = project.club?.let { EventClubRef(it.id!!, it.name) },
             participants =
                 project.participants.map { EventStudentRef(it.studentNumber?.fullStudentNumber, it.name) },
+            repositories = project.repositories.toList(),
+            techStacks = project.techStacks.toList(),
         )
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/QueryProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/QueryProjectServiceImpl.kt
@@ -52,6 +52,8 @@ class QueryProjectServiceImpl(
                                     sex = student.sex,
                                 )
                             },
+                        repositories = project.repositories.toList(),
+                        techStacks = project.techStacks.toList(),
                     )
                 },
         )

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ReactivateProjectServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/project/service/impl/ReactivateProjectServiceImpl.kt
@@ -57,5 +57,7 @@ class ReactivateProjectServiceImpl(
             club = project.club?.let { EventClubRef(it.id!!, it.name) },
             participants =
                 project.participants.map { EventStudentRef(it.studentNumber?.fullStudentNumber, it.name) },
+            repositories = project.repositories.toList(),
+            techStacks = project.techStacks.toList(),
         )
 }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/CreateProjectServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/CreateProjectServiceTest.kt
@@ -2,6 +2,7 @@ package team.themoment.datagsm.web.domain.project.service
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -91,9 +92,49 @@ class CreateProjectServiceTest :
                         result.club?.name shouldBe "SW개발동아리"
                         result.club?.type shouldBe ClubType.MAJOR_CLUB
                         result.participants shouldBe emptyList()
+                        result.repositories shouldBe emptyList()
+                        result.techStacks shouldBe emptyList()
 
                         verify(exactly = 1) { mockProjectRepository.existsByName(createRequest.name) }
                         verify(exactly = 1) { mockClubRepository.findById(createRequest.clubId!!) }
+                        verify(exactly = 1) { mockProjectRepository.save(any()) }
+                    }
+                }
+
+                context("리포지토리와 기술 스택 정보를 포함하여 생성 요청할 때") {
+                    val createRequest =
+                        ProjectReqDto(
+                            name = "기술스택 프로젝트",
+                            description = "리포지토리와 기술 스택이 있는 프로젝트입니다",
+                            startYear = 2024,
+                            clubId = null,
+                            participantIds = emptyList(),
+                            repositories = listOf("https://github.com/team/repo"),
+                            techStacks = listOf("Kotlin", "Spring Boot"),
+                        )
+
+                    val savedProject =
+                        ProjectJpaEntity().apply {
+                            id = 4L
+                            name = createRequest.name
+                            description = createRequest.description
+                            startYear = createRequest.startYear
+                            status = ProjectStatus.ACTIVE
+                            repositories = createRequest.repositories.toMutableSet()
+                            techStacks = createRequest.techStacks.toMutableSet()
+                        }
+
+                    beforeEach {
+                        every { mockProjectRepository.existsByName(createRequest.name) } returns false
+                        every { mockProjectRepository.save(any()) } returns savedProject
+                    }
+
+                    it("리포지토리와 기술 스택이 포함된 프로젝트가 생성되어야 한다") {
+                        val result = createProjectService.execute(createRequest)
+
+                        result.repositories shouldContainExactlyInAnyOrder listOf("https://github.com/team/repo")
+                        result.techStacks shouldContainExactlyInAnyOrder listOf("Kotlin", "Spring Boot")
+
                         verify(exactly = 1) { mockProjectRepository.save(any()) }
                     }
                 }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/ModifyProjectServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/project/service/ModifyProjectServiceTest.kt
@@ -2,6 +2,7 @@ package team.themoment.datagsm.web.domain.project.service
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.justRun
@@ -105,6 +106,40 @@ class ModifyProjectServiceTest :
                             )
                         }
                         verify(exactly = 1) { mockClubRepository.findById(1L) }
+                    }
+                }
+
+                context("리포지토리와 기술 스택을 전체 교체할 때") {
+                    val updateRequest =
+                        ProjectReqDto(
+                            name = "기존프로젝트",
+                            description = "기존 설명",
+                            startYear = 2023,
+                            clubId = 1L,
+                            participantIds = emptyList(),
+                            repositories = listOf("https://github.com/team/new-repo"),
+                            techStacks = listOf("Kotlin"),
+                        )
+
+                    beforeEach {
+                        existingProject.repositories = mutableSetOf("https://github.com/team/old-repo")
+                        existingProject.techStacks = mutableSetOf("Java", "Spring")
+
+                        every { mockProjectRepository.findById(projectId) } returns Optional.of(existingProject)
+                        every {
+                            mockProjectRepository.existsByNameAndIdNot(
+                                updateRequest.name,
+                                projectId,
+                            )
+                        } returns false
+                        every { mockClubRepository.findById(1L) } returns Optional.of(ownerClub)
+                    }
+
+                    it("리포지토리와 기술 스택이 새 값으로 완전히 교체되어야 한다") {
+                        val result = modifyProjectService.execute(projectId, updateRequest)
+
+                        result.repositories shouldContainExactlyInAnyOrder listOf("https://github.com/team/new-repo")
+                        result.techStacks shouldContainExactlyInAnyOrder listOf("Kotlin")
                     }
                 }
 


### PR DESCRIPTION
## 개요

`EveryGSM`에는 존재하지만 `DataGSM`에는 없던 프로젝트 리포지토리 링크와 기술 스택 정보를 추가하였습니다. `ProjectJpaEntity`에 `repositories`, `techStacks` 필드를 신설하고, `datagsm-openapi`, `datagsm-web` 양쪽 API의 `Req`/`ResDto`에 모두 반영하였습니다.

## 본문

`tb_project_repository`, `tb_project_tech_stack` 테이블을 `@ElementCollection` 기반 `MutableSet<String>`으로 매핑하여 `ProjectJpaEntity`에 추가하였습니다. `participants`와 동일하게 `Set` 컬렉션으로 구성하여, `ProjectJpaCustomRepositoryImpl`에서 `club`, `participants`와 함께 세 컬렉션을 동시에 `fetchJoin`하더라도 `MultipleBagFetchException`이 발생하지 않도록 하였습니다.

`ProjectReqDto`에는 `repositories`, `techStacks` 필드를 자유 문자열 목록으로 추가하고 개수·길이 제약(`@Size`)을 적용하였습니다. `ProjectResDto`와 webhook 페이로드인 `ProjectEventObject`에도 동일한 필드를 반영하였습니다.

`datagsm-openapi`, `datagsm-web` 양쪽의 `CreateProjectServiceImpl`, `ModifyProjectServiceImpl`, `QueryProjectServiceImpl`, `EndProjectServiceImpl`, `ReactivateProjectServiceImpl`, `DeleteProjectServiceImpl` 전체에 신규 필드 매핑을 반영하였습니다. `ModifyProjectServiceImpl`은 `PUT` 전체 교체 방식에 맞춰 리포지토리와 기술 스택을 완전히 새 값으로 치환하도록 구현하였습니다.

`CreateProjectServiceTest`, `ModifyProjectServiceTest`에 신규 필드 관련 테스트 케이스를 추가하였습니다. `Set` 컬렉션은 순서를 보장하지 않으므로 관련 검증에는 `shouldContainExactlyInAnyOrder` 매처를 사용하였습니다.

### 관련 이슈

closes #426

### 테스트

- `./gradlew :datagsm-openapi:test :datagsm-web:test` 전체 통과 (openapi 142개, web 361개)
- `./gradlew ktlintCheck` 통과
- `./gradlew build -x test` 전체 모듈 빌드 성공
