### PR TITLE
[oauth] `self_read` 스코프 4개로 세분화

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/internal/ResolvedAccountObject.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/internal/ResolvedAccountObject.kt
@@ -1,12 +1,16 @@
 package team.themoment.datagsm.common.domain.account.dto.internal
 
+import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.project.dto.internal.ProjectSummaryDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
 import team.themoment.datagsm.common.domain.teacher.dto.response.TeacherResDto
 
 /**
- * 계정에 연결된 대상(학생/선생님)을 조회한 결과를 담는 내부 DTO입니다.
+ * 계정에 연결된 대상(학생/선생님)과 그 소속 동아리·참여 프로젝트를 조회한 결과를 담는 내부 DTO입니다.
  */
 data class ResolvedAccountObject(
     val student: StudentResDto?,
     val teacher: TeacherResDto?,
+    val clubs: List<ClubSummaryDto> = emptyList(),
+    val projects: List<ProjectSummaryDto> = emptyList(),
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountInfoResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountInfoResDto.kt
@@ -23,12 +23,12 @@ data class AccountInfoResDto(
     @Deprecated("objectType == STUDENT 으로 대체 예정, 하위 호환을 위해 임시 유지", ReplaceWith("objectType == AccountObjectType.STUDENT"))
     @field:Schema(description = "학생 계정 여부 (Deprecated, objectType == STUDENT 으로 대체 예정)", example = "true", deprecated = true)
     val isStudent: Boolean,
-    @field:Schema(description = "학생 정보 (student_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
+    @field:Schema(description = "학생 정보 (학생인 경우에만 포함)")
     val student: StudentResDto?,
-    @field:Schema(description = "선생님 정보 (student_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
+    @field:Schema(description = "선생님 정보 (선생님인 경우에만 포함)")
     val teacher: TeacherResDto?,
-    @field:Schema(description = "소속 동아리 목록 (club_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
+    @field:Schema(description = "소속 동아리 목록")
     val clubs: List<ClubSummaryDto> = emptyList(),
-    @field:Schema(description = "참여 프로젝트 목록 (project_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
+    @field:Schema(description = "참여 프로젝트 목록")
     val projects: List<ProjectSummaryDto> = emptyList(),
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountInfoResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountInfoResDto.kt
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatus
+import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.project.dto.internal.ProjectSummaryDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
 import team.themoment.datagsm.common.domain.teacher.dto.response.TeacherResDto
 
@@ -21,8 +23,12 @@ data class AccountInfoResDto(
     @Deprecated("objectType == STUDENT 으로 대체 예정, 하위 호환을 위해 임시 유지", ReplaceWith("objectType == AccountObjectType.STUDENT"))
     @field:Schema(description = "학생 계정 여부 (Deprecated, objectType == STUDENT 으로 대체 예정)", example = "true", deprecated = true)
     val isStudent: Boolean,
-    @field:Schema(description = "학생 정보 (학생인 경우에만 포함)")
+    @field:Schema(description = "학생 정보 (student_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
     val student: StudentResDto?,
-    @field:Schema(description = "선생님 정보 (선생님인 경우에만 포함)")
+    @field:Schema(description = "선생님 정보 (student_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
     val teacher: TeacherResDto?,
+    @field:Schema(description = "소속 동아리 목록 (club_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
+    val clubs: List<ClubSummaryDto> = emptyList(),
+    @field:Schema(description = "참여 프로젝트 목록 (project_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
+    val projects: List<ProjectSummaryDto> = emptyList(),
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/resolver/AccountObjectResolver.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/resolver/AccountObjectResolver.kt
@@ -24,7 +24,11 @@ class AccountObjectResolver(
     private val teacherJpaRepository: TeacherJpaRepository,
     private val projectJpaRepository: ProjectJpaRepository,
 ) {
-    fun resolve(account: AccountJpaEntity): ResolvedAccountObject {
+    fun resolve(
+        account: AccountJpaEntity,
+        includeClubs: Boolean = true,
+        includeProjects: Boolean = true,
+    ): ResolvedAccountObject {
         val objectId = account.objectId ?: return ResolvedAccountObject(null, null)
         return when (account.objectType) {
             AccountObjectType.STUDENT -> {
@@ -32,8 +36,8 @@ class AccountObjectResolver(
                 ResolvedAccountObject(
                     student = student?.let { StudentResDto.from(it) },
                     teacher = null,
-                    clubs = student?.let { resolveClubs(it) } ?: emptyList(),
-                    projects = student?.let { resolveProjects(it) } ?: emptyList(),
+                    clubs = if (includeClubs) student?.let { resolveClubs(it) } ?: emptyList() else emptyList(),
+                    projects = if (includeProjects) student?.let { resolveProjects(it) } ?: emptyList() else emptyList(),
                 )
             }
             AccountObjectType.TEACHER ->

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/resolver/AccountObjectResolver.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/resolver/AccountObjectResolver.kt
@@ -5,7 +5,6 @@ import team.themoment.datagsm.common.domain.account.dto.internal.ResolvedAccount
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
-import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.project.dto.internal.ProjectSummaryDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
 import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
@@ -26,8 +25,8 @@ class AccountObjectResolver(
 ) {
     fun resolve(
         account: AccountJpaEntity,
-        includeClubs: Boolean = true,
-        includeProjects: Boolean = true,
+        includeClubs: Boolean = false,
+        includeProjects: Boolean = false,
     ): ResolvedAccountObject {
         val objectId = account.objectId ?: return ResolvedAccountObject(null, null)
         return when (account.objectType) {
@@ -50,14 +49,13 @@ class AccountObjectResolver(
     }
 
     private fun resolveClubs(student: StudentJpaEntity): List<ClubSummaryDto> =
-        listOfNotNull(student.majorClub, student.autonomousClub).map { it.toSummaryDto() }
+        listOfNotNull(student.majorClub, student.autonomousClub).map { ClubSummaryDto.from(it) }
 
     private fun resolveProjects(student: StudentJpaEntity): List<ProjectSummaryDto> =
         projectJpaRepository.findAllByParticipantId(student.id!!).map { it.toSummaryDto() }
 
-    private fun ClubJpaEntity.toSummaryDto() = ClubSummaryDto(id = id!!, name = name, type = type)
-
-    private fun ProjectJpaEntity.toSummaryDto() = ProjectSummaryDto(id = id!!, name = name, status = status, club = club?.toSummaryDto())
+    private fun ProjectJpaEntity.toSummaryDto() =
+        ProjectSummaryDto(id = id!!, name = name, status = status, club = club?.let { ClubSummaryDto.from(it) })
 
     fun resolveAll(accounts: List<AccountJpaEntity>): Map<Long, ResolvedAccountObject> {
         val studentIds =

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/resolver/AccountObjectResolver.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/resolver/AccountObjectResolver.kt
@@ -4,7 +4,13 @@ import org.springframework.stereotype.Component
 import team.themoment.datagsm.common.domain.account.dto.internal.ResolvedAccountObject
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
+import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
+import team.themoment.datagsm.common.domain.project.dto.internal.ProjectSummaryDto
+import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
 import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
+import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.common.domain.teacher.dto.response.TeacherResDto
 import team.themoment.datagsm.common.domain.teacher.repository.TeacherJpaRepository
@@ -16,15 +22,20 @@ import team.themoment.datagsm.common.domain.teacher.repository.TeacherJpaReposit
 class AccountObjectResolver(
     private val studentJpaRepository: StudentJpaRepository,
     private val teacherJpaRepository: TeacherJpaRepository,
+    private val projectJpaRepository: ProjectJpaRepository,
 ) {
     fun resolve(account: AccountJpaEntity): ResolvedAccountObject {
         val objectId = account.objectId ?: return ResolvedAccountObject(null, null)
         return when (account.objectType) {
-            AccountObjectType.STUDENT ->
+            AccountObjectType.STUDENT -> {
+                val student = studentJpaRepository.findById(objectId).orElse(null)
                 ResolvedAccountObject(
-                    student = studentJpaRepository.findById(objectId).map { StudentResDto.from(it) }.orElse(null),
+                    student = student?.let { StudentResDto.from(it) },
                     teacher = null,
+                    clubs = student?.let { resolveClubs(it) } ?: emptyList(),
+                    projects = student?.let { resolveProjects(it) } ?: emptyList(),
                 )
+            }
             AccountObjectType.TEACHER ->
                 ResolvedAccountObject(
                     student = null,
@@ -33,6 +44,16 @@ class AccountObjectResolver(
             null -> ResolvedAccountObject(null, null)
         }
     }
+
+    private fun resolveClubs(student: StudentJpaEntity): List<ClubSummaryDto> =
+        listOfNotNull(student.majorClub, student.autonomousClub).map { it.toSummaryDto() }
+
+    private fun resolveProjects(student: StudentJpaEntity): List<ProjectSummaryDto> =
+        projectJpaRepository.findAllByParticipantId(student.id!!).map { it.toSummaryDto() }
+
+    private fun ClubJpaEntity.toSummaryDto() = ClubSummaryDto(id = id!!, name = name, type = type)
+
+    private fun ProjectJpaEntity.toSummaryDto() = ProjectSummaryDto(id = id!!, name = name, status = status, club = club?.toSummaryDto())
 
     fun resolveAll(accounts: List<AccountJpaEntity>): Map<Long, ResolvedAccountObject> {
         val studentIds =

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/dto/response/OAuthScopeResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/dto/response/OAuthScopeResDto.kt
@@ -3,7 +3,7 @@ package team.themoment.datagsm.common.domain.client.dto.response
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class OAuthScopeResDto(
-    @field:Schema(description = "OAuth 권한 범위 이름", example = "appId:self_read")
+    @field:Schema(description = "OAuth 권한 범위 이름", example = "appId:account_read")
     val scope: String,
     @field:Schema(description = "OAuth 권한 범위 설명", example = "내 정보 조회")
     val description: String,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/constant/OAuthScope.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/constant/OAuthScope.kt
@@ -20,6 +20,12 @@ class OAuthScope(
     override fun hashCode(): Int = scope.hashCode()
 
     companion object {
+        const val ACCOUNT_READ = "account_read"
+        const val STUDENT_READ = "student_read"
+        const val SELF_READ = "self_read"
+        const val CLUB_READ = "club_read"
+        const val PROJECT_READ = "project_read"
+
         fun authorityOf(
             applicationId: String,
             scopeName: String,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/club/dto/internal/ClubSummaryDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/club/dto/internal/ClubSummaryDto.kt
@@ -1,6 +1,7 @@
 package team.themoment.datagsm.common.domain.club.dto.internal
 
 import io.swagger.v3.oas.annotations.media.Schema
+import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.ksp.annotation.SdkExport
 
@@ -12,4 +13,8 @@ data class ClubSummaryDto(
     val name: String,
     @field:Schema(description = "동아리 종류", example = "MAJOR_CLUB")
     val type: ClubType,
-)
+) {
+    companion object {
+        fun from(club: ClubJpaEntity): ClubSummaryDto = ClubSummaryDto(id = club.id!!, name = club.name, type = club.type)
+    }
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
@@ -28,8 +28,10 @@ data class OauthAuthorizeReqDto(
     )
     val code_challenge_method: String? = null,
     @param:Schema(
-        description = "요청할 OAuth Scope 목록 (공백 구분, 미입력 시 client의 전체 허용 scope 사용)",
-        example = "self:read profile:read",
+        description =
+            "요청할 OAuth Scope 목록 (공백 구분). 미입력 시 기본 scope(account_read student_read)만 부여됩니다. " +
+                "student_read/club_read/project_read는 명시적으로 요청해야 합니다. self_read는 하위 호환을 위한 deprecated scope입니다.",
+        example = "account_read student_read club_read project_read",
         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
     )
     val scope: String? = null,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
@@ -29,9 +29,9 @@ data class OauthAuthorizeReqDto(
     val code_challenge_method: String? = null,
     @param:Schema(
         description =
-            "요청할 OAuth Scope 목록 (공백 구분). 미입력 시 기본 scope(account_read student_read)만 부여됩니다. " +
+            "요청할 OAuth Scope 목록 (공백 구분, appId:scopeName 형식). 미입력 시 기본 scope(appId:account_read appId:student_read)만 부여됩니다. " +
                 "student_read/club_read/project_read는 명시적으로 요청해야 합니다. self_read는 하위 호환을 위한 deprecated scope입니다.",
-        example = "account_read student_read club_read project_read",
+        example = "appId:account_read appId:student_read appId:club_read appId:project_read",
         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
     )
     val scope: String? = null,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/internal/ProjectSummaryDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/internal/ProjectSummaryDto.kt
@@ -1,0 +1,18 @@
+package team.themoment.datagsm.common.domain.project.dto.internal
+
+import io.swagger.v3.oas.annotations.media.Schema
+import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
+import team.themoment.datagsm.ksp.annotation.SdkExport
+
+@SdkExport
+data class ProjectSummaryDto(
+    @field:Schema(description = "프로젝트 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "프로젝트 이름", example = "DataGSM")
+    val name: String,
+    @field:Schema(description = "프로젝트 상태", example = "ACTIVE")
+    val status: ProjectStatus,
+    @field:Schema(description = "소속 동아리")
+    val club: ClubSummaryDto?,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/ProjectJpaCustomRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/ProjectJpaCustomRepository.kt
@@ -17,4 +17,6 @@ interface ProjectJpaCustomRepository {
         sortBy: ProjectSortBy?,
         sortDirection: SortDirection,
     ): Page<ProjectJpaEntity>
+
+    fun findAllByParticipantId(studentId: Long): List<ProjectJpaEntity>
 }

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/impl/ProjectJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/impl/ProjectJpaCustomRepositoryImpl.kt
@@ -105,7 +105,6 @@ class ProjectJpaCustomRepositoryImpl(
             .join(projectJpaEntity.participants, studentJpaEntity)
             .where(studentJpaEntity.id.eq(studentId))
             .fetch()
-            .distinct()
 
     private fun createOrderSpecifier(
         sortBy: ProjectSortBy?,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/impl/ProjectJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/impl/ProjectJpaCustomRepositoryImpl.kt
@@ -11,6 +11,7 @@ import team.themoment.datagsm.common.domain.project.entity.QProjectJpaEntity.Com
 import team.themoment.datagsm.common.domain.project.entity.constant.ProjectSortBy
 import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.project.repository.custom.ProjectJpaCustomRepository
+import team.themoment.datagsm.common.domain.student.entity.QStudentJpaEntity.Companion.studentJpaEntity
 import team.themoment.datagsm.common.global.constant.SortDirection
 
 @Repository
@@ -95,6 +96,16 @@ class ProjectJpaCustomRepositoryImpl(
 
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
     }
+
+    override fun findAllByParticipantId(studentId: Long): List<ProjectJpaEntity> =
+        jpaQueryFactory
+            .selectFrom(projectJpaEntity)
+            .leftJoin(projectJpaEntity.club)
+            .fetchJoin()
+            .join(projectJpaEntity.participants, studentJpaEntity)
+            .where(studentJpaEntity.id.eq(studentId))
+            .fetch()
+            .distinct()
 
     private fun createOrderSpecifier(
         sortBy: ProjectSortBy?,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/response/StudentResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/response/StudentResDto.kt
@@ -61,11 +61,8 @@ data class StudentResDto(
                 role = student.role,
                 dormitoryFloor = student.dormitoryRoomNumber?.dormitoryRoomFloor,
                 dormitoryRoom = student.dormitoryRoomNumber?.dormitoryRoomNumber,
-                majorClub = student.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
-                autonomousClub =
-                    student.autonomousClub?.let {
-                        ClubSummaryDto(id = it.id!!, name = it.name, type = it.type)
-                    },
+                majorClub = student.majorClub?.let { ClubSummaryDto.from(it) },
+                autonomousClub = student.autonomousClub?.let { ClubSummaryDto.from(it) },
                 githubId = student.githubId,
                 githubUrl = student.githubId?.let { "https://github.com/$it" },
             )

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -12,6 +12,7 @@ import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.StartOauthAuthorizeFlowService
+import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
 import java.util.UUID
 
 @Service
@@ -19,6 +20,7 @@ class StartOauthAuthorizeFlowServiceImpl(
     private val clientJpaRepository: ClientJpaRepository,
     private val oauthEnvironment: OauthEnvironment,
     private val oauthAuthorizeStateRedisRepository: OauthAuthorizeStateRedisRepository,
+    private val jwtEnvironment: OauthJwtProvisionEnvironment,
 ) : StartOauthAuthorizeFlowService {
     override fun execute(reqDto: OauthAuthorizeReqDto): ResponseEntity<Void> {
         val clientId = reqDto.client_id ?: throw OAuthException.InvalidRequest("client_id는 필수입니다.")
@@ -87,11 +89,22 @@ class StartOauthAuthorizeFlowServiceImpl(
         requestedScopes: Set<String>?,
         clientScopes: Set<String>,
     ): Set<String> {
-        if (requestedScopes == null) return clientScopes
+        if (requestedScopes == null) return defaultScopes(clientScopes)
         val invalid = requestedScopes - clientScopes
         if (invalid.isNotEmpty()) {
             throw OAuthException.InvalidScope("클라이언트에 허용되지 않은 권한 범위가 포함되어 있습니다.")
         }
         return requestedScopes
+    }
+
+    // scope 파라미터 미입력 시 client의 전체 허용 scope가 아닌 기본 UserInfo scope만 요청된 것으로 처리한다.
+    // account_read/student_read를 아직 부여받지 못한 레거시 client는 deprecated self_read로 대체한다.
+    private fun defaultScopes(clientScopes: Set<String>): Set<String> {
+        val applicationId = jwtEnvironment.datagsmApplicationId
+        val defaults = setOf("$applicationId:account_read", "$applicationId:student_read").intersect(clientScopes)
+        if (defaults.isNotEmpty()) return defaults
+
+        val legacySelfRead = "$applicationId:self_read"
+        return if (legacySelfRead in clientScopes) setOf(legacySelfRead) else emptySet()
     }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import org.springframework.web.util.UriComponentsBuilder
+import team.themoment.datagsm.common.domain.client.entity.constant.OAuthScope
 import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeReqDto
 import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
@@ -99,12 +100,17 @@ class StartOauthAuthorizeFlowServiceImpl(
 
     // scope 파라미터 미입력 시 client의 전체 허용 scope가 아닌 기본 UserInfo scope만 요청된 것으로 처리한다.
     // account_read/student_read를 아직 부여받지 못한 레거시 client는 deprecated self_read로 대체한다.
+    // 둘 다 없는 client는 스코프 없는 토큰이 조용히 발급되는 것을 막기 위해 InvalidScope로 실패시킨다.
     private fun defaultScopes(clientScopes: Set<String>): Set<String> {
         val applicationId = jwtEnvironment.datagsmApplicationId
-        val defaults = setOf("$applicationId:account_read", "$applicationId:student_read").intersect(clientScopes)
+        val defaults =
+            setOf("$applicationId:${OAuthScope.ACCOUNT_READ}", "$applicationId:${OAuthScope.STUDENT_READ}")
+                .intersect(clientScopes)
         if (defaults.isNotEmpty()) return defaults
 
-        val legacySelfRead = "$applicationId:self_read"
-        return if (legacySelfRead in clientScopes) setOf(legacySelfRead) else emptySet()
+        val legacySelfRead = "$applicationId:${OAuthScope.SELF_READ}"
+        if (legacySelfRead in clientScopes) return setOf(legacySelfRead)
+
+        throw OAuthException.InvalidScope("클라이언트에 기본으로 부여할 수 있는 권한 범위가 없습니다.")
     }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/data/OauthJwtProvisionEnvironment.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/data/OauthJwtProvisionEnvironment.kt
@@ -9,4 +9,5 @@ data class OauthJwtProvisionEnvironment(
     val keyId: String,
     val accessTokenExpiration: Long,
     val refreshTokenExpiration: Long,
+    val datagsmApplicationId: String,
 )

--- a/datagsm-oauth-authorization/src/main/resources/application.yml
+++ b/datagsm-oauth-authorization/src/main/resources/application.yml
@@ -52,6 +52,7 @@ spring:
       public-key: ${JWT_PUBLIC_KEY}
       access-token-expiration: ${OAUTH_ACCESS_TOKEN_EXPIRATION:3600000}
       refresh-token-expiration: ${OAUTH_REFRESH_TOKEN_EXPIRATION:2592000000}
+      datagsm-application-id: ${DATAGSM_APPLICATION_ID}
     oauth:
       code-expiration-seconds: ${OAUTH_CODE_EXPIRATION:300}
       frontend-url: ${OAUTH_FRONTEND_URL:http://localhost:3000}

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -19,6 +19,7 @@ import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.StartOauthAuthorizeFlowServiceImpl
+import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
 import java.util.Optional
 
 class StartOauthAuthorizeFlowServiceTest :
@@ -31,16 +32,25 @@ class StartOauthAuthorizeFlowServiceTest :
                 every { frontendUrl } returns "http://localhost:3000"
                 every { authorizeStateExpirationMs } returns 600000L
             }
+        val mockJwtEnvironment =
+            mockk<OauthJwtProvisionEnvironment> {
+                every { datagsmApplicationId } returns "datagsm"
+            }
 
         val startOauthAuthorizeFlowService =
             StartOauthAuthorizeFlowServiceImpl(
                 mockClientJpaRepository,
                 mockOauthEnvironment,
                 mockOauthAuthorizeStateRedisRepository,
+                mockJwtEnvironment,
             )
 
         afterEach {
             clearAllMocks()
+        }
+
+        beforeEach {
+            every { mockJwtEnvironment.datagsmApplicationId } returns "datagsm"
         }
 
         describe("StartOauthAuthorizeFlowService 클래스의") {
@@ -54,7 +64,7 @@ class StartOauthAuthorizeFlowServiceTest :
                         id = testClientId
                         secret = "encodedSecret"
                         redirectUrls = setOf(testRedirectUri)
-                        scopes.add("self:read")
+                        scopes.addAll(setOf("datagsm:account_read", "datagsm:student_read"))
                         clientName = "Test Client"
                         serviceName = "Test Service"
                     }
@@ -94,7 +104,7 @@ class StartOauthAuthorizeFlowServiceTest :
                         savedEntitySlot.captured.codeChallenge shouldBe "challenge"
                         savedEntitySlot.captured.codeChallengeMethod shouldBe "S256"
                         savedEntitySlot.captured.ttl shouldBe 600
-                        savedEntitySlot.captured.scopes shouldBe setOf("self:read")
+                        savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read", "datagsm:student_read")
                     }
                 }
 
@@ -108,7 +118,7 @@ class StartOauthAuthorizeFlowServiceTest :
                         every { mockOauthAuthorizeStateRedisRepository.save(capture(savedEntitySlot)) } answers { firstArg() }
                     }
 
-                    it("client의 전체 scope가 state entity에 저장되어야 한다") {
+                    it("client 전체 scope가 아닌 기본 scope(account_read, student_read)만 state entity에 저장되어야 한다") {
                         val reqDto =
                             OauthAuthorizeReqDto(
                                 client_id = testClientId,
@@ -117,7 +127,39 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         startOauthAuthorizeFlowService.execute(reqDto)
 
-                        savedEntitySlot.captured.scopes shouldBe setOf("self:read")
+                        savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read", "datagsm:student_read")
+                    }
+                }
+
+                context("scope 파라미터가 null이고 client가 deprecated self_read만 가지고 있을 때") {
+                    val legacyClient =
+                        ClientJpaEntity().apply {
+                            id = testClientId
+                            secret = "encodedSecret"
+                            redirectUrls = setOf(testRedirectUri)
+                            scopes.add("datagsm:self_read")
+                            clientName = "Legacy Client"
+                            serviceName = "Legacy Service"
+                        }
+                    val savedEntitySlot = slot<OauthAuthorizeStateRedisEntity>()
+
+                    beforeEach {
+                        every { mockOauthEnvironment.frontendUrl } returns "http://localhost:3000"
+                        every { mockOauthEnvironment.authorizeStateExpirationMs } returns 600000L
+                        every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(legacyClient)
+                        every { mockOauthAuthorizeStateRedisRepository.save(capture(savedEntitySlot)) } answers { firstArg() }
+                    }
+
+                    it("하위 호환을 위해 self_read가 기본 scope로 저장되어야 한다") {
+                        val reqDto =
+                            OauthAuthorizeReqDto(
+                                client_id = testClientId,
+                                redirect_uri = testRedirectUri,
+                                response_type = "code",
+                            )
+                        startOauthAuthorizeFlowService.execute(reqDto)
+
+                        savedEntitySlot.captured.scopes shouldBe setOf("datagsm:self_read")
                     }
                 }
 
@@ -137,11 +179,11 @@ class StartOauthAuthorizeFlowServiceTest :
                                 client_id = testClientId,
                                 redirect_uri = testRedirectUri,
                                 response_type = "code",
-                                scope = "self:read",
+                                scope = "datagsm:account_read",
                             )
                         startOauthAuthorizeFlowService.execute(reqDto)
 
-                        savedEntitySlot.captured.scopes shouldBe setOf("self:read")
+                        savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read")
                     }
                 }
 
@@ -151,7 +193,9 @@ class StartOauthAuthorizeFlowServiceTest :
                             id = testClientId
                             secret = "encodedSecret"
                             redirectUrls = setOf(testRedirectUri)
-                            scopes.addAll(setOf("self:read", "profile:read"))
+                            scopes.addAll(
+                                setOf("datagsm:account_read", "datagsm:student_read", "datagsm:club_read", "datagsm:project_read"),
+                            )
                             clientName = "Test Client"
                             serviceName = "Test Service"
                         }
@@ -170,11 +214,11 @@ class StartOauthAuthorizeFlowServiceTest :
                                 client_id = testClientId,
                                 redirect_uri = testRedirectUri,
                                 response_type = "code",
-                                scope = "self:read profile:read",
+                                scope = "datagsm:account_read datagsm:club_read",
                             )
                         startOauthAuthorizeFlowService.execute(reqDto)
 
-                        savedEntitySlot.captured.scopes shouldBe setOf("self:read", "profile:read")
+                        savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read", "datagsm:club_read")
                     }
                 }
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -163,6 +163,37 @@ class StartOauthAuthorizeFlowServiceTest :
                     }
                 }
 
+                context("scope 파라미터가 null이고 client가 기본 scope를 하나도 가지고 있지 않을 때") {
+                    val noDefaultScopeClient =
+                        ClientJpaEntity().apply {
+                            id = testClientId
+                            secret = "encodedSecret"
+                            redirectUrls = setOf(testRedirectUri)
+                            scopes.add("datagsm:club_read")
+                            clientName = "No Default Scope Client"
+                            serviceName = "No Default Scope Service"
+                        }
+
+                    beforeEach {
+                        every { mockOauthEnvironment.frontendUrl } returns "http://localhost:3000"
+                        every { mockOauthEnvironment.authorizeStateExpirationMs } returns 600000L
+                        every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(noDefaultScopeClient)
+                    }
+
+                    it("OAuthException.InvalidScope가 발생해야 한다") {
+                        val reqDto =
+                            OauthAuthorizeReqDto(
+                                client_id = testClientId,
+                                redirect_uri = testRedirectUri,
+                                response_type = "code",
+                            )
+
+                        shouldThrow<OAuthException.InvalidScope> {
+                            startOauthAuthorizeFlowService.execute(reqDto)
+                        }
+                    }
+                }
+
                 context("허용된 scope를 요청할 때") {
                     val savedEntitySlot = slot<OauthAuthorizeStateRedisEntity>()
 

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/controller/UserInfoController.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/controller/UserInfoController.kt
@@ -17,7 +17,10 @@ class UserInfoController(
     @GetMapping("/userinfo")
     @Operation(
         summary = "사용자 정보 조회",
-        description = "OAuth2 Access Token을 사용하여 현재 사용자 정보를 조회합니다.",
+        description =
+            "OAuth2 Access Token을 사용하여 현재 사용자 정보를 조회합니다. " +
+                "student/teacher는 student_read(또는 하위 호환 self_read), clubs는 club_read, projects는 project_read " +
+                "스코프를 보유한 경우에만 값이 채워지며, 미보유 시 각각 null 또는 빈 목록으로 반환됩니다.",
     )
     fun getUserInfo(): AccountInfoResDto = queryUserInfoService.execute()
 }

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
@@ -16,13 +16,15 @@ class QueryUserInfoServiceImpl(
     @Transactional(readOnly = true)
     override fun execute(): AccountInfoResDto {
         val account = currentUserProvider.getCurrentAccount()
-        val resolved = accountObjectResolver.resolve(account)
         val scopeNames = currentUserProvider.getGrantedScopeNames()
 
         // self_read(deprecated)는 account_read + student_read를 합친 기존 동작과 동일하게 취급한다.
         val hasStudentRead = "student_read" in scopeNames || "self_read" in scopeNames
         val hasClubRead = "club_read" in scopeNames
         val hasProjectRead = "project_read" in scopeNames
+
+        // 부여되지 않은 스코프의 club/project 조회는 리졸버가 아예 수행하지 않도록 건너뛴다.
+        val resolved = accountObjectResolver.resolve(account, includeClubs = hasClubRead, includeProjects = hasProjectRead)
 
         return AccountInfoResDto(
             id = account.id!!,

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
@@ -17,6 +17,12 @@ class QueryUserInfoServiceImpl(
     override fun execute(): AccountInfoResDto {
         val account = currentUserProvider.getCurrentAccount()
         val resolved = accountObjectResolver.resolve(account)
+        val scopeNames = currentUserProvider.getGrantedScopeNames()
+
+        // self_read(deprecated)는 account_read + student_read를 합친 기존 동작과 동일하게 취급한다.
+        val hasStudentRead = "student_read" in scopeNames || "self_read" in scopeNames
+        val hasClubRead = "club_read" in scopeNames
+        val hasProjectRead = "project_read" in scopeNames
 
         return AccountInfoResDto(
             id = account.id!!,
@@ -25,8 +31,10 @@ class QueryUserInfoServiceImpl(
             status = account.status,
             objectType = account.objectType,
             isStudent = account.objectType == AccountObjectType.STUDENT,
-            student = resolved.student,
-            teacher = resolved.teacher,
+            student = if (hasStudentRead) resolved.student else null,
+            teacher = if (hasStudentRead) resolved.teacher else null,
+            clubs = if (hasClubRead) resolved.clubs else emptyList(),
+            projects = if (hasProjectRead) resolved.projects else emptyList(),
         )
     }
 }

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.account.dto.response.AccountInfoResDto
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.resolver.AccountObjectResolver
+import team.themoment.datagsm.common.domain.client.entity.constant.OAuthScope
 import team.themoment.datagsm.oauth.userinfo.domain.userinfo.service.QueryUserInfoService
 import team.themoment.datagsm.oauth.userinfo.global.security.provider.CurrentUserProvider
 
@@ -19,12 +20,21 @@ class QueryUserInfoServiceImpl(
         val scopeNames = currentUserProvider.getGrantedScopeNames()
 
         // self_read(deprecated)는 account_read + student_read를 합친 기존 동작과 동일하게 취급한다.
-        val hasStudentRead = "student_read" in scopeNames || "self_read" in scopeNames
-        val hasClubRead = "club_read" in scopeNames
-        val hasProjectRead = "project_read" in scopeNames
+        val hasStudentRead = OAuthScope.STUDENT_READ in scopeNames || OAuthScope.SELF_READ in scopeNames
+        val hasClubRead = OAuthScope.CLUB_READ in scopeNames
+        val hasProjectRead = OAuthScope.PROJECT_READ in scopeNames
 
         // 부여되지 않은 스코프의 club/project 조회는 리졸버가 아예 수행하지 않도록 건너뛴다.
         val resolved = accountObjectResolver.resolve(account, includeClubs = hasClubRead, includeProjects = hasProjectRead)
+
+        // StudentResDto에는 majorClub/autonomousClub이 포함되어 있어, club_read가 없으면 clubs 필드뿐 아니라
+        // student 안의 동아리 정보도 함께 가려야 club_read 스코프가 실제로 의미를 가진다.
+        val student =
+            if (hasStudentRead) {
+                resolved.student?.let { if (hasClubRead) it else it.copy(majorClub = null, autonomousClub = null) }
+            } else {
+                null
+            }
 
         return AccountInfoResDto(
             id = account.id!!,
@@ -33,7 +43,7 @@ class QueryUserInfoServiceImpl(
             status = account.status,
             objectType = account.objectType,
             isStudent = account.objectType == AccountObjectType.STUDENT,
-            student = if (hasStudentRead) resolved.student else null,
+            student = student,
             teacher = if (hasStudentRead) resolved.teacher else null,
             clubs = if (hasClubRead) resolved.clubs else emptyList(),
             projects = if (hasProjectRead) resolved.projects else emptyList(),

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
@@ -36,6 +36,7 @@ class SecurityConfig(
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        val accountReadAuthority = OAuthScope.authorityOf(oauthJwtVerificationEnvironment.datagsmApplicationId, "account_read")
         val selfReadAuthority = OAuthScope.authorityOf(oauthJwtVerificationEnvironment.datagsmApplicationId, "self_read")
 
         http
@@ -55,7 +56,7 @@ class SecurityConfig(
             ).authorizeHttpRequests {
                 it
                     .requestMatchers("/userinfo")
-                    .hasAuthority(selfReadAuthority)
+                    .hasAnyAuthority(accountReadAuthority, selfReadAuthority)
                     .anyRequest()
                     .permitAll()
             }

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
@@ -36,8 +36,9 @@ class SecurityConfig(
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-        val accountReadAuthority = OAuthScope.authorityOf(oauthJwtVerificationEnvironment.datagsmApplicationId, "account_read")
-        val selfReadAuthority = OAuthScope.authorityOf(oauthJwtVerificationEnvironment.datagsmApplicationId, "self_read")
+        val accountReadAuthority =
+            OAuthScope.authorityOf(oauthJwtVerificationEnvironment.datagsmApplicationId, OAuthScope.ACCOUNT_READ)
+        val selfReadAuthority = OAuthScope.authorityOf(oauthJwtVerificationEnvironment.datagsmApplicationId, OAuthScope.SELF_READ)
 
         http
             .csrf(CsrfConfigurer<*>::disable)

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/provider/CurrentUserProvider.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/provider/CurrentUserProvider.kt
@@ -6,12 +6,14 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
+import team.themoment.datagsm.oauth.userinfo.global.data.OauthJwtVerificationEnvironment
 import team.themoment.datagsm.oauth.userinfo.global.security.authentication.OauthAuthenticationToken
 import team.themoment.sdk.exception.ExpectedException
 
 @Component
 class CurrentUserProvider(
     private val accountJpaRepository: AccountJpaRepository,
+    private val oauthJwtVerificationEnvironment: OauthJwtVerificationEnvironment,
 ) {
     fun getAuthentication(): OauthAuthenticationToken {
         val authentication: Authentication? =
@@ -37,9 +39,13 @@ class CurrentUserProvider(
             .orElseThrow { ExpectedException("계정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
     }
 
-    fun getGrantedScopeNames(): Set<String> =
-        getAuthentication()
+    fun getGrantedScopeNames(): Set<String> {
+        val datagsmPrefix = "SCOPE_${oauthJwtVerificationEnvironment.datagsmApplicationId}:"
+        return getAuthentication()
             .authorities
-            .mapNotNull { it.authority?.substringAfter(':') }
+            .mapNotNull { it.authority }
+            .filter { it.startsWith(datagsmPrefix) }
+            .map { it.removePrefix(datagsmPrefix) }
             .toSet()
+    }
 }

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/provider/CurrentUserProvider.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/provider/CurrentUserProvider.kt
@@ -36,4 +36,10 @@ class CurrentUserProvider(
             .findByEmail(email)
             .orElseThrow { ExpectedException("계정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
     }
+
+    fun getGrantedScopeNames(): Set<String> =
+        getAuthentication()
+            .authorities
+            .mapNotNull { it.authority?.substringAfter(':') }
+            .toSet()
 }

--- a/datagsm-oauth-userinfo/src/test/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/QueryUserInfoServiceTest.kt
+++ b/datagsm-oauth-userinfo/src/test/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/QueryUserInfoServiceTest.kt
@@ -1,6 +1,7 @@
 package team.themoment.datagsm.oauth.userinfo.domain.userinfo.service
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -11,6 +12,13 @@ import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
 import team.themoment.datagsm.common.domain.account.resolver.AccountObjectResolver
+import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
+import team.themoment.datagsm.common.domain.project.dto.internal.ProjectSummaryDto
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
+import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
+import team.themoment.datagsm.common.domain.student.entity.constant.Sex
+import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
 import team.themoment.datagsm.common.domain.teacher.dto.response.TeacherResDto
 import team.themoment.datagsm.common.domain.teacher.entity.TeacherJpaEntity
 import team.themoment.datagsm.common.domain.teacher.entity.constant.TeacherDepartment
@@ -27,6 +35,29 @@ class QueryUserInfoServiceTest :
         afterEach {
             clearAllMocks()
         }
+
+        val studentDto =
+            StudentResDto(
+                id = 10L,
+                name = "홍길동",
+                sex = Sex.MAN,
+                email = "student@gsm.hs.kr",
+                grade = 1,
+                classNum = 1,
+                number = 1,
+                studentNumber = 1101,
+                major = null,
+                specialty = null,
+                role = StudentRole.GENERAL_STUDENT,
+                dormitoryFloor = null,
+                dormitoryRoom = null,
+                majorClub = null,
+                autonomousClub = null,
+                githubId = null,
+                githubUrl = null,
+            )
+        val clubSummary = ClubSummaryDto(id = 100L, name = "SW개발동아리", type = ClubType.MAJOR_CLUB)
+        val projectSummary = ProjectSummaryDto(id = 200L, name = "DataGSM", status = ProjectStatus.ACTIVE, club = clubSummary)
 
         describe("QueryUserInfoService 클래스의") {
             describe("execute 메서드는") {
@@ -45,6 +76,7 @@ class QueryUserInfoServiceTest :
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
                         every { mockAccountObjectResolver.resolve(mockAccount) } returns
                             ResolvedAccountObject(null, null)
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read")
                     }
 
                     it("계정 정보가 정상적으로 반환되어야 한다") {
@@ -56,6 +88,8 @@ class QueryUserInfoServiceTest :
                         result.objectType shouldBe null
                         result.student shouldBe null
                         result.teacher shouldBe null
+                        result.clubs.shouldBeEmpty()
+                        result.projects.shouldBeEmpty()
 
                         verify(exactly = 1) { mockCurrentUserProvider.getCurrentAccount() }
                     }
@@ -80,14 +114,150 @@ class QueryUserInfoServiceTest :
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
                         every { mockAccountObjectResolver.resolve(mockAccount) } returns
                             ResolvedAccountObject(null, TeacherResDto.from(teacher))
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read")
                     }
 
-                    it("선생님 정보가 포함되어 반환되어야 한다") {
+                    it("student_read 스코프가 있으면 선생님 정보가 포함되어 반환되어야 한다") {
                         val result = queryUserInfoService.execute()
 
                         result.objectType shouldBe AccountObjectType.TEACHER
                         result.teacher?.id shouldBe 50L
                         result.teacher?.name shouldBe "김선생"
+                    }
+                }
+
+                context("학생 계정이 account_read 스코프만 가지고 있을 때") {
+                    val mockAccount =
+                        AccountJpaEntity().apply {
+                            id = 2L
+                            email = "student@gsm.hs.kr"
+                            password = "encodedPassword"
+                            role = AccountRole.USER
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+
+                    beforeEach {
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
+                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read")
+                    }
+
+                    it("student/clubs/projects는 모두 비어있어야 한다") {
+                        val result = queryUserInfoService.execute()
+
+                        result.student shouldBe null
+                        result.teacher shouldBe null
+                        result.clubs.shouldBeEmpty()
+                        result.projects.shouldBeEmpty()
+                    }
+                }
+
+                context("학생 계정이 account_read와 student_read 스코프를 가지고 있을 때") {
+                    val mockAccount =
+                        AccountJpaEntity().apply {
+                            id = 2L
+                            email = "student@gsm.hs.kr"
+                            password = "encodedPassword"
+                            role = AccountRole.USER
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+
+                    beforeEach {
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
+                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read")
+                    }
+
+                    it("student 정보만 채워지고 clubs/projects는 비어있어야 한다") {
+                        val result = queryUserInfoService.execute()
+
+                        result.student shouldBe studentDto
+                        result.clubs.shouldBeEmpty()
+                        result.projects.shouldBeEmpty()
+                    }
+                }
+
+                context("학생 계정이 club_read 스코프까지 가지고 있을 때") {
+                    val mockAccount =
+                        AccountJpaEntity().apply {
+                            id = 2L
+                            email = "student@gsm.hs.kr"
+                            password = "encodedPassword"
+                            role = AccountRole.USER
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+
+                    beforeEach {
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
+                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read", "club_read")
+                    }
+
+                    it("clubs가 채워지고 projects는 비어있어야 한다") {
+                        val result = queryUserInfoService.execute()
+
+                        result.clubs shouldBe listOf(clubSummary)
+                        result.projects.shouldBeEmpty()
+                    }
+                }
+
+                context("학생 계정이 project_read 스코프까지 가지고 있을 때") {
+                    val mockAccount =
+                        AccountJpaEntity().apply {
+                            id = 2L
+                            email = "student@gsm.hs.kr"
+                            password = "encodedPassword"
+                            role = AccountRole.USER
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+
+                    beforeEach {
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
+                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns
+                            setOf("account_read", "student_read", "club_read", "project_read")
+                    }
+
+                    it("clubs와 projects가 모두 채워져야 한다") {
+                        val result = queryUserInfoService.execute()
+
+                        result.clubs shouldBe listOf(clubSummary)
+                        result.projects shouldBe listOf(projectSummary)
+                    }
+                }
+
+                context("학생 계정이 deprecated self_read 스코프만 가지고 있을 때 (하위 호환)") {
+                    val mockAccount =
+                        AccountJpaEntity().apply {
+                            id = 2L
+                            email = "student@gsm.hs.kr"
+                            password = "encodedPassword"
+                            role = AccountRole.USER
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+
+                    beforeEach {
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
+                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("self_read")
+                    }
+
+                    it("student 정보는 채워지고 clubs/projects는 비어있어야 한다") {
+                        val result = queryUserInfoService.execute()
+
+                        result.student shouldBe studentDto
+                        result.clubs.shouldBeEmpty()
+                        result.projects.shouldBeEmpty()
                     }
                 }
             }

--- a/datagsm-oauth-userinfo/src/test/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/QueryUserInfoServiceTest.kt
+++ b/datagsm-oauth-userinfo/src/test/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/QueryUserInfoServiceTest.kt
@@ -74,7 +74,7 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = false, includeProjects = false) } returns
                             ResolvedAccountObject(null, null)
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read")
                     }
@@ -112,7 +112,7 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = false, includeProjects = false) } returns
                             ResolvedAccountObject(null, TeacherResDto.from(teacher))
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read")
                     }
@@ -139,8 +139,8 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
-                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = false, includeProjects = false) } returns
+                            ResolvedAccountObject(studentDto, null)
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read")
                     }
 
@@ -167,8 +167,8 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
-                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = false, includeProjects = false) } returns
+                            ResolvedAccountObject(studentDto, null)
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read")
                     }
 
@@ -194,8 +194,8 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
-                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = true, includeProjects = false) } returns
+                            ResolvedAccountObject(studentDto, null, listOf(clubSummary))
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read", "club_read")
                     }
 
@@ -220,7 +220,7 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = true, includeProjects = true) } returns
                             ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns
                             setOf("account_read", "student_read", "club_read", "project_read")
@@ -247,8 +247,8 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
-                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = false, includeProjects = false) } returns
+                            ResolvedAccountObject(studentDto, null)
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("self_read")
                     }
 

--- a/datagsm-oauth-userinfo/src/test/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/QueryUserInfoServiceTest.kt
+++ b/datagsm-oauth-userinfo/src/test/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/QueryUserInfoServiceTest.kt
@@ -181,6 +181,34 @@ class QueryUserInfoServiceTest :
                     }
                 }
 
+                context("학생 계정이 club_read 없이 student_read만 가지고 있고 student에 동아리 정보가 있을 때") {
+                    val mockAccount =
+                        AccountJpaEntity().apply {
+                            id = 2L
+                            email = "student@gsm.hs.kr"
+                            password = "encodedPassword"
+                            role = AccountRole.USER
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+                    val studentWithClub = studentDto.copy(majorClub = clubSummary, autonomousClub = clubSummary)
+
+                    beforeEach {
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = false, includeProjects = false) } returns
+                            ResolvedAccountObject(studentWithClub, null)
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read")
+                    }
+
+                    it("club_read가 없으므로 student 안의 majorClub/autonomousClub도 가려져야 한다") {
+                        val result = queryUserInfoService.execute()
+
+                        result.student?.majorClub shouldBe null
+                        result.student?.autonomousClub shouldBe null
+                        result.clubs.shouldBeEmpty()
+                    }
+                }
+
                 context("학생 계정이 club_read 스코프까지 가지고 있을 때") {
                     val mockAccount =
                         AccountJpaEntity().apply {

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
@@ -27,6 +27,8 @@ class QueryMyInfoServiceImpl(
             isStudent = account.objectType == AccountObjectType.STUDENT,
             student = resolved.student,
             teacher = resolved.teacher,
+            clubs = resolved.clubs,
+            projects = resolved.projects,
         )
     }
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
@@ -16,7 +16,7 @@ class QueryMyInfoServiceImpl(
     @Transactional(readOnly = true)
     override fun execute(): AccountInfoResDto {
         val account = currentUserProvider.getCurrentAccount()
-        val resolved = accountObjectResolver.resolve(account)
+        val resolved = accountObjectResolver.resolve(account, includeClubs = true, includeProjects = true)
 
         return AccountInfoResDto(
             id = account.id!!,

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/QueryMyInfoServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/QueryMyInfoServiceTest.kt
@@ -10,6 +10,10 @@ import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
 import team.themoment.datagsm.common.domain.account.resolver.AccountObjectResolver
+import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
+import team.themoment.datagsm.common.domain.project.dto.internal.ProjectSummaryDto
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
 import team.themoment.datagsm.common.domain.student.entity.DormitoryRoomNumber
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
@@ -93,10 +97,15 @@ class QueryMyInfoServiceTest :
                             }
                         every { mockCurrentUserProvider.getCurrentAccount() } returns account
                         every { mockAccountObjectResolver.resolve(account) } returns
-                            ResolvedAccountObject(StudentResDto.from(student), null)
+                            ResolvedAccountObject(
+                                StudentResDto.from(student),
+                                null,
+                                listOf(ClubSummaryDto(id = 100L, name = "SW개발동아리", type = ClubType.MAJOR_CLUB)),
+                                listOf(ProjectSummaryDto(id = 200L, name = "DataGSM", status = ProjectStatus.ACTIVE, club = null)),
+                            )
                     }
 
-                    it("학생 정보를 포함하여 계정 정보를 반환해야 한다") {
+                    it("학생 정보와 동아리·프로젝트 정보를 포함하여 계정 정보를 반환해야 한다") {
                         val result = queryMyInfoService.execute()
 
                         result.id shouldBe 2L
@@ -116,6 +125,11 @@ class QueryMyInfoServiceTest :
                         studentDto.major shouldBe Major.SW_DEVELOPMENT
                         studentDto.dormitoryFloor shouldBe 2
                         studentDto.dormitoryRoom shouldBe 201
+
+                        result.clubs.size shouldBe 1
+                        result.clubs.first().name shouldBe "SW개발동아리"
+                        result.projects.size shouldBe 1
+                        result.projects.first().name shouldBe "DataGSM"
 
                         verify(exactly = 1) { mockCurrentUserProvider.getCurrentAccount() }
                     }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/QueryMyInfoServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/QueryMyInfoServiceTest.kt
@@ -54,7 +54,8 @@ class QueryMyInfoServiceTest :
                                 role = AccountRole.ADMIN
                             }
                         every { mockCurrentUserProvider.getCurrentAccount() } returns account
-                        every { mockAccountObjectResolver.resolve(account) } returns ResolvedAccountObject(null, null)
+                        every { mockAccountObjectResolver.resolve(account, includeClubs = true, includeProjects = true) } returns
+                            ResolvedAccountObject(null, null)
                     }
 
                     it("연결 대상 정보 없이 계정 정보를 반환해야 한다") {
@@ -96,7 +97,7 @@ class QueryMyInfoServiceTest :
                                 objectType = AccountObjectType.STUDENT
                             }
                         every { mockCurrentUserProvider.getCurrentAccount() } returns account
-                        every { mockAccountObjectResolver.resolve(account) } returns
+                        every { mockAccountObjectResolver.resolve(account, includeClubs = true, includeProjects = true) } returns
                             ResolvedAccountObject(
                                 StudentResDto.from(student),
                                 null,
@@ -154,7 +155,7 @@ class QueryMyInfoServiceTest :
                                 objectType = AccountObjectType.TEACHER
                             }
                         every { mockCurrentUserProvider.getCurrentAccount() } returns account
-                        every { mockAccountObjectResolver.resolve(account) } returns
+                        every { mockAccountObjectResolver.resolve(account, includeClubs = true, includeProjects = true) } returns
                             ResolvedAccountObject(null, TeacherResDto.from(teacher))
                     }
 


### PR DESCRIPTION
## 개요

OAuth `/userinfo`의 단일 `self_read` 스코프를 `account_read`/`student_read`/`club_read`/`project_read` 4개로 세분화하였습니다. `self_read`는 하위 호환을 위해 deprecated 상태로 유지하였습니다.

## 본문

### 배경

기존에는 `datagsm:self_read` 하나로 계정·학생 정보를 모두 반환하고 있었으며, 동아리·프로젝트 소속 정보는 제공하지 않았습니다. 클라이언트가 필요한 정보만 선택적으로 요청할 수 있도록 스코프를 세분화하였습니다.

### 주요 변경 사항

- `OAuthScope` 신규 4종 도입: `account_read`(계정 기본 정보), `student_read`(학생/선생님 상세 정보), `club_read`(소속 동아리), `project_read`(참여 프로젝트)
- `self_read`는 삭제하지 않고 `account_read` + `student_read`와 동등하게 동작하도록 유지 (deprecated, 하위 호환)
- `SecurityConfig`에서 `/userinfo` 접근 조건을 `account_read` 또는 `self_read` 중 하나를 보유한 경우로 완화
- `QueryUserInfoServiceImpl`에서 보유 스코프에 따라 `student`/`teacher`/`clubs`/`projects` 필드를 조건부로 채우도록 변경
- `AccountObjectResolver`에 `includeClubs`/`includeProjects` 파라미터를 추가하여, 미부여 스코프에 대해서는 동아리·프로젝트 조회 쿼리 자체를 실행하지 않도록 최적화
- `datagsm-web`의 `QueryMyInfoServiceImpl`(내 정보 조회)도 동일하게 `clubs`/`projects`를 응답에 포함
- `ProjectJpaCustomRepository`에 `findAllByParticipantId` 신규 추가 (QueryDSL)
- `StartOauthAuthorizeFlowServiceImpl`에서 `scope` 파라미터 미입력 시 `client`의 전체 허용 스코프 대신 기본 스코프(`account_read`, `student_read`)만 부여하도록 변경. 레거시 클라이언트가 `account_read`/`student_read`를 아직 보유하지 않은 경우 `self_read`로 폴백

### 테스트

- `QueryUserInfoServiceTest`: 스코프 조합별(계정만/학생 포함/동아리 포함/프로젝트 포함/`self_read` 하위 호환) 응답 검증 케이스 추가
- `StartOauthAuthorizeFlowServiceTest`: 기본 스코프 부여 및 레거시 `self_read` 폴백 케이스 추가
- `QueryMyInfoServiceTest`: `clubs`/`projects` 포함 검증 추가
- 전체 모듈 빌드·`ktlintCheck`·테스트 통과 확인

### 후속 작업 (범위 밖)

- 운영 DB `tb_oauth_scope`에 `account_read`/`student_read`/`club_read`/`project_read` 실제 등록은 배포 후 관리자가 수행해야 합니다.

https://claude.ai/code/session_014PW7XBWgWi7ju9M1jSAFte
