### PR TITLE
[oauth] SSO IdP 세션 도입

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/internal/ResolvedAccountObject.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/internal/ResolvedAccountObject.kt
@@ -1,12 +1,16 @@
 package team.themoment.datagsm.common.domain.account.dto.internal
 
+import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.project.dto.internal.ProjectSummaryDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
 import team.themoment.datagsm.common.domain.teacher.dto.response.TeacherResDto
 
 /**
- * 계정에 연결된 대상(학생/선생님)을 조회한 결과를 담는 내부 DTO입니다.
+ * 계정에 연결된 대상(학생/선생님)과 그 소속 동아리·참여 프로젝트를 조회한 결과를 담는 내부 DTO입니다.
  */
 data class ResolvedAccountObject(
     val student: StudentResDto?,
     val teacher: TeacherResDto?,
+    val clubs: List<ClubSummaryDto> = emptyList(),
+    val projects: List<ProjectSummaryDto> = emptyList(),
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountInfoResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountInfoResDto.kt
@@ -23,12 +23,12 @@ data class AccountInfoResDto(
     @Deprecated("objectType == STUDENT 으로 대체 예정, 하위 호환을 위해 임시 유지", ReplaceWith("objectType == AccountObjectType.STUDENT"))
     @field:Schema(description = "학생 계정 여부 (Deprecated, objectType == STUDENT 으로 대체 예정)", example = "true", deprecated = true)
     val isStudent: Boolean,
-    @field:Schema(description = "학생 정보 (student_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
+    @field:Schema(description = "학생 정보 (학생인 경우에만 포함)")
     val student: StudentResDto?,
-    @field:Schema(description = "선생님 정보 (student_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
+    @field:Schema(description = "선생님 정보 (선생님인 경우에만 포함)")
     val teacher: TeacherResDto?,
-    @field:Schema(description = "소속 동아리 목록 (club_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
+    @field:Schema(description = "소속 동아리 목록")
     val clubs: List<ClubSummaryDto> = emptyList(),
-    @field:Schema(description = "참여 프로젝트 목록 (project_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
+    @field:Schema(description = "참여 프로젝트 목록")
     val projects: List<ProjectSummaryDto> = emptyList(),
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountInfoResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/dto/response/AccountInfoResDto.kt
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatus
+import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.project.dto.internal.ProjectSummaryDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
 import team.themoment.datagsm.common.domain.teacher.dto.response.TeacherResDto
 
@@ -21,8 +23,12 @@ data class AccountInfoResDto(
     @Deprecated("objectType == STUDENT 으로 대체 예정, 하위 호환을 위해 임시 유지", ReplaceWith("objectType == AccountObjectType.STUDENT"))
     @field:Schema(description = "학생 계정 여부 (Deprecated, objectType == STUDENT 으로 대체 예정)", example = "true", deprecated = true)
     val isStudent: Boolean,
-    @field:Schema(description = "학생 정보 (학생인 경우에만 포함)")
+    @field:Schema(description = "학생 정보 (student_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
     val student: StudentResDto?,
-    @field:Schema(description = "선생님 정보 (선생님인 경우에만 포함)")
+    @field:Schema(description = "선생님 정보 (student_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
     val teacher: TeacherResDto?,
+    @field:Schema(description = "소속 동아리 목록 (club_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
+    val clubs: List<ClubSummaryDto> = emptyList(),
+    @field:Schema(description = "참여 프로젝트 목록 (project_read 스코프 보유 시에만 포함, OAuth UserInfo 기준)")
+    val projects: List<ProjectSummaryDto> = emptyList(),
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/resolver/AccountObjectResolver.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/resolver/AccountObjectResolver.kt
@@ -24,7 +24,11 @@ class AccountObjectResolver(
     private val teacherJpaRepository: TeacherJpaRepository,
     private val projectJpaRepository: ProjectJpaRepository,
 ) {
-    fun resolve(account: AccountJpaEntity): ResolvedAccountObject {
+    fun resolve(
+        account: AccountJpaEntity,
+        includeClubs: Boolean = true,
+        includeProjects: Boolean = true,
+    ): ResolvedAccountObject {
         val objectId = account.objectId ?: return ResolvedAccountObject(null, null)
         return when (account.objectType) {
             AccountObjectType.STUDENT -> {
@@ -32,8 +36,8 @@ class AccountObjectResolver(
                 ResolvedAccountObject(
                     student = student?.let { StudentResDto.from(it) },
                     teacher = null,
-                    clubs = student?.let { resolveClubs(it) } ?: emptyList(),
-                    projects = student?.let { resolveProjects(it) } ?: emptyList(),
+                    clubs = if (includeClubs) student?.let { resolveClubs(it) } ?: emptyList() else emptyList(),
+                    projects = if (includeProjects) student?.let { resolveProjects(it) } ?: emptyList() else emptyList(),
                 )
             }
             AccountObjectType.TEACHER ->

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/resolver/AccountObjectResolver.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/resolver/AccountObjectResolver.kt
@@ -5,7 +5,6 @@ import team.themoment.datagsm.common.domain.account.dto.internal.ResolvedAccount
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
-import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.project.dto.internal.ProjectSummaryDto
 import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
 import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
@@ -26,8 +25,8 @@ class AccountObjectResolver(
 ) {
     fun resolve(
         account: AccountJpaEntity,
-        includeClubs: Boolean = true,
-        includeProjects: Boolean = true,
+        includeClubs: Boolean = false,
+        includeProjects: Boolean = false,
     ): ResolvedAccountObject {
         val objectId = account.objectId ?: return ResolvedAccountObject(null, null)
         return when (account.objectType) {
@@ -50,14 +49,13 @@ class AccountObjectResolver(
     }
 
     private fun resolveClubs(student: StudentJpaEntity): List<ClubSummaryDto> =
-        listOfNotNull(student.majorClub, student.autonomousClub).map { it.toSummaryDto() }
+        listOfNotNull(student.majorClub, student.autonomousClub).map { ClubSummaryDto.from(it) }
 
     private fun resolveProjects(student: StudentJpaEntity): List<ProjectSummaryDto> =
         projectJpaRepository.findAllByParticipantId(student.id!!).map { it.toSummaryDto() }
 
-    private fun ClubJpaEntity.toSummaryDto() = ClubSummaryDto(id = id!!, name = name, type = type)
-
-    private fun ProjectJpaEntity.toSummaryDto() = ProjectSummaryDto(id = id!!, name = name, status = status, club = club?.toSummaryDto())
+    private fun ProjectJpaEntity.toSummaryDto() =
+        ProjectSummaryDto(id = id!!, name = name, status = status, club = club?.let { ClubSummaryDto.from(it) })
 
     fun resolveAll(accounts: List<AccountJpaEntity>): Map<Long, ResolvedAccountObject> {
         val studentIds =

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/resolver/AccountObjectResolver.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/account/resolver/AccountObjectResolver.kt
@@ -4,7 +4,13 @@ import org.springframework.stereotype.Component
 import team.themoment.datagsm.common.domain.account.dto.internal.ResolvedAccountObject
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
+import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
+import team.themoment.datagsm.common.domain.project.dto.internal.ProjectSummaryDto
+import team.themoment.datagsm.common.domain.project.entity.ProjectJpaEntity
+import team.themoment.datagsm.common.domain.project.repository.ProjectJpaRepository
 import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
+import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.common.domain.teacher.dto.response.TeacherResDto
 import team.themoment.datagsm.common.domain.teacher.repository.TeacherJpaRepository
@@ -16,15 +22,20 @@ import team.themoment.datagsm.common.domain.teacher.repository.TeacherJpaReposit
 class AccountObjectResolver(
     private val studentJpaRepository: StudentJpaRepository,
     private val teacherJpaRepository: TeacherJpaRepository,
+    private val projectJpaRepository: ProjectJpaRepository,
 ) {
     fun resolve(account: AccountJpaEntity): ResolvedAccountObject {
         val objectId = account.objectId ?: return ResolvedAccountObject(null, null)
         return when (account.objectType) {
-            AccountObjectType.STUDENT ->
+            AccountObjectType.STUDENT -> {
+                val student = studentJpaRepository.findById(objectId).orElse(null)
                 ResolvedAccountObject(
-                    student = studentJpaRepository.findById(objectId).map { StudentResDto.from(it) }.orElse(null),
+                    student = student?.let { StudentResDto.from(it) },
                     teacher = null,
+                    clubs = student?.let { resolveClubs(it) } ?: emptyList(),
+                    projects = student?.let { resolveProjects(it) } ?: emptyList(),
                 )
+            }
             AccountObjectType.TEACHER ->
                 ResolvedAccountObject(
                     student = null,
@@ -33,6 +44,16 @@ class AccountObjectResolver(
             null -> ResolvedAccountObject(null, null)
         }
     }
+
+    private fun resolveClubs(student: StudentJpaEntity): List<ClubSummaryDto> =
+        listOfNotNull(student.majorClub, student.autonomousClub).map { it.toSummaryDto() }
+
+    private fun resolveProjects(student: StudentJpaEntity): List<ProjectSummaryDto> =
+        projectJpaRepository.findAllByParticipantId(student.id!!).map { it.toSummaryDto() }
+
+    private fun ClubJpaEntity.toSummaryDto() = ClubSummaryDto(id = id!!, name = name, type = type)
+
+    private fun ProjectJpaEntity.toSummaryDto() = ProjectSummaryDto(id = id!!, name = name, status = status, club = club?.toSummaryDto())
 
     fun resolveAll(accounts: List<AccountJpaEntity>): Map<Long, ResolvedAccountObject> {
         val studentIds =

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/dto/response/OAuthScopeResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/dto/response/OAuthScopeResDto.kt
@@ -3,7 +3,7 @@ package team.themoment.datagsm.common.domain.client.dto.response
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class OAuthScopeResDto(
-    @field:Schema(description = "OAuth 권한 범위 이름", example = "appId:self_read")
+    @field:Schema(description = "OAuth 권한 범위 이름", example = "appId:account_read")
     val scope: String,
     @field:Schema(description = "OAuth 권한 범위 설명", example = "내 정보 조회")
     val description: String,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/constant/OAuthScope.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/constant/OAuthScope.kt
@@ -20,6 +20,12 @@ class OAuthScope(
     override fun hashCode(): Int = scope.hashCode()
 
     companion object {
+        const val ACCOUNT_READ = "account_read"
+        const val STUDENT_READ = "student_read"
+        const val SELF_READ = "self_read"
+        const val CLUB_READ = "club_read"
+        const val PROJECT_READ = "project_read"
+
         fun authorityOf(
             applicationId: String,
             scopeName: String,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/club/dto/internal/ClubSummaryDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/club/dto/internal/ClubSummaryDto.kt
@@ -1,6 +1,7 @@
 package team.themoment.datagsm.common.domain.club.dto.internal
 
 import io.swagger.v3.oas.annotations.media.Schema
+import team.themoment.datagsm.common.domain.club.entity.ClubJpaEntity
 import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
 import team.themoment.datagsm.ksp.annotation.SdkExport
 
@@ -12,4 +13,8 @@ data class ClubSummaryDto(
     val name: String,
     @field:Schema(description = "동아리 종류", example = "MAJOR_CLUB")
     val type: ClubType,
-)
+) {
+    companion object {
+        fun from(club: ClubJpaEntity): ClubSummaryDto = ClubSummaryDto(id = club.id!!, name = club.name, type = club.type)
+    }
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
@@ -28,8 +28,10 @@ data class OauthAuthorizeReqDto(
     )
     val code_challenge_method: String? = null,
     @param:Schema(
-        description = "요청할 OAuth Scope 목록 (공백 구분, 미입력 시 client의 전체 허용 scope 사용)",
-        example = "self:read profile:read",
+        description =
+            "요청할 OAuth Scope 목록 (공백 구분). 미입력 시 기본 scope(account_read student_read)만 부여됩니다. " +
+                "student_read/club_read/project_read는 명시적으로 요청해야 합니다. self_read는 하위 호환을 위한 deprecated scope입니다.",
+        example = "account_read student_read club_read project_read",
         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
     )
     val scope: String? = null,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
@@ -29,9 +29,9 @@ data class OauthAuthorizeReqDto(
     val code_challenge_method: String? = null,
     @param:Schema(
         description =
-            "요청할 OAuth Scope 목록 (공백 구분). 미입력 시 기본 scope(account_read student_read)만 부여됩니다. " +
+            "요청할 OAuth Scope 목록 (공백 구분, appId:scopeName 형식). 미입력 시 기본 scope(appId:account_read appId:student_read)만 부여됩니다. " +
                 "student_read/club_read/project_read는 명시적으로 요청해야 합니다. self_read는 하위 호환을 위한 deprecated scope입니다.",
-        example = "account_read student_read club_read project_read",
+        example = "appId:account_read appId:student_read appId:club_read appId:project_read",
         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
     )
     val scope: String? = null,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionHandoffRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionHandoffRedisEntity.kt
@@ -1,0 +1,19 @@
+package team.themoment.datagsm.common.domain.oauth.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.TimeToLive
+
+/**
+ * BFF가 서버-투-서버로 호출하는 POST /authorize 응답에는 브라우저 쿠키를 심을 수 없다.
+ * 세션 쿠키를 백엔드 도메인에 심기 위해 브라우저를 한 번 경유시키는 일회용 티켓이다.
+ */
+@RedisHash("idp_session_handoff")
+data class IdpSessionHandoffRedisEntity(
+    @Id
+    val ticket: String,
+    val sessionId: String,
+    val redirectUrl: String,
+    @TimeToLive
+    val ttl: Long,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionRedisEntity.kt
@@ -1,0 +1,14 @@
+package team.themoment.datagsm.common.domain.oauth.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.TimeToLive
+
+@RedisHash("idp_session")
+data class IdpSessionRedisEntity(
+    @Id
+    val sessionId: String,
+    val email: String,
+    @TimeToLive
+    val ttl: Long,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthConsentJpaEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthConsentJpaEntity.kt
@@ -1,0 +1,71 @@
+package team.themoment.datagsm.common.domain.oauth.entity
+
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+/**
+ * 사용자가 특정 클라이언트에 허용한 scope 기록.
+ * SSO 세션으로 로그인을 생략할 때, 이미 동의한 scope인지 판단하는 근거가 된다.
+ */
+@Table(
+    name = "tb_oauth_consent",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_oauth_consent_account_client", columnNames = ["account_id", "client_id"]),
+    ],
+    indexes = [
+        Index(name = "idx_oauth_consent_account_id", columnList = "account_id"),
+    ],
+)
+@Entity
+class OauthConsentJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null
+
+    @Column(name = "account_id", nullable = false)
+    var accountId: Long = 0
+
+    @Column(name = "client_id", nullable = false)
+    lateinit var clientId: String
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name = "tb_oauth_consent_scope",
+        joinColumns = [JoinColumn(name = "consent_id")],
+    )
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @Column(name = "scope")
+    val grantedScopes: MutableSet<String> = mutableSetOf()
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime? = null
+
+    companion object {
+        fun create(
+            accountId: Long,
+            clientId: String,
+            scopes: Set<String>,
+        ): OauthConsentJpaEntity =
+            OauthConsentJpaEntity().apply {
+                this.accountId = accountId
+                this.clientId = clientId
+                this.grantedScopes.addAll(scopes)
+            }
+    }
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/IdpSessionHandoffRedisRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/IdpSessionHandoffRedisRepository.kt
@@ -1,0 +1,6 @@
+package team.themoment.datagsm.common.domain.oauth.repository
+
+import org.springframework.data.repository.CrudRepository
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
+
+interface IdpSessionHandoffRedisRepository : CrudRepository<IdpSessionHandoffRedisEntity, String>

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/IdpSessionRedisRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/IdpSessionRedisRepository.kt
@@ -1,0 +1,6 @@
+package team.themoment.datagsm.common.domain.oauth.repository
+
+import org.springframework.data.repository.CrudRepository
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
+
+interface IdpSessionRedisRepository : CrudRepository<IdpSessionRedisEntity, String>

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/OauthConsentJpaRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/OauthConsentJpaRepository.kt
@@ -1,0 +1,12 @@
+package team.themoment.datagsm.common.domain.oauth.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
+import java.util.Optional
+
+interface OauthConsentJpaRepository : JpaRepository<OauthConsentJpaEntity, Long> {
+    fun findByAccountIdAndClientId(
+        accountId: Long,
+        clientId: String,
+    ): Optional<OauthConsentJpaEntity>
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/internal/ProjectSummaryDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/dto/internal/ProjectSummaryDto.kt
@@ -1,0 +1,18 @@
+package team.themoment.datagsm.common.domain.project.dto.internal
+
+import io.swagger.v3.oas.annotations.media.Schema
+import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
+import team.themoment.datagsm.ksp.annotation.SdkExport
+
+@SdkExport
+data class ProjectSummaryDto(
+    @field:Schema(description = "프로젝트 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "프로젝트 이름", example = "DataGSM")
+    val name: String,
+    @field:Schema(description = "프로젝트 상태", example = "ACTIVE")
+    val status: ProjectStatus,
+    @field:Schema(description = "소속 동아리")
+    val club: ClubSummaryDto?,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/ProjectJpaCustomRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/ProjectJpaCustomRepository.kt
@@ -17,4 +17,6 @@ interface ProjectJpaCustomRepository {
         sortBy: ProjectSortBy?,
         sortDirection: SortDirection,
     ): Page<ProjectJpaEntity>
+
+    fun findAllByParticipantId(studentId: Long): List<ProjectJpaEntity>
 }

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/impl/ProjectJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/impl/ProjectJpaCustomRepositoryImpl.kt
@@ -105,7 +105,6 @@ class ProjectJpaCustomRepositoryImpl(
             .join(projectJpaEntity.participants, studentJpaEntity)
             .where(studentJpaEntity.id.eq(studentId))
             .fetch()
-            .distinct()
 
     private fun createOrderSpecifier(
         sortBy: ProjectSortBy?,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/impl/ProjectJpaCustomRepositoryImpl.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/project/repository/custom/impl/ProjectJpaCustomRepositoryImpl.kt
@@ -11,6 +11,7 @@ import team.themoment.datagsm.common.domain.project.entity.QProjectJpaEntity.Com
 import team.themoment.datagsm.common.domain.project.entity.constant.ProjectSortBy
 import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.project.repository.custom.ProjectJpaCustomRepository
+import team.themoment.datagsm.common.domain.student.entity.QStudentJpaEntity.Companion.studentJpaEntity
 import team.themoment.datagsm.common.global.constant.SortDirection
 
 @Repository
@@ -95,6 +96,16 @@ class ProjectJpaCustomRepositoryImpl(
 
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
     }
+
+    override fun findAllByParticipantId(studentId: Long): List<ProjectJpaEntity> =
+        jpaQueryFactory
+            .selectFrom(projectJpaEntity)
+            .leftJoin(projectJpaEntity.club)
+            .fetchJoin()
+            .join(projectJpaEntity.participants, studentJpaEntity)
+            .where(studentJpaEntity.id.eq(studentId))
+            .fetch()
+            .distinct()
 
     private fun createOrderSpecifier(
         sortBy: ProjectSortBy?,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/response/StudentResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/student/dto/response/StudentResDto.kt
@@ -61,11 +61,8 @@ data class StudentResDto(
                 role = student.role,
                 dormitoryFloor = student.dormitoryRoomNumber?.dormitoryRoomFloor,
                 dormitoryRoom = student.dormitoryRoomNumber?.dormitoryRoomNumber,
-                majorClub = student.majorClub?.let { ClubSummaryDto(id = it.id!!, name = it.name, type = it.type) },
-                autonomousClub =
-                    student.autonomousClub?.let {
-                        ClubSummaryDto(id = it.id!!, name = it.name, type = it.type)
-                    },
+                majorClub = student.majorClub?.let { ClubSummaryDto.from(it) },
+                autonomousClub = student.autonomousClub?.let { ClubSummaryDto.from(it) },
                 githubId = student.githubId,
                 githubUrl = student.githubId?.let { "https://github.com/$it" },
             )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/data/OauthEnvironment.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/data/OauthEnvironment.kt
@@ -7,4 +7,10 @@ data class OauthEnvironment(
     val codeExpirationSeconds: Long,
     val frontendUrl: String,
     val authorizeStateExpirationMs: Long,
+    val issuerUrl: String,
+    val idpSessionExpirationSeconds: Long,
+    val idpSessionHandoffExpirationSeconds: Long,
+    val idpSessionCookieName: String,
+    val idpSessionCookieDomain: String?,
+    val idpSessionCookieSecure: Boolean,
 )

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
@@ -7,12 +7,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.themoment.datagsm.common.domain.oauth.dto.request.Oauth2TokenReqDto
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeReqDto
@@ -22,6 +24,7 @@ import team.themoment.datagsm.common.domain.oauth.dto.response.Oauth2TokenResDto
 import team.themoment.datagsm.common.domain.oauth.dto.response.OauthSessionResDto
 import team.themoment.datagsm.common.domain.student.dto.request.QueryStudentDataEditRequestReqDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentDataEditRequestResDto
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteIdpSessionHandoffService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthAuthorizeFlowService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.Oauth2TokenService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryJwkSetService
@@ -36,6 +39,7 @@ class OauthController(
     val oauth2TokenService: Oauth2TokenService,
     val startOauthAuthorizeFlowService: StartOauthAuthorizeFlowService,
     val completeOauthAuthorizeFlowService: CompleteOauthAuthorizeFlowService,
+    val completeIdpSessionHandoffService: CompleteIdpSessionHandoffService,
     val queryOauthSessionService: QueryOauthSessionService,
     val queryJwkSetService: QueryJwkSetService,
     val queryStudentDataEditRequestService: QueryStudentDataEditRequestService,
@@ -54,7 +58,23 @@ class OauthController(
     )
     fun authorizeGet(
         @Valid @ModelAttribute queryReq: OauthAuthorizeReqDto,
-    ): ResponseEntity<Void> = startOauthAuthorizeFlowService.execute(queryReq)
+        @CookieValue(name = "\${spring.security.oauth.idp-session-cookie-name}", required = false) sessionId: String?,
+    ): ResponseEntity<Void> = startOauthAuthorizeFlowService.execute(queryReq, sessionId)
+
+    @GetMapping("/authorize/session")
+    @Operation(
+        summary = "IdP 세션 확립",
+        description = "로그인 직후 발급된 일회용 티켓으로 SSO 세션 쿠키를 설정하고 클라이언트로 리다이렉트합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "302", description = "세션 쿠키 설정 후 외부 서비스로 리다이렉트"),
+            ApiResponse(responseCode = "400", description = "유효하지 않거나 만료된 티켓", content = [Content()]),
+        ],
+    )
+    fun completeIdpSessionHandoff(
+        @RequestParam ticket: String,
+    ): ResponseEntity<Void> = completeIdpSessionHandoffService.execute(ticket)
 
     @PostMapping("/authorize")
     @Operation(

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffService.kt
@@ -1,0 +1,7 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import org.springframework.http.ResponseEntity
+
+interface CompleteIdpSessionHandoffService {
+    fun execute(ticket: String): ResponseEntity<Void>
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/IssueAuthorizationCodeService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/IssueAuthorizationCodeService.kt
@@ -1,0 +1,13 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+interface IssueAuthorizationCodeService {
+    fun execute(
+        email: String,
+        clientId: String,
+        redirectUri: String,
+        state: String?,
+        codeChallenge: String?,
+        codeChallengeMethod: String?,
+        scopes: Set<String>,
+    ): String
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowService.kt
@@ -4,5 +4,8 @@ import org.springframework.http.ResponseEntity
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeReqDto
 
 interface StartOauthAuthorizeFlowService {
-    fun execute(reqDto: OauthAuthorizeReqDto): ResponseEntity<Void>
+    fun execute(
+        reqDto: OauthAuthorizeReqDto,
+        sessionId: String?,
+    ): ResponseEntity<Void>
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
@@ -1,0 +1,48 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseCookie
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteIdpSessionHandoffService
+import java.net.URI
+import java.time.Duration
+
+@Service
+class CompleteIdpSessionHandoffServiceImpl(
+    private val idpSessionHandoffRedisRepository: IdpSessionHandoffRedisRepository,
+    private val oauthEnvironment: OauthEnvironment,
+) : CompleteIdpSessionHandoffService {
+    override fun execute(ticket: String): ResponseEntity<Void> {
+        val handoff =
+            idpSessionHandoffRedisRepository.findByIdOrNull(ticket)
+                ?: throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
+
+        idpSessionHandoffRedisRepository.deleteById(ticket)
+
+        val cookie =
+            ResponseCookie
+                .from(oauthEnvironment.idpSessionCookieName, handoff.sessionId)
+                .httpOnly(true)
+                .secure(oauthEnvironment.idpSessionCookieSecure)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(Duration.ofSeconds(oauthEnvironment.idpSessionExpirationSeconds))
+                .also { builder ->
+                    oauthEnvironment.idpSessionCookieDomain
+                        ?.takeIf { it.isNotBlank() }
+                        ?.let { builder.domain(it) }
+                }.build()
+
+        return ResponseEntity
+            .status(HttpStatus.FOUND)
+            .header(HttpHeaders.SET_COOKIE, cookie.toString())
+            .location(URI.create(handoff.redirectUrl))
+            .build()
+    }
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.util.UriComponentsBuilder
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatus
 import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
@@ -16,10 +17,14 @@ import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.StudentEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeSubmitReqDto
-import team.themoment.datagsm.common.domain.oauth.entity.OauthCodeRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
-import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepository
 import team.themoment.datagsm.common.domain.student.entity.DormitoryRoomNumber
 import team.themoment.datagsm.common.domain.student.entity.StudentDataEditRequestJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
@@ -28,11 +33,13 @@ import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRe
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthAuthorizeFlowService
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
 import team.themoment.sdk.exception.ExpectedException
 import java.net.URI
 import java.security.SecureRandom
 import java.util.Base64
+import java.util.UUID
 
 @Service
 class CompleteOauthAuthorizeFlowServiceImpl(
@@ -40,8 +47,11 @@ class CompleteOauthAuthorizeFlowServiceImpl(
     private val studentJpaRepository: StudentJpaRepository,
     private val clubJpaRepository: ClubJpaRepository,
     private val studentDataEditRequestJpaRepository: StudentDataEditRequestJpaRepository,
-    private val oauthCodeRedisRepository: OauthCodeRedisRepository,
     private val oauthAuthorizeStateRedisRepository: OauthAuthorizeStateRedisRepository,
+    private val idpSessionRedisRepository: IdpSessionRedisRepository,
+    private val idpSessionHandoffRedisRepository: IdpSessionHandoffRedisRepository,
+    private val oauthConsentJpaRepository: OauthConsentJpaRepository,
+    private val issueAuthorizationCodeService: IssueAuthorizationCodeService,
     private val passwordEncoder: PasswordEncoder,
     private val oauthEnvironment: OauthEnvironment,
     private val oauthClientRateLimitService: OAuthClientRateLimitService,
@@ -93,29 +103,73 @@ class CompleteOauthAuthorizeFlowServiceImpl(
             resolveStudentDataEditRequestIfNeeded(account.objectId!!, reqDto)
         }
 
-        val code = generateAuthorizationCode()
-
-        val oauthCodeEntity =
-            OauthCodeRedisEntity(
+        val redirectUrl =
+            issueAuthorizationCodeService.execute(
                 email = account.email,
                 clientId = clientId,
                 redirectUri = redirectUri,
+                state = state,
                 codeChallenge = codeChallenge,
                 codeChallengeMethod = codeChallengeMethod,
                 scopes = scopes,
-                code = code,
-                ttl = oauthEnvironment.codeExpirationSeconds,
             )
-        oauthCodeRedisRepository.save(oauthCodeEntity)
 
         oauthAuthorizeStateRedisRepository.deleteById(reqDto.token)
 
-        val redirectUrl = buildRedirectUrl(redirectUri, code, state)
+        account.id?.let { recordConsent(it, clientId, scopes) }
+
+        val handoffUrl = createSessionHandoff(account.email, redirectUrl)
 
         return ResponseEntity
             .status(HttpStatus.FOUND)
-            .location(URI.create(redirectUrl))
+            .location(URI.create(handoffUrl))
             .build()
+    }
+
+    // BFF가 서버-투-서버로 호출하므로 이 응답에는 브라우저 쿠키를 심을 수 없다.
+    // 세션을 만들어두고, 브라우저가 최상위 이동으로 경유할 일회용 티켓 URL을 돌려준다.
+    private fun createSessionHandoff(
+        email: String,
+        redirectUrl: String,
+    ): String {
+        val sessionId = UUID.randomUUID().toString()
+        idpSessionRedisRepository.save(
+            IdpSessionRedisEntity(
+                sessionId = sessionId,
+                email = email,
+                ttl = oauthEnvironment.idpSessionExpirationSeconds,
+            ),
+        )
+
+        val ticket = generateOpaqueToken()
+        idpSessionHandoffRedisRepository.save(
+            IdpSessionHandoffRedisEntity(
+                ticket = ticket,
+                sessionId = sessionId,
+                redirectUrl = redirectUrl,
+                ttl = oauthEnvironment.idpSessionHandoffExpirationSeconds,
+            ),
+        )
+
+        return UriComponentsBuilder
+            .fromUriString(oauthEnvironment.issuerUrl)
+            .path("/v1/oauth/authorize/session")
+            .queryParam("ticket", ticket)
+            .build()
+            .toUriString()
+    }
+
+    private fun recordConsent(
+        accountId: Long,
+        clientId: String,
+        scopes: Set<String>,
+    ) {
+        val consent =
+            oauthConsentJpaRepository
+                .findByAccountIdAndClientId(accountId, clientId)
+                .orElseGet { OauthConsentJpaEntity.create(accountId, clientId, emptySet()) }
+        consent.grantedScopes.addAll(scopes)
+        oauthConsentJpaRepository.save(consent)
     }
 
     private fun resolveStudentDataEditRequestIfNeeded(
@@ -227,21 +281,9 @@ class CompleteOauthAuthorizeFlowServiceImpl(
             githubId = student.githubId,
         )
 
-    private fun generateAuthorizationCode(): String =
+    private fun generateOpaqueToken(): String =
         Base64
             .getUrlEncoder()
             .withoutPadding()
             .encodeToString(ByteArray(22).also { secureRandom.nextBytes(it) })
-
-    private fun buildRedirectUrl(
-        redirectUri: String,
-        code: String,
-        state: String?,
-    ): String =
-        buildString {
-            append(redirectUri)
-            append(if (redirectUri.contains('?')) '&' else '?')
-            append("code=").append(code)
-            state?.let { append("&state=").append(it) }
-        }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/IssueAuthorizationCodeServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/IssueAuthorizationCodeServiceImpl.kt
@@ -1,0 +1,64 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
+
+import org.springframework.stereotype.Service
+import team.themoment.datagsm.common.domain.oauth.entity.OauthCodeRedisEntity
+import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
+import java.security.SecureRandom
+import java.util.Base64
+
+@Service
+class IssueAuthorizationCodeServiceImpl(
+    private val oauthCodeRedisRepository: OauthCodeRedisRepository,
+    private val oauthEnvironment: OauthEnvironment,
+) : IssueAuthorizationCodeService {
+    companion object {
+        private val secureRandom = SecureRandom()
+    }
+
+    override fun execute(
+        email: String,
+        clientId: String,
+        redirectUri: String,
+        state: String?,
+        codeChallenge: String?,
+        codeChallengeMethod: String?,
+        scopes: Set<String>,
+    ): String {
+        val code = generateAuthorizationCode()
+
+        oauthCodeRedisRepository.save(
+            OauthCodeRedisEntity(
+                email = email,
+                clientId = clientId,
+                redirectUri = redirectUri,
+                codeChallenge = codeChallenge,
+                codeChallengeMethod = codeChallengeMethod,
+                scopes = scopes,
+                code = code,
+                ttl = oauthEnvironment.codeExpirationSeconds,
+            ),
+        )
+
+        return buildRedirectUrl(redirectUri, code, state)
+    }
+
+    private fun generateAuthorizationCode(): String =
+        Base64
+            .getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(ByteArray(22).also { secureRandom.nextBytes(it) })
+
+    private fun buildRedirectUrl(
+        redirectUri: String,
+        code: String,
+        state: String?,
+    ): String =
+        buildString {
+            append(redirectUri)
+            append(if (redirectUri.contains('?')) '&' else '?')
+            append("code=").append(code)
+            state?.let { append("&state=").append(it) }
+        }
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -12,6 +12,7 @@ import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.StartOauthAuthorizeFlowService
+import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
 import java.util.UUID
 
 @Service
@@ -19,6 +20,7 @@ class StartOauthAuthorizeFlowServiceImpl(
     private val clientJpaRepository: ClientJpaRepository,
     private val oauthEnvironment: OauthEnvironment,
     private val oauthAuthorizeStateRedisRepository: OauthAuthorizeStateRedisRepository,
+    private val jwtEnvironment: OauthJwtProvisionEnvironment,
 ) : StartOauthAuthorizeFlowService {
     override fun execute(reqDto: OauthAuthorizeReqDto): ResponseEntity<Void> {
         val clientId = reqDto.client_id ?: throw OAuthException.InvalidRequest("client_id는 필수입니다.")
@@ -87,11 +89,22 @@ class StartOauthAuthorizeFlowServiceImpl(
         requestedScopes: Set<String>?,
         clientScopes: Set<String>,
     ): Set<String> {
-        if (requestedScopes == null) return clientScopes
+        if (requestedScopes == null) return defaultScopes(clientScopes)
         val invalid = requestedScopes - clientScopes
         if (invalid.isNotEmpty()) {
             throw OAuthException.InvalidScope("클라이언트에 허용되지 않은 권한 범위가 포함되어 있습니다.")
         }
         return requestedScopes
+    }
+
+    // scope 파라미터 미입력 시 client의 전체 허용 scope가 아닌 기본 UserInfo scope만 요청된 것으로 처리한다.
+    // account_read/student_read를 아직 부여받지 못한 레거시 client는 deprecated self_read로 대체한다.
+    private fun defaultScopes(clientScopes: Set<String>): Set<String> {
+        val applicationId = jwtEnvironment.datagsmApplicationId
+        val defaults = setOf("$applicationId:account_read", "$applicationId:student_read").intersect(clientScopes)
+        if (defaults.isNotEmpty()) return defaults
+
+        val legacySelfRead = "$applicationId:self_read"
+        return if (legacySelfRead in clientScopes) setOf(legacySelfRead) else emptySet()
     }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import org.springframework.web.util.UriComponentsBuilder
+import team.themoment.datagsm.common.domain.client.entity.constant.OAuthScope
 import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeReqDto
 import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
@@ -99,12 +100,17 @@ class StartOauthAuthorizeFlowServiceImpl(
 
     // scope 파라미터 미입력 시 client의 전체 허용 scope가 아닌 기본 UserInfo scope만 요청된 것으로 처리한다.
     // account_read/student_read를 아직 부여받지 못한 레거시 client는 deprecated self_read로 대체한다.
+    // 둘 다 없는 client는 스코프 없는 토큰이 조용히 발급되는 것을 막기 위해 InvalidScope로 실패시킨다.
     private fun defaultScopes(clientScopes: Set<String>): Set<String> {
         val applicationId = jwtEnvironment.datagsmApplicationId
-        val defaults = setOf("$applicationId:account_read", "$applicationId:student_read").intersect(clientScopes)
+        val defaults =
+            setOf("$applicationId:${OAuthScope.ACCOUNT_READ}", "$applicationId:${OAuthScope.STUDENT_READ}")
+                .intersect(clientScopes)
         if (defaults.isNotEmpty()) return defaults
 
-        val legacySelfRead = "$applicationId:self_read"
-        return if (legacySelfRead in clientScopes) setOf(legacySelfRead) else emptySet()
+        val legacySelfRead = "$applicationId:${OAuthScope.SELF_READ}"
+        if (legacySelfRead in clientScopes) return setOf(legacySelfRead)
+
+        throw OAuthException.InvalidScope("클라이언트에 기본으로 부여할 수 있는 권한 범위가 없습니다.")
     }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -1,19 +1,30 @@
 package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.util.UriComponentsBuilder
+import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatus
+import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
 import team.themoment.datagsm.common.domain.client.entity.constant.OAuthScope
 import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeReqDto
 import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
 import team.themoment.datagsm.common.domain.oauth.entity.constant.PkceChallengeMethod
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepository
+import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRequestJpaRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.StartOauthAuthorizeFlowService
 import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
+import java.net.URI
 import java.util.UUID
 
 @Service
@@ -22,8 +33,17 @@ class StartOauthAuthorizeFlowServiceImpl(
     private val oauthEnvironment: OauthEnvironment,
     private val oauthAuthorizeStateRedisRepository: OauthAuthorizeStateRedisRepository,
     private val jwtEnvironment: OauthJwtProvisionEnvironment,
+    private val idpSessionRedisRepository: IdpSessionRedisRepository,
+    private val accountJpaRepository: AccountJpaRepository,
+    private val studentDataEditRequestJpaRepository: StudentDataEditRequestJpaRepository,
+    private val oauthConsentJpaRepository: OauthConsentJpaRepository,
+    private val issueAuthorizationCodeService: IssueAuthorizationCodeService,
 ) : StartOauthAuthorizeFlowService {
-    override fun execute(reqDto: OauthAuthorizeReqDto): ResponseEntity<Void> {
+    @Transactional(readOnly = true)
+    override fun execute(
+        reqDto: OauthAuthorizeReqDto,
+        sessionId: String?,
+    ): ResponseEntity<Void> {
         val clientId = reqDto.client_id ?: throw OAuthException.InvalidRequest("client_id는 필수입니다.")
         val redirectUri = reqDto.redirect_uri ?: throw OAuthException.InvalidRequest("redirect_uri는 필수입니다.")
         val responseType = reqDto.response_type
@@ -56,6 +76,24 @@ class StartOauthAuthorizeFlowServiceImpl(
                 ?.toSet()
         val resolvedScopes = resolveScopes(requestedScopes, client.scopes)
 
+        val ssoAccount = resolveSsoAccount(sessionId, clientId, resolvedScopes)
+        if (ssoAccount != null) {
+            val redirectUrl =
+                issueAuthorizationCodeService.execute(
+                    email = ssoAccount.email,
+                    clientId = clientId,
+                    redirectUri = redirectUri,
+                    state = state,
+                    codeChallenge = codeChallenge,
+                    codeChallengeMethod = codeChallengeMethod,
+                    scopes = resolvedScopes,
+                )
+            return ResponseEntity
+                .status(HttpStatus.FOUND)
+                .location(URI.create(redirectUrl))
+                .build()
+        }
+
         val token = UUID.randomUUID().toString()
 
         val stateEntity =
@@ -84,6 +122,37 @@ class StartOauthAuthorizeFlowServiceImpl(
             .status(HttpStatus.FOUND)
             .location(location)
             .build()
+    }
+
+    // SSO 세션으로 로그인을 생략할 수 있는지 판단한다.
+    // 어느 조건이든 충족하지 못하면 null을 반환해 기존 로그인 플로우로 폴백시킨다.
+    private fun resolveSsoAccount(
+        sessionId: String?,
+        clientId: String,
+        resolvedScopes: Set<String>,
+    ): AccountJpaEntity? {
+        if (sessionId.isNullOrBlank()) return null
+
+        val session = idpSessionRedisRepository.findByIdOrNull(sessionId) ?: return null
+        val account = accountJpaRepository.findByEmail(session.email).orElse(null) ?: return null
+        val accountId = account.id ?: return null
+
+        if (account.status != AccountStatus.ACTIVE) return null
+
+        val studentId = account.objectId
+        if (account.objectType == AccountObjectType.STUDENT && studentId != null) {
+            val hasPendingEditRequest = studentDataEditRequestJpaRepository.findByStudentId(studentId).isPresent
+            if (hasPendingEditRequest) return null
+        }
+
+        val consent =
+            oauthConsentJpaRepository
+                .findByAccountIdAndClientId(accountId, clientId)
+                .orElse(null) ?: return null
+
+        if (!consent.grantedScopes.containsAll(resolvedScopes)) return null
+
+        return account
     }
 
     private fun resolveScopes(

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/data/OauthJwtProvisionEnvironment.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/data/OauthJwtProvisionEnvironment.kt
@@ -9,4 +9,5 @@ data class OauthJwtProvisionEnvironment(
     val keyId: String,
     val accessTokenExpiration: Long,
     val refreshTokenExpiration: Long,
+    val datagsmApplicationId: String,
 )

--- a/datagsm-oauth-authorization/src/main/resources/application.yml
+++ b/datagsm-oauth-authorization/src/main/resources/application.yml
@@ -52,6 +52,7 @@ spring:
       public-key: ${JWT_PUBLIC_KEY}
       access-token-expiration: ${OAUTH_ACCESS_TOKEN_EXPIRATION:3600000}
       refresh-token-expiration: ${OAUTH_REFRESH_TOKEN_EXPIRATION:2592000000}
+      datagsm-application-id: ${DATAGSM_APPLICATION_ID}
     oauth:
       code-expiration-seconds: ${OAUTH_CODE_EXPIRATION:300}
       frontend-url: ${OAUTH_FRONTEND_URL:http://localhost:3000}

--- a/datagsm-oauth-authorization/src/main/resources/application.yml
+++ b/datagsm-oauth-authorization/src/main/resources/application.yml
@@ -57,6 +57,12 @@ spring:
       code-expiration-seconds: ${OAUTH_CODE_EXPIRATION:300}
       frontend-url: ${OAUTH_FRONTEND_URL:http://localhost:3000}
       authorize-state-expiration-ms: ${OAUTH_AUTHORIZE_STATE_EXPIRATION_MS:600000}
+      issuer-url: ${OAUTH_ISSUER_URL:http://localhost:8081}
+      idp-session-expiration-seconds: ${OAUTH_IDP_SESSION_EXPIRATION_SECONDS:28800}
+      idp-session-handoff-expiration-seconds: ${OAUTH_IDP_SESSION_HANDOFF_EXPIRATION_SECONDS:60}
+      idp-session-cookie-name: ${OAUTH_IDP_SESSION_COOKIE_NAME:datagsm_idp_session}
+      idp-session-cookie-domain: ${OAUTH_IDP_SESSION_COOKIE_DOMAIN:}
+      idp-session-cookie-secure: ${OAUTH_IDP_SESSION_COOKIE_SECURE:true}
     oauth-client:
       rate-limit:
         enabled: true

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffServiceTest.kt
@@ -1,0 +1,120 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
+import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.CompleteIdpSessionHandoffServiceImpl
+import java.util.Optional
+
+class CompleteIdpSessionHandoffServiceTest :
+    DescribeSpec({
+
+        val mockIdpSessionHandoffRedisRepository = mockk<IdpSessionHandoffRedisRepository>(relaxed = true)
+        val mockOauthEnvironment = mockk<OauthEnvironment>()
+
+        val completeIdpSessionHandoffService =
+            CompleteIdpSessionHandoffServiceImpl(
+                mockIdpSessionHandoffRedisRepository,
+                mockOauthEnvironment,
+            )
+
+        afterEach {
+            clearAllMocks()
+        }
+
+        describe("CompleteIdpSessionHandoffService 클래스의") {
+            describe("execute 메서드는") {
+
+                val testTicket = "test-ticket-123"
+                val testSessionId = "session-abc"
+                val testRedirectUrl = "https://example.com/callback?code=test-code&state=random-state"
+                val cookieName = "datagsm_idp_session"
+                val sessionTtl = 28800L
+
+                val handoff =
+                    IdpSessionHandoffRedisEntity(
+                        ticket = testTicket,
+                        sessionId = testSessionId,
+                        redirectUrl = testRedirectUrl,
+                        ttl = 60,
+                    )
+
+                beforeEach {
+                    every { mockOauthEnvironment.idpSessionCookieName } returns cookieName
+                    every { mockOauthEnvironment.idpSessionExpirationSeconds } returns sessionTtl
+                    every { mockOauthEnvironment.idpSessionCookieSecure } returns true
+                    every { mockOauthEnvironment.idpSessionCookieDomain } returns ".datagsm.kr"
+                }
+
+                context("유효한 티켓이 주어졌을 때") {
+                    beforeEach {
+                        every { mockIdpSessionHandoffRedisRepository.findById(testTicket) } returns Optional.of(handoff)
+                    }
+
+                    it("세션 쿠키를 설정하고 원래 목적지로 302 리다이렉트되어야 한다") {
+                        val response = completeIdpSessionHandoffService.execute(testTicket)
+
+                        response.statusCode shouldBe HttpStatus.FOUND
+                        response.headers.location?.toString() shouldBe testRedirectUrl
+
+                        val setCookie = response.headers.getFirst(HttpHeaders.SET_COOKIE) ?: ""
+                        setCookie shouldContain "$cookieName=$testSessionId"
+                        setCookie shouldContain "HttpOnly"
+                        setCookie shouldContain "Secure"
+                        setCookie shouldContain "SameSite=Lax"
+                        setCookie shouldContain "Domain=.datagsm.kr"
+                        setCookie shouldContain "Max-Age=$sessionTtl"
+                    }
+
+                    it("티켓은 일회용이므로 사용 즉시 삭제되어야 한다") {
+                        completeIdpSessionHandoffService.execute(testTicket)
+
+                        verify(exactly = 1) { mockIdpSessionHandoffRedisRepository.deleteById(testTicket) }
+                    }
+                }
+
+                context("쿠키 도메인이 설정되지 않았을 때") {
+                    beforeEach {
+                        every { mockOauthEnvironment.idpSessionCookieDomain } returns null
+                        every { mockIdpSessionHandoffRedisRepository.findById(testTicket) } returns Optional.of(handoff)
+                    }
+
+                    it("Domain 속성 없이 호스트 전용 쿠키가 설정되어야 한다") {
+                        val response = completeIdpSessionHandoffService.execute(testTicket)
+
+                        val setCookie = response.headers.getFirst(HttpHeaders.SET_COOKIE) ?: ""
+                        setCookie shouldContain "$cookieName=$testSessionId"
+                        setCookie.contains("Domain=") shouldBe false
+                    }
+                }
+
+                context("유효하지 않거나 만료된 티켓이 주어졌을 때") {
+                    beforeEach {
+                        every { mockIdpSessionHandoffRedisRepository.findById(any()) } returns Optional.empty()
+                    }
+
+                    it("InvalidRequest 예외가 발생하고 티켓이 삭제되지 않아야 한다") {
+                        val exception =
+                            shouldThrow<OAuthException.InvalidRequest> {
+                                completeIdpSessionHandoffService.execute("expired-ticket")
+                            }
+
+                        exception.error shouldBe "invalid_request"
+
+                        verify(exactly = 0) { mockIdpSessionHandoffRedisRepository.deleteById(any()) }
+                    }
+                }
+            }
+        }
+    })

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
@@ -20,11 +20,15 @@ import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatu
 import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeSubmitReqDto
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
 import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
-import team.themoment.datagsm.common.domain.oauth.entity.OauthCodeRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
-import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepository
 import team.themoment.datagsm.common.domain.student.entity.StudentDataEditRequestJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
@@ -32,6 +36,7 @@ import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRe
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.common.global.dto.internal.RateLimitConsumeResult
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.CompleteOauthAuthorizeFlowServiceImpl
 import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
 import team.themoment.sdk.exception.ExpectedException
@@ -44,8 +49,11 @@ class CompleteOauthAuthorizeFlowServiceTest :
         val mockStudentJpaRepository = mockk<StudentJpaRepository>()
         val mockClubJpaRepository = mockk<ClubJpaRepository>()
         val mockStudentDataEditRequestJpaRepository = mockk<StudentDataEditRequestJpaRepository>(relaxed = true)
-        val mockOauthCodeRedisRepository = mockk<OauthCodeRedisRepository>(relaxed = true)
         val mockOauthAuthorizeStateRedisRepository = mockk<OauthAuthorizeStateRedisRepository>(relaxed = true)
+        val mockIdpSessionRedisRepository = mockk<IdpSessionRedisRepository>(relaxed = true)
+        val mockIdpSessionHandoffRedisRepository = mockk<IdpSessionHandoffRedisRepository>(relaxed = true)
+        val mockOauthConsentJpaRepository = mockk<OauthConsentJpaRepository>(relaxed = true)
+        val mockIssueAuthorizationCodeService = mockk<IssueAuthorizationCodeService>()
         val mockPasswordEncoder = mockk<PasswordEncoder>()
         val mockOauthEnvironment = mockk<OauthEnvironment>()
         val mockOauthClientRateLimitService = mockk<OAuthClientRateLimitService>()
@@ -57,8 +65,11 @@ class CompleteOauthAuthorizeFlowServiceTest :
                 mockStudentJpaRepository,
                 mockClubJpaRepository,
                 mockStudentDataEditRequestJpaRepository,
-                mockOauthCodeRedisRepository,
                 mockOauthAuthorizeStateRedisRepository,
+                mockIdpSessionRedisRepository,
+                mockIdpSessionHandoffRedisRepository,
+                mockOauthConsentJpaRepository,
+                mockIssueAuthorizationCodeService,
                 mockPasswordEncoder,
                 mockOauthEnvironment,
                 mockOauthClientRateLimitService,
@@ -76,7 +87,10 @@ class CompleteOauthAuthorizeFlowServiceTest :
                 val testToken = "test-token-123"
                 val testClientId = "client-123"
                 val testRedirectUri = "https://example.com/callback"
+                val testIssuerUrl = "https://oauth.example.com"
                 val codeExpirationSeconds = 300L
+                val idpSessionExpirationSeconds = 28800L
+                val idpSessionHandoffExpirationSeconds = 60L
 
                 val mockAccount =
                     AccountJpaEntity().apply {
@@ -87,6 +101,9 @@ class CompleteOauthAuthorizeFlowServiceTest :
 
                 beforeEach {
                     every { mockOauthEnvironment.codeExpirationSeconds } returns codeExpirationSeconds
+                    every { mockOauthEnvironment.issuerUrl } returns testIssuerUrl
+                    every { mockOauthEnvironment.idpSessionExpirationSeconds } returns idpSessionExpirationSeconds
+                    every { mockOauthEnvironment.idpSessionHandoffExpirationSeconds } returns idpSessionHandoffExpirationSeconds
                     every { mockOauthClientRateLimitService.tryConsumeAndReturnRemaining(any()) } returns
                         RateLimitConsumeResult(consumed = true, remainingTokens = 299, secondsToWaitForRefill = 0)
                 }
@@ -111,39 +128,69 @@ class CompleteOauthAuthorizeFlowServiceTest :
                             ttl = 600,
                         )
 
-                    val savedEntitySlot = slot<OauthCodeRedisEntity>()
+                    val issuedRedirectUrl = "$testRedirectUri?code=test-code&state=random-state"
+                    val sessionSlot = slot<IdpSessionRedisEntity>()
+                    val handoffSlot = slot<IdpSessionHandoffRedisEntity>()
 
                     beforeEach {
                         every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns Optional.of(mockStateEntity)
                         every { mockAccountJpaRepository.findByEmail(testEmail) } returns Optional.of(mockAccount)
                         every { mockPasswordEncoder.matches("password123!", mockAccount.password) } returns true
-                        every { mockOauthCodeRedisRepository.save(capture(savedEntitySlot)) } answers { firstArg() }
+                        every {
+                            mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                        } returns issuedRedirectUrl
+                        every { mockIdpSessionRedisRepository.save(capture(sessionSlot)) } answers { firstArg() }
+                        every { mockIdpSessionHandoffRedisRepository.save(capture(handoffSlot)) } answers { firstArg() }
+                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(any(), any()) } returns Optional.empty()
+                        every { mockOauthConsentJpaRepository.save(any<OauthConsentJpaEntity>()) } answers { firstArg() }
                     }
 
-                    it("302 리다이렉트 ResponseEntity가 반환되어야 한다") {
+                    it("세션 핸드오프 URL로 302 리다이렉트되어야 한다") {
                         val response = completeOauthAuthorizeFlowService.execute(reqDto)
 
                         response.statusCode shouldBe HttpStatus.FOUND
                         response.headers.location shouldNotBe null
 
                         val redirectUrl = response.headers.location?.toString() ?: ""
-                        redirectUrl shouldStartWith testRedirectUri
-                        redirectUrl shouldContain "code="
-                        redirectUrl shouldContain "state=random-state"
+                        redirectUrl shouldStartWith "$testIssuerUrl/v1/oauth/authorize/session"
+                        redirectUrl shouldContain "ticket="
                     }
 
-                    it("Redis에 Authorization Code가 저장되어야 한다") {
+                    it("Authorization Code 발급이 위임되어야 한다") {
                         completeOauthAuthorizeFlowService.execute(reqDto)
 
-                        verify(exactly = 1) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 1) {
+                            mockIssueAuthorizationCodeService.execute(
+                                testEmail,
+                                testClientId,
+                                testRedirectUri,
+                                "random-state",
+                                "challenge",
+                                "S256",
+                                setOf("self:read"),
+                            )
+                        }
+                    }
 
-                        savedEntitySlot.captured.email shouldBe testEmail
-                        savedEntitySlot.captured.clientId shouldBe testClientId
-                        savedEntitySlot.captured.redirectUri shouldBe testRedirectUri
-                        savedEntitySlot.captured.codeChallenge shouldBe "challenge"
-                        savedEntitySlot.captured.codeChallengeMethod shouldBe "S256"
-                        savedEntitySlot.captured.scopes shouldBe setOf("self:read")
-                        savedEntitySlot.captured.ttl shouldBe codeExpirationSeconds
+                    it("IdP 세션이 생성되고 핸드오프 티켓에 연결되어야 한다") {
+                        completeOauthAuthorizeFlowService.execute(reqDto)
+
+                        sessionSlot.captured.email shouldBe testEmail
+                        sessionSlot.captured.ttl shouldBe idpSessionExpirationSeconds
+
+                        handoffSlot.captured.sessionId shouldBe sessionSlot.captured.sessionId
+                        handoffSlot.captured.redirectUrl shouldBe issuedRedirectUrl
+                        handoffSlot.captured.ttl shouldBe idpSessionHandoffExpirationSeconds
+                    }
+
+                    it("요청한 scope가 동의 기록으로 저장되어야 한다") {
+                        val consentSlot = slot<OauthConsentJpaEntity>()
+                        every { mockOauthConsentJpaRepository.save(capture(consentSlot)) } answers { firstArg() }
+
+                        completeOauthAuthorizeFlowService.execute(reqDto)
+
+                        consentSlot.captured.clientId shouldBe testClientId
+                        consentSlot.captured.grantedScopes shouldBe mutableSetOf("self:read")
                     }
 
                     it("Redis에서 인증 상태가 삭제되어야 한다") {
@@ -174,7 +221,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         exception.errorDescription shouldBe "인증 토큰이 유효하지 않거나 만료되었습니다. 다시 시도해주세요."
 
                         verify(exactly = 0) { mockAccountJpaRepository.findByEmail(any()) }
-                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 0) { mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any()) }
                     }
                 }
 
@@ -212,7 +259,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         exception.message shouldBe "이메일 또는 비밀번호가 일치하지 않습니다."
                         exception.statusCode shouldBe HttpStatus.UNAUTHORIZED
 
-                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 0) { mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any()) }
                     }
                 }
 
@@ -251,7 +298,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         exception.message shouldBe "이메일 또는 비밀번호가 일치하지 않습니다."
                         exception.statusCode shouldBe HttpStatus.UNAUTHORIZED
 
-                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 0) { mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any()) }
                     }
                 }
 
@@ -289,7 +336,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         exception.statusCode shouldBe HttpStatus.UNAUTHORIZED
 
                         verify(exactly = 0) { mockAccountJpaRepository.findByEmail(any()) }
-                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 0) { mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any()) }
                     }
                 }
 
@@ -336,7 +383,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         exception.message shouldBe "아직 승인되지 않은 계정입니다."
                         exception.statusCode shouldBe HttpStatus.FORBIDDEN
 
-                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 0) { mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any()) }
                     }
                 }
 
@@ -391,7 +438,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         exception.message shouldBe "정보 수정이 필요합니다. 정보를 수정한 후 다시 로그인해주세요."
                         exception.statusCode shouldBe HttpStatus.UNPROCESSABLE_ENTITY
 
-                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 0) { mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any()) }
                     }
                 }
 
@@ -448,7 +495,15 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         every { mockStudentDataEditRequestJpaRepository.findByStudentId(10L) } returns Optional.of(editRequest)
                         every { mockStudentJpaRepository.findById(10L) } returns Optional.of(mockStudent)
                         every { mockStudentJpaRepository.existsByStudentNumberAndNotId(2, 1, 5, 10L) } returns false
-                        every { mockOauthCodeRedisRepository.save(any()) } answers { firstArg() }
+                        every {
+                            mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                        } returns "$testRedirectUri?code=test-code&state=random-state"
+                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(any(), any()) } returns Optional.empty()
+                        every { mockOauthConsentJpaRepository.save(any<OauthConsentJpaEntity>()) } answers { firstArg() }
+                        every { mockIdpSessionRedisRepository.save(any<IdpSessionRedisEntity>()) } answers { firstArg() }
+                        every {
+                            mockIdpSessionHandoffRedisRepository.save(any<IdpSessionHandoffRedisEntity>())
+                        } answers { firstArg() }
                     }
 
                     it("정보가 수정되고 302 리다이렉트 ResponseEntity가 반환되어야 한다") {

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -19,6 +19,7 @@ import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.StartOauthAuthorizeFlowServiceImpl
+import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
 import java.util.Optional
 
 class StartOauthAuthorizeFlowServiceTest :
@@ -31,16 +32,25 @@ class StartOauthAuthorizeFlowServiceTest :
                 every { frontendUrl } returns "http://localhost:3000"
                 every { authorizeStateExpirationMs } returns 600000L
             }
+        val mockJwtEnvironment =
+            mockk<OauthJwtProvisionEnvironment> {
+                every { datagsmApplicationId } returns "datagsm"
+            }
 
         val startOauthAuthorizeFlowService =
             StartOauthAuthorizeFlowServiceImpl(
                 mockClientJpaRepository,
                 mockOauthEnvironment,
                 mockOauthAuthorizeStateRedisRepository,
+                mockJwtEnvironment,
             )
 
         afterEach {
             clearAllMocks()
+        }
+
+        beforeEach {
+            every { mockJwtEnvironment.datagsmApplicationId } returns "datagsm"
         }
 
         describe("StartOauthAuthorizeFlowService 클래스의") {
@@ -54,7 +64,7 @@ class StartOauthAuthorizeFlowServiceTest :
                         id = testClientId
                         secret = "encodedSecret"
                         redirectUrls = setOf(testRedirectUri)
-                        scopes.add("self:read")
+                        scopes.addAll(setOf("datagsm:account_read", "datagsm:student_read"))
                         clientName = "Test Client"
                         serviceName = "Test Service"
                     }
@@ -94,7 +104,7 @@ class StartOauthAuthorizeFlowServiceTest :
                         savedEntitySlot.captured.codeChallenge shouldBe "challenge"
                         savedEntitySlot.captured.codeChallengeMethod shouldBe "S256"
                         savedEntitySlot.captured.ttl shouldBe 600
-                        savedEntitySlot.captured.scopes shouldBe setOf("self:read")
+                        savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read", "datagsm:student_read")
                     }
                 }
 
@@ -108,7 +118,7 @@ class StartOauthAuthorizeFlowServiceTest :
                         every { mockOauthAuthorizeStateRedisRepository.save(capture(savedEntitySlot)) } answers { firstArg() }
                     }
 
-                    it("client의 전체 scope가 state entity에 저장되어야 한다") {
+                    it("client 전체 scope가 아닌 기본 scope(account_read, student_read)만 state entity에 저장되어야 한다") {
                         val reqDto =
                             OauthAuthorizeReqDto(
                                 client_id = testClientId,
@@ -117,7 +127,39 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         startOauthAuthorizeFlowService.execute(reqDto)
 
-                        savedEntitySlot.captured.scopes shouldBe setOf("self:read")
+                        savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read", "datagsm:student_read")
+                    }
+                }
+
+                context("scope 파라미터가 null이고 client가 deprecated self_read만 가지고 있을 때") {
+                    val legacyClient =
+                        ClientJpaEntity().apply {
+                            id = testClientId
+                            secret = "encodedSecret"
+                            redirectUrls = setOf(testRedirectUri)
+                            scopes.add("datagsm:self_read")
+                            clientName = "Legacy Client"
+                            serviceName = "Legacy Service"
+                        }
+                    val savedEntitySlot = slot<OauthAuthorizeStateRedisEntity>()
+
+                    beforeEach {
+                        every { mockOauthEnvironment.frontendUrl } returns "http://localhost:3000"
+                        every { mockOauthEnvironment.authorizeStateExpirationMs } returns 600000L
+                        every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(legacyClient)
+                        every { mockOauthAuthorizeStateRedisRepository.save(capture(savedEntitySlot)) } answers { firstArg() }
+                    }
+
+                    it("하위 호환을 위해 self_read가 기본 scope로 저장되어야 한다") {
+                        val reqDto =
+                            OauthAuthorizeReqDto(
+                                client_id = testClientId,
+                                redirect_uri = testRedirectUri,
+                                response_type = "code",
+                            )
+                        startOauthAuthorizeFlowService.execute(reqDto)
+
+                        savedEntitySlot.captured.scopes shouldBe setOf("datagsm:self_read")
                     }
                 }
 
@@ -137,11 +179,11 @@ class StartOauthAuthorizeFlowServiceTest :
                                 client_id = testClientId,
                                 redirect_uri = testRedirectUri,
                                 response_type = "code",
-                                scope = "self:read",
+                                scope = "datagsm:account_read",
                             )
                         startOauthAuthorizeFlowService.execute(reqDto)
 
-                        savedEntitySlot.captured.scopes shouldBe setOf("self:read")
+                        savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read")
                     }
                 }
 
@@ -151,7 +193,9 @@ class StartOauthAuthorizeFlowServiceTest :
                             id = testClientId
                             secret = "encodedSecret"
                             redirectUrls = setOf(testRedirectUri)
-                            scopes.addAll(setOf("self:read", "profile:read"))
+                            scopes.addAll(
+                                setOf("datagsm:account_read", "datagsm:student_read", "datagsm:club_read", "datagsm:project_read"),
+                            )
                             clientName = "Test Client"
                             serviceName = "Test Service"
                         }
@@ -170,11 +214,11 @@ class StartOauthAuthorizeFlowServiceTest :
                                 client_id = testClientId,
                                 redirect_uri = testRedirectUri,
                                 response_type = "code",
-                                scope = "self:read profile:read",
+                                scope = "datagsm:account_read datagsm:club_read",
                             )
                         startOauthAuthorizeFlowService.execute(reqDto)
 
-                        savedEntitySlot.captured.scopes shouldBe setOf("self:read", "profile:read")
+                        savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read", "datagsm:club_read")
                     }
                 }
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -163,6 +163,37 @@ class StartOauthAuthorizeFlowServiceTest :
                     }
                 }
 
+                context("scope 파라미터가 null이고 client가 기본 scope를 하나도 가지고 있지 않을 때") {
+                    val noDefaultScopeClient =
+                        ClientJpaEntity().apply {
+                            id = testClientId
+                            secret = "encodedSecret"
+                            redirectUrls = setOf(testRedirectUri)
+                            scopes.add("datagsm:club_read")
+                            clientName = "No Default Scope Client"
+                            serviceName = "No Default Scope Service"
+                        }
+
+                    beforeEach {
+                        every { mockOauthEnvironment.frontendUrl } returns "http://localhost:3000"
+                        every { mockOauthEnvironment.authorizeStateExpirationMs } returns 600000L
+                        every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(noDefaultScopeClient)
+                    }
+
+                    it("OAuthException.InvalidScope가 발생해야 한다") {
+                        val reqDto =
+                            OauthAuthorizeReqDto(
+                                client_id = testClientId,
+                                redirect_uri = testRedirectUri,
+                                response_type = "code",
+                            )
+
+                        shouldThrow<OAuthException.InvalidScope> {
+                            startOauthAuthorizeFlowService.execute(reqDto)
+                        }
+                    }
+                }
+
                 context("허용된 scope를 요청할 때") {
                     val savedEntitySlot = slot<OauthAuthorizeStateRedisEntity>()
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -11,13 +11,24 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.springframework.http.HttpStatus
+import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatus
+import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
 import team.themoment.datagsm.common.domain.client.entity.ClientJpaEntity
 import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeReqDto
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
 import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepository
+import team.themoment.datagsm.common.domain.student.entity.StudentDataEditRequestJpaEntity
+import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRequestJpaRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.StartOauthAuthorizeFlowServiceImpl
 import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
 import java.util.Optional
@@ -37,12 +48,23 @@ class StartOauthAuthorizeFlowServiceTest :
                 every { datagsmApplicationId } returns "datagsm"
             }
 
+        val mockIdpSessionRedisRepository = mockk<IdpSessionRedisRepository>(relaxed = true)
+        val mockAccountJpaRepository = mockk<AccountJpaRepository>(relaxed = true)
+        val mockStudentDataEditRequestJpaRepository = mockk<StudentDataEditRequestJpaRepository>(relaxed = true)
+        val mockOauthConsentJpaRepository = mockk<OauthConsentJpaRepository>(relaxed = true)
+        val mockIssueAuthorizationCodeService = mockk<IssueAuthorizationCodeService>(relaxed = true)
+
         val startOauthAuthorizeFlowService =
             StartOauthAuthorizeFlowServiceImpl(
                 mockClientJpaRepository,
                 mockOauthEnvironment,
                 mockOauthAuthorizeStateRedisRepository,
                 mockJwtEnvironment,
+                mockIdpSessionRedisRepository,
+                mockAccountJpaRepository,
+                mockStudentDataEditRequestJpaRepository,
+                mockOauthConsentJpaRepository,
+                mockIssueAuthorizationCodeService,
             )
 
         afterEach {
@@ -87,7 +109,7 @@ class StartOauthAuthorizeFlowServiceTest :
                                 code_challenge = "challenge",
                                 code_challenge_method = "S256",
                             )
-                        val response = startOauthAuthorizeFlowService.execute(reqDto)
+                        val response = startOauthAuthorizeFlowService.execute(reqDto, null)
 
                         response.statusCode shouldBe HttpStatus.FOUND
                         response.headers.location shouldNotBe null
@@ -125,7 +147,7 @@ class StartOauthAuthorizeFlowServiceTest :
                                 redirect_uri = testRedirectUri,
                                 response_type = "code",
                             )
-                        startOauthAuthorizeFlowService.execute(reqDto)
+                        startOauthAuthorizeFlowService.execute(reqDto, null)
 
                         savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read", "datagsm:student_read")
                     }
@@ -157,7 +179,7 @@ class StartOauthAuthorizeFlowServiceTest :
                                 redirect_uri = testRedirectUri,
                                 response_type = "code",
                             )
-                        startOauthAuthorizeFlowService.execute(reqDto)
+                        startOauthAuthorizeFlowService.execute(reqDto, null)
 
                         savedEntitySlot.captured.scopes shouldBe setOf("datagsm:self_read")
                     }
@@ -189,7 +211,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
 
                         shouldThrow<OAuthException.InvalidScope> {
-                            startOauthAuthorizeFlowService.execute(reqDto)
+                            startOauthAuthorizeFlowService.execute(reqDto, null)
                         }
                     }
                 }
@@ -212,7 +234,7 @@ class StartOauthAuthorizeFlowServiceTest :
                                 response_type = "code",
                                 scope = "datagsm:account_read",
                             )
-                        startOauthAuthorizeFlowService.execute(reqDto)
+                        startOauthAuthorizeFlowService.execute(reqDto, null)
 
                         savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read")
                     }
@@ -247,7 +269,7 @@ class StartOauthAuthorizeFlowServiceTest :
                                 response_type = "code",
                                 scope = "datagsm:account_read datagsm:club_read",
                             )
-                        startOauthAuthorizeFlowService.execute(reqDto)
+                        startOauthAuthorizeFlowService.execute(reqDto, null)
 
                         savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read", "datagsm:club_read")
                     }
@@ -268,7 +290,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         val exception =
                             shouldThrow<OAuthException.InvalidScope> {
-                                startOauthAuthorizeFlowService.execute(reqDto)
+                                startOauthAuthorizeFlowService.execute(reqDto, null)
                             }
 
                         exception.error shouldBe "invalid_scope"
@@ -290,7 +312,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         val exception =
                             shouldThrow<OAuthException.InvalidRequest> {
-                                startOauthAuthorizeFlowService.execute(reqDto)
+                                startOauthAuthorizeFlowService.execute(reqDto, null)
                             }
 
                         exception.error shouldBe "invalid_request"
@@ -315,7 +337,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         val exception =
                             shouldThrow<OAuthException.InvalidClient> {
-                                startOauthAuthorizeFlowService.execute(reqDto)
+                                startOauthAuthorizeFlowService.execute(reqDto, null)
                             }
 
                         exception.error shouldBe "invalid_client"
@@ -342,7 +364,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         val exception =
                             shouldThrow<OAuthException.InvalidRequest> {
-                                startOauthAuthorizeFlowService.execute(reqDto)
+                                startOauthAuthorizeFlowService.execute(reqDto, null)
                             }
 
                         exception.errorDescription shouldBe "등록되지 않은 redirect_uri입니다."
@@ -368,12 +390,156 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         val exception =
                             shouldThrow<OAuthException.InvalidRequest> {
-                                startOauthAuthorizeFlowService.execute(reqDto)
+                                startOauthAuthorizeFlowService.execute(reqDto, null)
                             }
 
                         exception.errorDescription shouldBe "지원하지 않는 code_challenge_method입니다."
 
                         verify(exactly = 0) { mockOauthAuthorizeStateRedisRepository.save(any()) }
+                    }
+                }
+
+                describe("SSO 세션이 주어졌을 때") {
+                    val testSessionId = "session-abc"
+                    val testEmail = "user@gsm.hs.kr"
+                    val issuedRedirectUrl = "$testRedirectUri?code=test-code"
+                    val loginPageUrl = "http://localhost:3000/oauth/authorize"
+
+                    val ssoReqDto =
+                        OauthAuthorizeReqDto(
+                            client_id = testClientId,
+                            redirect_uri = testRedirectUri,
+                            response_type = "code",
+                            scope = "datagsm:account_read",
+                        )
+
+                    fun activeAccount() =
+                        AccountJpaEntity().apply {
+                            id = 1L
+                            email = testEmail
+                            password = "hashedPassword"
+                            status = AccountStatus.ACTIVE
+                        }
+
+                    beforeEach {
+                        every { mockOauthEnvironment.frontendUrl } returns "http://localhost:3000"
+                        every { mockOauthEnvironment.authorizeStateExpirationMs } returns 600000L
+                        every {
+                            mockOauthAuthorizeStateRedisRepository.save(any<OauthAuthorizeStateRedisEntity>())
+                        } answers { firstArg() }
+                        every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(mockClient)
+                        every { mockIdpSessionRedisRepository.findById(testSessionId) } returns
+                            Optional.of(IdpSessionRedisEntity(testSessionId, testEmail, 28800))
+                        every { mockAccountJpaRepository.findByEmail(testEmail) } returns Optional.of(activeAccount())
+                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returns
+                            Optional.of(OauthConsentJpaEntity.create(1L, testClientId, setOf("datagsm:account_read")))
+                        every {
+                            mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                        } returns issuedRedirectUrl
+                    }
+
+                    context("모든 검증 항목을 충족할 때") {
+                        it("로그인 페이지를 거치지 않고 클라이언트로 바로 리다이렉트되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
+
+                            response.statusCode shouldBe HttpStatus.FOUND
+                            response.headers.location?.toString() shouldBe issuedRedirectUrl
+
+                            verify(exactly = 0) { mockOauthAuthorizeStateRedisRepository.save(any()) }
+                        }
+                    }
+
+                    context("세션 쿠키가 없을 때") {
+                        it("기존 로그인 플로우로 폴백되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, null)
+
+                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            verify(exactly = 1) { mockOauthAuthorizeStateRedisRepository.save(any()) }
+                        }
+                    }
+
+                    context("세션이 만료되었을 때") {
+                        beforeEach {
+                            every { mockIdpSessionRedisRepository.findById(testSessionId) } returns Optional.empty()
+                        }
+
+                        it("기존 로그인 플로우로 폴백되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
+
+                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            verify(exactly = 1) { mockOauthAuthorizeStateRedisRepository.save(any()) }
+                        }
+                    }
+
+                    context("계정이 ACTIVE 상태가 아닐 때") {
+                        beforeEach {
+                            every { mockAccountJpaRepository.findByEmail(testEmail) } returns
+                                Optional.of(activeAccount().apply { status = AccountStatus.PENDING })
+                        }
+
+                        it("기존 로그인 플로우로 폴백되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
+
+                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            verify(exactly = 0) {
+                                mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                            }
+                        }
+                    }
+
+                    context("해소되지 않은 학생 정보 수정 요청이 있을 때") {
+                        beforeEach {
+                            every { mockAccountJpaRepository.findByEmail(testEmail) } returns
+                                Optional.of(
+                                    activeAccount().apply {
+                                        objectType = AccountObjectType.STUDENT
+                                        objectId = 10L
+                                    },
+                                )
+                            every { mockStudentDataEditRequestJpaRepository.findByStudentId(10L) } returns
+                                Optional.of(StudentDataEditRequestJpaEntity())
+                        }
+
+                        it("정보 수정 강제가 우회되지 않도록 로그인 플로우로 폴백되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
+
+                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            verify(exactly = 0) {
+                                mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                            }
+                        }
+                    }
+
+                    context("해당 클라이언트에 대한 동의 기록이 없을 때") {
+                        beforeEach {
+                            every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returns
+                                Optional.empty()
+                        }
+
+                        it("기존 로그인 플로우로 폴백되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
+
+                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            verify(exactly = 0) {
+                                mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                            }
+                        }
+                    }
+
+                    context("동의 기록이 요청한 scope를 모두 포함하지 않을 때") {
+                        beforeEach {
+                            every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returns
+                                Optional.of(OauthConsentJpaEntity.create(1L, testClientId, setOf("datagsm:student_read")))
+                        }
+
+                        it("기존 로그인 플로우로 폴백되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
+
+                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            verify(exactly = 0) {
+                                mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                            }
+                        }
                     }
                 }
             }

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/controller/UserInfoController.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/controller/UserInfoController.kt
@@ -17,7 +17,10 @@ class UserInfoController(
     @GetMapping("/userinfo")
     @Operation(
         summary = "사용자 정보 조회",
-        description = "OAuth2 Access Token을 사용하여 현재 사용자 정보를 조회합니다.",
+        description =
+            "OAuth2 Access Token을 사용하여 현재 사용자 정보를 조회합니다. " +
+                "student/teacher는 student_read(또는 하위 호환 self_read), clubs는 club_read, projects는 project_read " +
+                "스코프를 보유한 경우에만 값이 채워지며, 미보유 시 각각 null 또는 빈 목록으로 반환됩니다.",
     )
     fun getUserInfo(): AccountInfoResDto = queryUserInfoService.execute()
 }

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
@@ -16,13 +16,15 @@ class QueryUserInfoServiceImpl(
     @Transactional(readOnly = true)
     override fun execute(): AccountInfoResDto {
         val account = currentUserProvider.getCurrentAccount()
-        val resolved = accountObjectResolver.resolve(account)
         val scopeNames = currentUserProvider.getGrantedScopeNames()
 
         // self_read(deprecated)는 account_read + student_read를 합친 기존 동작과 동일하게 취급한다.
         val hasStudentRead = "student_read" in scopeNames || "self_read" in scopeNames
         val hasClubRead = "club_read" in scopeNames
         val hasProjectRead = "project_read" in scopeNames
+
+        // 부여되지 않은 스코프의 club/project 조회는 리졸버가 아예 수행하지 않도록 건너뛴다.
+        val resolved = accountObjectResolver.resolve(account, includeClubs = hasClubRead, includeProjects = hasProjectRead)
 
         return AccountInfoResDto(
             id = account.id!!,

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
@@ -17,6 +17,12 @@ class QueryUserInfoServiceImpl(
     override fun execute(): AccountInfoResDto {
         val account = currentUserProvider.getCurrentAccount()
         val resolved = accountObjectResolver.resolve(account)
+        val scopeNames = currentUserProvider.getGrantedScopeNames()
+
+        // self_read(deprecated)는 account_read + student_read를 합친 기존 동작과 동일하게 취급한다.
+        val hasStudentRead = "student_read" in scopeNames || "self_read" in scopeNames
+        val hasClubRead = "club_read" in scopeNames
+        val hasProjectRead = "project_read" in scopeNames
 
         return AccountInfoResDto(
             id = account.id!!,
@@ -25,8 +31,10 @@ class QueryUserInfoServiceImpl(
             status = account.status,
             objectType = account.objectType,
             isStudent = account.objectType == AccountObjectType.STUDENT,
-            student = resolved.student,
-            teacher = resolved.teacher,
+            student = if (hasStudentRead) resolved.student else null,
+            teacher = if (hasStudentRead) resolved.teacher else null,
+            clubs = if (hasClubRead) resolved.clubs else emptyList(),
+            projects = if (hasProjectRead) resolved.projects else emptyList(),
         )
     }
 }

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/impl/QueryUserInfoServiceImpl.kt
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.account.dto.response.AccountInfoResDto
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.resolver.AccountObjectResolver
+import team.themoment.datagsm.common.domain.client.entity.constant.OAuthScope
 import team.themoment.datagsm.oauth.userinfo.domain.userinfo.service.QueryUserInfoService
 import team.themoment.datagsm.oauth.userinfo.global.security.provider.CurrentUserProvider
 
@@ -19,12 +20,21 @@ class QueryUserInfoServiceImpl(
         val scopeNames = currentUserProvider.getGrantedScopeNames()
 
         // self_read(deprecated)는 account_read + student_read를 합친 기존 동작과 동일하게 취급한다.
-        val hasStudentRead = "student_read" in scopeNames || "self_read" in scopeNames
-        val hasClubRead = "club_read" in scopeNames
-        val hasProjectRead = "project_read" in scopeNames
+        val hasStudentRead = OAuthScope.STUDENT_READ in scopeNames || OAuthScope.SELF_READ in scopeNames
+        val hasClubRead = OAuthScope.CLUB_READ in scopeNames
+        val hasProjectRead = OAuthScope.PROJECT_READ in scopeNames
 
         // 부여되지 않은 스코프의 club/project 조회는 리졸버가 아예 수행하지 않도록 건너뛴다.
         val resolved = accountObjectResolver.resolve(account, includeClubs = hasClubRead, includeProjects = hasProjectRead)
+
+        // StudentResDto에는 majorClub/autonomousClub이 포함되어 있어, club_read가 없으면 clubs 필드뿐 아니라
+        // student 안의 동아리 정보도 함께 가려야 club_read 스코프가 실제로 의미를 가진다.
+        val student =
+            if (hasStudentRead) {
+                resolved.student?.let { if (hasClubRead) it else it.copy(majorClub = null, autonomousClub = null) }
+            } else {
+                null
+            }
 
         return AccountInfoResDto(
             id = account.id!!,
@@ -33,7 +43,7 @@ class QueryUserInfoServiceImpl(
             status = account.status,
             objectType = account.objectType,
             isStudent = account.objectType == AccountObjectType.STUDENT,
-            student = if (hasStudentRead) resolved.student else null,
+            student = student,
             teacher = if (hasStudentRead) resolved.teacher else null,
             clubs = if (hasClubRead) resolved.clubs else emptyList(),
             projects = if (hasProjectRead) resolved.projects else emptyList(),

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
@@ -36,6 +36,7 @@ class SecurityConfig(
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        val accountReadAuthority = OAuthScope.authorityOf(oauthJwtVerificationEnvironment.datagsmApplicationId, "account_read")
         val selfReadAuthority = OAuthScope.authorityOf(oauthJwtVerificationEnvironment.datagsmApplicationId, "self_read")
 
         http
@@ -55,7 +56,7 @@ class SecurityConfig(
             ).authorizeHttpRequests {
                 it
                     .requestMatchers("/userinfo")
-                    .hasAuthority(selfReadAuthority)
+                    .hasAnyAuthority(accountReadAuthority, selfReadAuthority)
                     .anyRequest()
                     .permitAll()
             }

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/config/SecurityConfig.kt
@@ -36,8 +36,9 @@ class SecurityConfig(
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-        val accountReadAuthority = OAuthScope.authorityOf(oauthJwtVerificationEnvironment.datagsmApplicationId, "account_read")
-        val selfReadAuthority = OAuthScope.authorityOf(oauthJwtVerificationEnvironment.datagsmApplicationId, "self_read")
+        val accountReadAuthority =
+            OAuthScope.authorityOf(oauthJwtVerificationEnvironment.datagsmApplicationId, OAuthScope.ACCOUNT_READ)
+        val selfReadAuthority = OAuthScope.authorityOf(oauthJwtVerificationEnvironment.datagsmApplicationId, OAuthScope.SELF_READ)
 
         http
             .csrf(CsrfConfigurer<*>::disable)

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/provider/CurrentUserProvider.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/provider/CurrentUserProvider.kt
@@ -6,12 +6,14 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
+import team.themoment.datagsm.oauth.userinfo.global.data.OauthJwtVerificationEnvironment
 import team.themoment.datagsm.oauth.userinfo.global.security.authentication.OauthAuthenticationToken
 import team.themoment.sdk.exception.ExpectedException
 
 @Component
 class CurrentUserProvider(
     private val accountJpaRepository: AccountJpaRepository,
+    private val oauthJwtVerificationEnvironment: OauthJwtVerificationEnvironment,
 ) {
     fun getAuthentication(): OauthAuthenticationToken {
         val authentication: Authentication? =
@@ -37,9 +39,13 @@ class CurrentUserProvider(
             .orElseThrow { ExpectedException("계정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
     }
 
-    fun getGrantedScopeNames(): Set<String> =
-        getAuthentication()
+    fun getGrantedScopeNames(): Set<String> {
+        val datagsmPrefix = "SCOPE_${oauthJwtVerificationEnvironment.datagsmApplicationId}:"
+        return getAuthentication()
             .authorities
-            .mapNotNull { it.authority?.substringAfter(':') }
+            .mapNotNull { it.authority }
+            .filter { it.startsWith(datagsmPrefix) }
+            .map { it.removePrefix(datagsmPrefix) }
             .toSet()
+    }
 }

--- a/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/provider/CurrentUserProvider.kt
+++ b/datagsm-oauth-userinfo/src/main/kotlin/team/themoment/datagsm/oauth/userinfo/global/security/provider/CurrentUserProvider.kt
@@ -36,4 +36,10 @@ class CurrentUserProvider(
             .findByEmail(email)
             .orElseThrow { ExpectedException("계정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND) }
     }
+
+    fun getGrantedScopeNames(): Set<String> =
+        getAuthentication()
+            .authorities
+            .mapNotNull { it.authority?.substringAfter(':') }
+            .toSet()
 }

--- a/datagsm-oauth-userinfo/src/test/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/QueryUserInfoServiceTest.kt
+++ b/datagsm-oauth-userinfo/src/test/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/QueryUserInfoServiceTest.kt
@@ -1,6 +1,7 @@
 package team.themoment.datagsm.oauth.userinfo.domain.userinfo.service
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -11,6 +12,13 @@ import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
 import team.themoment.datagsm.common.domain.account.resolver.AccountObjectResolver
+import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
+import team.themoment.datagsm.common.domain.project.dto.internal.ProjectSummaryDto
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
+import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
+import team.themoment.datagsm.common.domain.student.entity.constant.Sex
+import team.themoment.datagsm.common.domain.student.entity.constant.StudentRole
 import team.themoment.datagsm.common.domain.teacher.dto.response.TeacherResDto
 import team.themoment.datagsm.common.domain.teacher.entity.TeacherJpaEntity
 import team.themoment.datagsm.common.domain.teacher.entity.constant.TeacherDepartment
@@ -27,6 +35,29 @@ class QueryUserInfoServiceTest :
         afterEach {
             clearAllMocks()
         }
+
+        val studentDto =
+            StudentResDto(
+                id = 10L,
+                name = "홍길동",
+                sex = Sex.MAN,
+                email = "student@gsm.hs.kr",
+                grade = 1,
+                classNum = 1,
+                number = 1,
+                studentNumber = 1101,
+                major = null,
+                specialty = null,
+                role = StudentRole.GENERAL_STUDENT,
+                dormitoryFloor = null,
+                dormitoryRoom = null,
+                majorClub = null,
+                autonomousClub = null,
+                githubId = null,
+                githubUrl = null,
+            )
+        val clubSummary = ClubSummaryDto(id = 100L, name = "SW개발동아리", type = ClubType.MAJOR_CLUB)
+        val projectSummary = ProjectSummaryDto(id = 200L, name = "DataGSM", status = ProjectStatus.ACTIVE, club = clubSummary)
 
         describe("QueryUserInfoService 클래스의") {
             describe("execute 메서드는") {
@@ -45,6 +76,7 @@ class QueryUserInfoServiceTest :
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
                         every { mockAccountObjectResolver.resolve(mockAccount) } returns
                             ResolvedAccountObject(null, null)
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read")
                     }
 
                     it("계정 정보가 정상적으로 반환되어야 한다") {
@@ -56,6 +88,8 @@ class QueryUserInfoServiceTest :
                         result.objectType shouldBe null
                         result.student shouldBe null
                         result.teacher shouldBe null
+                        result.clubs.shouldBeEmpty()
+                        result.projects.shouldBeEmpty()
 
                         verify(exactly = 1) { mockCurrentUserProvider.getCurrentAccount() }
                     }
@@ -80,14 +114,150 @@ class QueryUserInfoServiceTest :
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
                         every { mockAccountObjectResolver.resolve(mockAccount) } returns
                             ResolvedAccountObject(null, TeacherResDto.from(teacher))
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read")
                     }
 
-                    it("선생님 정보가 포함되어 반환되어야 한다") {
+                    it("student_read 스코프가 있으면 선생님 정보가 포함되어 반환되어야 한다") {
                         val result = queryUserInfoService.execute()
 
                         result.objectType shouldBe AccountObjectType.TEACHER
                         result.teacher?.id shouldBe 50L
                         result.teacher?.name shouldBe "김선생"
+                    }
+                }
+
+                context("학생 계정이 account_read 스코프만 가지고 있을 때") {
+                    val mockAccount =
+                        AccountJpaEntity().apply {
+                            id = 2L
+                            email = "student@gsm.hs.kr"
+                            password = "encodedPassword"
+                            role = AccountRole.USER
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+
+                    beforeEach {
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
+                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read")
+                    }
+
+                    it("student/clubs/projects는 모두 비어있어야 한다") {
+                        val result = queryUserInfoService.execute()
+
+                        result.student shouldBe null
+                        result.teacher shouldBe null
+                        result.clubs.shouldBeEmpty()
+                        result.projects.shouldBeEmpty()
+                    }
+                }
+
+                context("학생 계정이 account_read와 student_read 스코프를 가지고 있을 때") {
+                    val mockAccount =
+                        AccountJpaEntity().apply {
+                            id = 2L
+                            email = "student@gsm.hs.kr"
+                            password = "encodedPassword"
+                            role = AccountRole.USER
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+
+                    beforeEach {
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
+                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read")
+                    }
+
+                    it("student 정보만 채워지고 clubs/projects는 비어있어야 한다") {
+                        val result = queryUserInfoService.execute()
+
+                        result.student shouldBe studentDto
+                        result.clubs.shouldBeEmpty()
+                        result.projects.shouldBeEmpty()
+                    }
+                }
+
+                context("학생 계정이 club_read 스코프까지 가지고 있을 때") {
+                    val mockAccount =
+                        AccountJpaEntity().apply {
+                            id = 2L
+                            email = "student@gsm.hs.kr"
+                            password = "encodedPassword"
+                            role = AccountRole.USER
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+
+                    beforeEach {
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
+                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read", "club_read")
+                    }
+
+                    it("clubs가 채워지고 projects는 비어있어야 한다") {
+                        val result = queryUserInfoService.execute()
+
+                        result.clubs shouldBe listOf(clubSummary)
+                        result.projects.shouldBeEmpty()
+                    }
+                }
+
+                context("학생 계정이 project_read 스코프까지 가지고 있을 때") {
+                    val mockAccount =
+                        AccountJpaEntity().apply {
+                            id = 2L
+                            email = "student@gsm.hs.kr"
+                            password = "encodedPassword"
+                            role = AccountRole.USER
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+
+                    beforeEach {
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
+                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns
+                            setOf("account_read", "student_read", "club_read", "project_read")
+                    }
+
+                    it("clubs와 projects가 모두 채워져야 한다") {
+                        val result = queryUserInfoService.execute()
+
+                        result.clubs shouldBe listOf(clubSummary)
+                        result.projects shouldBe listOf(projectSummary)
+                    }
+                }
+
+                context("학생 계정이 deprecated self_read 스코프만 가지고 있을 때 (하위 호환)") {
+                    val mockAccount =
+                        AccountJpaEntity().apply {
+                            id = 2L
+                            email = "student@gsm.hs.kr"
+                            password = "encodedPassword"
+                            role = AccountRole.USER
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+
+                    beforeEach {
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
+                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("self_read")
+                    }
+
+                    it("student 정보는 채워지고 clubs/projects는 비어있어야 한다") {
+                        val result = queryUserInfoService.execute()
+
+                        result.student shouldBe studentDto
+                        result.clubs.shouldBeEmpty()
+                        result.projects.shouldBeEmpty()
                     }
                 }
             }

--- a/datagsm-oauth-userinfo/src/test/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/QueryUserInfoServiceTest.kt
+++ b/datagsm-oauth-userinfo/src/test/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/QueryUserInfoServiceTest.kt
@@ -74,7 +74,7 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = false, includeProjects = false) } returns
                             ResolvedAccountObject(null, null)
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read")
                     }
@@ -112,7 +112,7 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = false, includeProjects = false) } returns
                             ResolvedAccountObject(null, TeacherResDto.from(teacher))
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read")
                     }
@@ -139,8 +139,8 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
-                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = false, includeProjects = false) } returns
+                            ResolvedAccountObject(studentDto, null)
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read")
                     }
 
@@ -167,8 +167,8 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
-                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = false, includeProjects = false) } returns
+                            ResolvedAccountObject(studentDto, null)
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read")
                     }
 
@@ -194,8 +194,8 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
-                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = true, includeProjects = false) } returns
+                            ResolvedAccountObject(studentDto, null, listOf(clubSummary))
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read", "club_read")
                     }
 
@@ -220,7 +220,7 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = true, includeProjects = true) } returns
                             ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns
                             setOf("account_read", "student_read", "club_read", "project_read")
@@ -247,8 +247,8 @@ class QueryUserInfoServiceTest :
 
                     beforeEach {
                         every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
-                        every { mockAccountObjectResolver.resolve(mockAccount) } returns
-                            ResolvedAccountObject(studentDto, null, listOf(clubSummary), listOf(projectSummary))
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = false, includeProjects = false) } returns
+                            ResolvedAccountObject(studentDto, null)
                         every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("self_read")
                     }
 

--- a/datagsm-oauth-userinfo/src/test/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/QueryUserInfoServiceTest.kt
+++ b/datagsm-oauth-userinfo/src/test/kotlin/team/themoment/datagsm/oauth/userinfo/domain/userinfo/service/QueryUserInfoServiceTest.kt
@@ -181,6 +181,34 @@ class QueryUserInfoServiceTest :
                     }
                 }
 
+                context("학생 계정이 club_read 없이 student_read만 가지고 있고 student에 동아리 정보가 있을 때") {
+                    val mockAccount =
+                        AccountJpaEntity().apply {
+                            id = 2L
+                            email = "student@gsm.hs.kr"
+                            password = "encodedPassword"
+                            role = AccountRole.USER
+                            objectId = 10L
+                            objectType = AccountObjectType.STUDENT
+                        }
+                    val studentWithClub = studentDto.copy(majorClub = clubSummary, autonomousClub = clubSummary)
+
+                    beforeEach {
+                        every { mockCurrentUserProvider.getCurrentAccount() } returns mockAccount
+                        every { mockAccountObjectResolver.resolve(mockAccount, includeClubs = false, includeProjects = false) } returns
+                            ResolvedAccountObject(studentWithClub, null)
+                        every { mockCurrentUserProvider.getGrantedScopeNames() } returns setOf("account_read", "student_read")
+                    }
+
+                    it("club_read가 없으므로 student 안의 majorClub/autonomousClub도 가려져야 한다") {
+                        val result = queryUserInfoService.execute()
+
+                        result.student?.majorClub shouldBe null
+                        result.student?.autonomousClub shouldBe null
+                        result.clubs.shouldBeEmpty()
+                    }
+                }
+
                 context("학생 계정이 club_read 스코프까지 가지고 있을 때") {
                     val mockAccount =
                         AccountJpaEntity().apply {

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
@@ -27,6 +27,8 @@ class QueryMyInfoServiceImpl(
             isStudent = account.objectType == AccountObjectType.STUDENT,
             student = resolved.student,
             teacher = resolved.teacher,
+            clubs = resolved.clubs,
+            projects = resolved.projects,
         )
     }
 }

--- a/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
+++ b/datagsm-web/src/main/kotlin/team/themoment/datagsm/web/domain/account/service/impl/QueryMyInfoServiceImpl.kt
@@ -16,7 +16,7 @@ class QueryMyInfoServiceImpl(
     @Transactional(readOnly = true)
     override fun execute(): AccountInfoResDto {
         val account = currentUserProvider.getCurrentAccount()
-        val resolved = accountObjectResolver.resolve(account)
+        val resolved = accountObjectResolver.resolve(account, includeClubs = true, includeProjects = true)
 
         return AccountInfoResDto(
             id = account.id!!,

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/QueryMyInfoServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/QueryMyInfoServiceTest.kt
@@ -10,6 +10,10 @@ import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
 import team.themoment.datagsm.common.domain.account.resolver.AccountObjectResolver
+import team.themoment.datagsm.common.domain.club.dto.internal.ClubSummaryDto
+import team.themoment.datagsm.common.domain.club.entity.constant.ClubType
+import team.themoment.datagsm.common.domain.project.dto.internal.ProjectSummaryDto
+import team.themoment.datagsm.common.domain.project.entity.constant.ProjectStatus
 import team.themoment.datagsm.common.domain.student.dto.response.StudentResDto
 import team.themoment.datagsm.common.domain.student.entity.DormitoryRoomNumber
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
@@ -93,10 +97,15 @@ class QueryMyInfoServiceTest :
                             }
                         every { mockCurrentUserProvider.getCurrentAccount() } returns account
                         every { mockAccountObjectResolver.resolve(account) } returns
-                            ResolvedAccountObject(StudentResDto.from(student), null)
+                            ResolvedAccountObject(
+                                StudentResDto.from(student),
+                                null,
+                                listOf(ClubSummaryDto(id = 100L, name = "SW개발동아리", type = ClubType.MAJOR_CLUB)),
+                                listOf(ProjectSummaryDto(id = 200L, name = "DataGSM", status = ProjectStatus.ACTIVE, club = null)),
+                            )
                     }
 
-                    it("학생 정보를 포함하여 계정 정보를 반환해야 한다") {
+                    it("학생 정보와 동아리·프로젝트 정보를 포함하여 계정 정보를 반환해야 한다") {
                         val result = queryMyInfoService.execute()
 
                         result.id shouldBe 2L
@@ -116,6 +125,11 @@ class QueryMyInfoServiceTest :
                         studentDto.major shouldBe Major.SW_DEVELOPMENT
                         studentDto.dormitoryFloor shouldBe 2
                         studentDto.dormitoryRoom shouldBe 201
+
+                        result.clubs.size shouldBe 1
+                        result.clubs.first().name shouldBe "SW개발동아리"
+                        result.projects.size shouldBe 1
+                        result.projects.first().name shouldBe "DataGSM"
 
                         verify(exactly = 1) { mockCurrentUserProvider.getCurrentAccount() }
                     }

--- a/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/QueryMyInfoServiceTest.kt
+++ b/datagsm-web/src/test/kotlin/team/themoment/datagsm/web/domain/account/service/QueryMyInfoServiceTest.kt
@@ -54,7 +54,8 @@ class QueryMyInfoServiceTest :
                                 role = AccountRole.ADMIN
                             }
                         every { mockCurrentUserProvider.getCurrentAccount() } returns account
-                        every { mockAccountObjectResolver.resolve(account) } returns ResolvedAccountObject(null, null)
+                        every { mockAccountObjectResolver.resolve(account, includeClubs = true, includeProjects = true) } returns
+                            ResolvedAccountObject(null, null)
                     }
 
                     it("연결 대상 정보 없이 계정 정보를 반환해야 한다") {
@@ -96,7 +97,7 @@ class QueryMyInfoServiceTest :
                                 objectType = AccountObjectType.STUDENT
                             }
                         every { mockCurrentUserProvider.getCurrentAccount() } returns account
-                        every { mockAccountObjectResolver.resolve(account) } returns
+                        every { mockAccountObjectResolver.resolve(account, includeClubs = true, includeProjects = true) } returns
                             ResolvedAccountObject(
                                 StudentResDto.from(student),
                                 null,
@@ -154,7 +155,7 @@ class QueryMyInfoServiceTest :
                                 objectType = AccountObjectType.TEACHER
                             }
                         every { mockCurrentUserProvider.getCurrentAccount() } returns account
-                        every { mockAccountObjectResolver.resolve(account) } returns
+                        every { mockAccountObjectResolver.resolve(account, includeClubs = true, includeProjects = true) } returns
                             ResolvedAccountObject(null, TeacherResDto.from(teacher))
                     }
 


### PR DESCRIPTION
## 개요

OAuth 로그인 상태를 IdP(datagsm-server)에 보관해, 여러 클라이언트를 오갈 때 재로그인 없이 인증이 이어지도록 합니다.

기존에는 로그인 성공 결과가 어디에도 남지 않아(요청 1건에 대한 code 발급 후 종료) 다른 클라이언트로 이동하면 항상 다시 로그인해야 했습니다. 이 PR은 "로그인 성공"과 "code 발급"을 분리해 SSO를 가능하게 합니다.

## 변경 흐름

```
GET /v1/oauth/authorize  (브라우저 최상위 이동 → 쿠키 자동 실림)
  ├─ 세션 유효 ∧ 계정 ACTIVE ∧ 미해소 정보수정요청 없음 ∧ 요청 scope가 동의 기록에 포함
  │    → 로그인 생략하고 code 발급 → 클라이언트로 302
  └─ 하나라도 미충족 → 기존 로그인 페이지로 302 (폴백)

POST /v1/oauth/authorize  (BFF 서버-투-서버)
  → 자격증명 검증 → 동의 기록 → 세션 생성 → 핸드오프 URL로 302

GET /v1/oauth/authorize/session?ticket=  (신규, 브라우저 최상위 이동)
  → 티켓 검증 후 즉시 삭제(일회용) → Set-Cookie → 클라이언트로 302
```

### 핸드오프 단계가 필요한 이유

`POST /v1/oauth/authorize`는 프론트 BFF가 서버-투-서버 fetch로 호출하므로, 이 응답에 `Set-Cookie`를 실어도 브라우저가 아닌 Next.js 서버가 받게 됩니다. 따라서 브라우저가 최상위 내비게이션으로 백엔드를 한 번 경유하도록 일회용 티켓을 두고, 그 지점에서 세션 쿠키를 심습니다.

## 보안 고려

- **정보 수정 강제가 SSO로 우회되지 않습니다.** 세션이 있어도 미해소 `StudentDataEditRequest`가 있으면 code를 발급하지 않고 로그인 페이지로 폴백합니다.
- 세션 쿠키는 `HttpOnly` / `Secure` / `SameSite=Lax` / `Max-Age` 적용.
- 핸드오프 티켓은 일회용이며 사용 즉시 삭제됩니다(기본 TTL 60초).
- 클라이언트별 scope 동의를 기록해, 동의하지 않은 scope는 세션이 있어도 자동 승인되지 않습니다.

## 주요 변경 파일

**신규**
- `IdpSessionRedisEntity` / `IdpSessionRedisRepository` — 로그인 세션 (기본 8시간)
- `IdpSessionHandoffRedisEntity` / `IdpSessionHandoffRedisRepository` — 일회용 핸드오프 티켓
- `OauthConsentJpaEntity` / `OauthConsentJpaRepository` — 클라이언트별 scope 동의 기록
- `IssueAuthorizationCodeService(+Impl)` — code 발급 로직을 GET/POST 양쪽에서 재사용하도록 추출
- `CompleteIdpSessionHandoffService(+Impl)` — 티켓 소비 및 쿠키 설정

**수정**
- `StartOauthAuthorizeFlowServiceImpl` — SSO 세션 분기 추가
- `CompleteOauthAuthorizeFlowServiceImpl` — 세션·동의·핸드오프 생성, code 발급 위임
- `OauthController` — 쿠키 파라미터, 핸드오프 엔드포인트
- `OauthEnvironment` / `application.yml` — 세션·쿠키 설정

## ⚠️ Breaking Change (프론트 수정 필요)

`POST /v1/oauth/authorize`의 응답 `Location`이 변경됩니다.

```
변경 전: https://client.example.com/callback?code=xxx&state=yyy
변경 후: https://oauth.authorization.datagsm.kr/v1/oauth/authorize/session?ticket=zzz
```

BFF가 이 Location을 **가공 없이 그대로 브라우저에 반환하면 정상 동작**합니다. 다만 다음에 해당하면 수정이 필요합니다.

- fetch에 `redirect: 'follow'`가 걸려 있으면 → **`redirect: 'manual'`로 변경 필수** (서버가 리다이렉트를 따라가면 쿠키가 브라우저에 심기지 않습니다)
- Location이 클라이언트 주소인지 검증하는 로직이 있으면 → 백엔드 도메인도 허용
- Location에서 `code`/`state`를 파싱해 쓰고 있으면 → 제거

프론트 수정은 이 PR 머지 전에 완료될 예정입니다.

## 배포 환경변수

```bash
OAUTH_ISSUER_URL=https://oauth.authorization.datagsm.kr
OAUTH_IDP_SESSION_COOKIE_DOMAIN=.datagsm.kr
```

`OAUTH_ISSUER_URL`이 잘못되면 핸드오프 리다이렉트가 깨집니다. 나머지(세션 8시간, 쿠키명, `Secure=true`)는 기본값으로 충분합니다.

## 테스트

- 전 모듈 643개 통과 (authorization 모듈 111개)
- 신규 11개: SSO 성공 경로 1, 폴백 6(세션 없음/만료/비ACTIVE/정보수정요청/동의없음/scope부족), 핸드오프 4

## 후속 작업 (별도 PR)

- `id_token` 발급 및 `openid` scope — OIDC 표준 준수
- `/.well-known/openid-configuration` discovery 문서
- 동의 화면 UI (현재는 재로그인 시 자동 동의)
- 로그아웃 전파 (현재는 세션 만료에 의존)