### PR TITLE
[oauth] SSO IdP 세션 도입

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionHandoffRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionHandoffRedisEntity.kt
@@ -7,12 +7,17 @@ import org.springframework.data.redis.core.TimeToLive
 /**
  * BFF가 서버-투-서버로 호출하는 POST /authorize 응답에는 브라우저 쿠키를 심을 수 없다.
  * 세션 쿠키를 백엔드 도메인에 심기 위해 브라우저를 한 번 경유시키는 일회용 티켓이다.
+ *
+ * ticket은 URL에 노출되어 로그·Referer·브라우저 히스토리에 남으므로 그것만으로는 세션을 발급하지 않는다.
+ * 정상 브라우저만 가진 verifier의 해시를 함께 저장해, 소비 시점에 대조한다.
  */
 @RedisHash("idp_session_handoff")
 data class IdpSessionHandoffRedisEntity(
     @Id
     val ticket: String,
+    val verifierHash: String,
     val sessionId: String,
+    val clientId: String,
     val redirectUrl: String,
     @TimeToLive
     val ttl: Long,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionHandoffRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionHandoffRedisEntity.kt
@@ -1,0 +1,19 @@
+package team.themoment.datagsm.common.domain.oauth.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.TimeToLive
+
+/**
+ * BFF가 서버-투-서버로 호출하는 POST /authorize 응답에는 브라우저 쿠키를 심을 수 없다.
+ * 세션 쿠키를 백엔드 도메인에 심기 위해 브라우저를 한 번 경유시키는 일회용 티켓이다.
+ */
+@RedisHash("idp_session_handoff")
+data class IdpSessionHandoffRedisEntity(
+    @Id
+    val ticket: String,
+    val sessionId: String,
+    val redirectUrl: String,
+    @TimeToLive
+    val ttl: Long,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionRedisEntity.kt
@@ -1,0 +1,14 @@
+package team.themoment.datagsm.common.domain.oauth.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.TimeToLive
+
+@RedisHash("idp_session")
+data class IdpSessionRedisEntity(
+    @Id
+    val sessionId: String,
+    val email: String,
+    @TimeToLive
+    val ttl: Long,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthConsentJpaEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthConsentJpaEntity.kt
@@ -1,0 +1,71 @@
+package team.themoment.datagsm.common.domain.oauth.entity
+
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+/**
+ * 사용자가 특정 클라이언트에 허용한 scope 기록.
+ * SSO 세션으로 로그인을 생략할 때, 이미 동의한 scope인지 판단하는 근거가 된다.
+ */
+@Table(
+    name = "tb_oauth_consent",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_oauth_consent_account_client", columnNames = ["account_id", "client_id"]),
+    ],
+    indexes = [
+        Index(name = "idx_oauth_consent_account_id", columnList = "account_id"),
+    ],
+)
+@Entity
+class OauthConsentJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null
+
+    @Column(name = "account_id", nullable = false)
+    var accountId: Long = 0
+
+    @Column(name = "client_id", nullable = false)
+    lateinit var clientId: String
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name = "tb_oauth_consent_scope",
+        joinColumns = [JoinColumn(name = "consent_id")],
+    )
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @Column(name = "scope")
+    val grantedScopes: MutableSet<String> = mutableSetOf()
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime? = null
+
+    companion object {
+        fun create(
+            accountId: Long,
+            clientId: String,
+            scopes: Set<String>,
+        ): OauthConsentJpaEntity =
+            OauthConsentJpaEntity().apply {
+                this.accountId = accountId
+                this.clientId = clientId
+                this.grantedScopes.addAll(scopes)
+            }
+    }
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthConsentJpaEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthConsentJpaEntity.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
-import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
@@ -25,9 +24,6 @@ import java.time.LocalDateTime
     name = "tb_oauth_consent",
     uniqueConstraints = [
         UniqueConstraint(name = "uk_oauth_consent_account_client", columnNames = ["account_id", "client_id"]),
-    ],
-    indexes = [
-        Index(name = "idx_oauth_consent_account_id", columnList = "account_id"),
     ],
 )
 @Entity

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/IdpSessionHandoffRedisRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/IdpSessionHandoffRedisRepository.kt
@@ -1,0 +1,6 @@
+package team.themoment.datagsm.common.domain.oauth.repository
+
+import org.springframework.data.repository.CrudRepository
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
+
+interface IdpSessionHandoffRedisRepository : CrudRepository<IdpSessionHandoffRedisEntity, String>

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/IdpSessionRedisRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/IdpSessionRedisRepository.kt
@@ -1,0 +1,6 @@
+package team.themoment.datagsm.common.domain.oauth.repository
+
+import org.springframework.data.repository.CrudRepository
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
+
+interface IdpSessionRedisRepository : CrudRepository<IdpSessionRedisEntity, String>

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/OauthConsentJpaRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/OauthConsentJpaRepository.kt
@@ -1,0 +1,12 @@
+package team.themoment.datagsm.common.domain.oauth.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
+import java.util.Optional
+
+interface OauthConsentJpaRepository : JpaRepository<OauthConsentJpaEntity, Long> {
+    fun findByAccountIdAndClientId(
+        accountId: Long,
+        clientId: String,
+    ): Optional<OauthConsentJpaEntity>
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/data/OauthEnvironment.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/data/OauthEnvironment.kt
@@ -13,4 +13,5 @@ data class OauthEnvironment(
     val idpSessionCookieName: String,
     val idpSessionCookieDomain: String?,
     val idpSessionCookieSecure: Boolean,
+    val idpSessionHandoffRequireFetchMetadata: Boolean,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/data/OauthEnvironment.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/data/OauthEnvironment.kt
@@ -11,7 +11,6 @@ data class OauthEnvironment(
     val idpSessionExpirationSeconds: Long,
     val idpSessionHandoffExpirationSeconds: Long,
     val idpSessionCookieName: String,
-    val idpSessionCookieDomain: String?,
     val idpSessionCookieSecure: Boolean,
     val idpSessionHandoffRequireFetchMetadata: Boolean,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/data/OauthEnvironment.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/data/OauthEnvironment.kt
@@ -7,4 +7,10 @@ data class OauthEnvironment(
     val codeExpirationSeconds: Long,
     val frontendUrl: String,
     val authorizeStateExpirationMs: Long,
+    val issuerUrl: String,
+    val idpSessionExpirationSeconds: Long,
+    val idpSessionHandoffExpirationSeconds: Long,
+    val idpSessionCookieName: String,
+    val idpSessionCookieDomain: String?,
+    val idpSessionCookieSecure: Boolean,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/security/util/OpaqueTokenHashUtil.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/security/util/OpaqueTokenHashUtil.kt
@@ -1,0 +1,24 @@
+package team.themoment.datagsm.common.global.security.util
+
+import java.security.MessageDigest
+
+/**
+ * 불투명 토큰을 저장·대조하기 위한 해시 유틸.
+ * 발급 측과 검증 측이 서로 다른 방식을 쓰면 대조가 통째로 실패하므로 한 곳에서 관리한다.
+ */
+object OpaqueTokenHashUtil {
+    fun hash(value: String): String =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+
+    fun matches(
+        rawValue: String,
+        expectedHash: String,
+    ): Boolean =
+        MessageDigest.isEqual(
+            hash(rawValue).toByteArray(Charsets.UTF_8),
+            expectedHash.toByteArray(Charsets.UTF_8),
+        )
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
@@ -75,7 +75,7 @@ class OauthController(
     )
     fun completeIdpSessionHandoff(
         @RequestParam ticket: String,
-        @RequestParam verifier: String,
+        @RequestParam(required = false) verifier: String?,
         @RequestHeader(name = "Sec-Fetch-Site", required = false) secFetchSite: String?,
         @RequestHeader(name = "Sec-Fetch-Mode", required = false) secFetchMode: String?,
     ): ResponseEntity<Void> = completeIdpSessionHandoffService.execute(ticket, verifier, secFetchSite, secFetchMode)

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -75,7 +76,9 @@ class OauthController(
     fun completeIdpSessionHandoff(
         @RequestParam ticket: String,
         @RequestParam verifier: String,
-    ): ResponseEntity<Void> = completeIdpSessionHandoffService.execute(ticket, verifier)
+        @RequestHeader(name = "Sec-Fetch-Site", required = false) secFetchSite: String?,
+        @RequestHeader(name = "Sec-Fetch-Mode", required = false) secFetchMode: String?,
+    ): ResponseEntity<Void> = completeIdpSessionHandoffService.execute(ticket, verifier, secFetchSite, secFetchMode)
 
     @PostMapping("/authorize")
     @Operation(

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
@@ -7,12 +7,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.themoment.datagsm.common.domain.oauth.dto.request.Oauth2TokenReqDto
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeReqDto
@@ -22,6 +24,7 @@ import team.themoment.datagsm.common.domain.oauth.dto.response.Oauth2TokenResDto
 import team.themoment.datagsm.common.domain.oauth.dto.response.OauthSessionResDto
 import team.themoment.datagsm.common.domain.student.dto.request.QueryStudentDataEditRequestReqDto
 import team.themoment.datagsm.common.domain.student.dto.response.StudentDataEditRequestResDto
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteIdpSessionHandoffService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthAuthorizeFlowService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.Oauth2TokenService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryJwkSetService
@@ -36,6 +39,7 @@ class OauthController(
     val oauth2TokenService: Oauth2TokenService,
     val startOauthAuthorizeFlowService: StartOauthAuthorizeFlowService,
     val completeOauthAuthorizeFlowService: CompleteOauthAuthorizeFlowService,
+    val completeIdpSessionHandoffService: CompleteIdpSessionHandoffService,
     val queryOauthSessionService: QueryOauthSessionService,
     val queryJwkSetService: QueryJwkSetService,
     val queryStudentDataEditRequestService: QueryStudentDataEditRequestService,
@@ -54,7 +58,23 @@ class OauthController(
     )
     fun authorizeGet(
         @Valid @ModelAttribute queryReq: OauthAuthorizeReqDto,
-    ): ResponseEntity<Void> = startOauthAuthorizeFlowService.execute(queryReq)
+        @CookieValue(name = "\${spring.security.oauth.idp-session-cookie-name}", required = false) sessionId: String?,
+    ): ResponseEntity<Void> = startOauthAuthorizeFlowService.execute(queryReq, sessionId)
+
+    @GetMapping("/authorize/session")
+    @Operation(
+        summary = "IdP 세션 확립",
+        description = "로그인 직후 발급된 일회용 티켓으로 SSO 세션 쿠키를 설정하고 클라이언트로 리다이렉트합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "302", description = "세션 쿠키 설정 후 외부 서비스로 리다이렉트"),
+            ApiResponse(responseCode = "400", description = "유효하지 않거나 만료된 티켓", content = [Content()]),
+        ],
+    )
+    fun completeIdpSessionHandoff(
+        @RequestParam ticket: String,
+    ): ResponseEntity<Void> = completeIdpSessionHandoffService.execute(ticket)
 
     @PostMapping("/authorize")
     @Operation(

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
@@ -74,7 +74,8 @@ class OauthController(
     )
     fun completeIdpSessionHandoff(
         @RequestParam ticket: String,
-    ): ResponseEntity<Void> = completeIdpSessionHandoffService.execute(ticket)
+        @RequestParam verifier: String,
+    ): ResponseEntity<Void> = completeIdpSessionHandoffService.execute(ticket, verifier)
 
     @PostMapping("/authorize")
     @Operation(

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffService.kt
@@ -3,5 +3,8 @@ package team.themoment.datagsm.oauth.authorization.domain.oauth.service
 import org.springframework.http.ResponseEntity
 
 interface CompleteIdpSessionHandoffService {
-    fun execute(ticket: String): ResponseEntity<Void>
+    fun execute(
+        ticket: String,
+        verifier: String,
+    ): ResponseEntity<Void>
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffService.kt
@@ -6,5 +6,7 @@ interface CompleteIdpSessionHandoffService {
     fun execute(
         ticket: String,
         verifier: String,
+        secFetchSite: String?,
+        secFetchMode: String?,
     ): ResponseEntity<Void>
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffService.kt
@@ -5,7 +5,7 @@ import org.springframework.http.ResponseEntity
 interface CompleteIdpSessionHandoffService {
     fun execute(
         ticket: String,
-        verifier: String,
+        verifier: String?,
         secFetchSite: String?,
         secFetchMode: String?,
     ): ResponseEntity<Void>

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffService.kt
@@ -1,0 +1,7 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import org.springframework.http.ResponseEntity
+
+interface CompleteIdpSessionHandoffService {
+    fun execute(ticket: String): ResponseEntity<Void>
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/IssueAuthorizationCodeService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/IssueAuthorizationCodeService.kt
@@ -1,0 +1,13 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+interface IssueAuthorizationCodeService {
+    fun execute(
+        email: String,
+        clientId: String,
+        redirectUri: String,
+        state: String?,
+        codeChallenge: String?,
+        codeChallengeMethod: String?,
+        scopes: Set<String>,
+    ): String
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowService.kt
@@ -4,5 +4,8 @@ import org.springframework.http.ResponseEntity
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeReqDto
 
 interface StartOauthAuthorizeFlowService {
-    fun execute(reqDto: OauthAuthorizeReqDto): ResponseEntity<Void>
+    fun execute(
+        reqDto: OauthAuthorizeReqDto,
+        sessionId: String?,
+    ): ResponseEntity<Void>
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
@@ -6,24 +6,40 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
+import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteIdpSessionHandoffService
 import java.net.URI
+import java.security.MessageDigest
 import java.time.Duration
 
 @Service
 class CompleteIdpSessionHandoffServiceImpl(
     private val idpSessionHandoffRedisRepository: IdpSessionHandoffRedisRepository,
+    private val clientJpaRepository: ClientJpaRepository,
     private val oauthEnvironment: OauthEnvironment,
 ) : CompleteIdpSessionHandoffService {
-    override fun execute(ticket: String): ResponseEntity<Void> {
+    override fun execute(
+        ticket: String,
+        verifier: String,
+    ): ResponseEntity<Void> {
         val handoff =
             idpSessionHandoffRedisRepository.findByIdOrNull(ticket)
                 ?: throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
 
+        // ticket은 URL에 노출되므로, 실제 브라우저만 가진 verifier까지 일치해야 세션을 발급한다.
+        // 불일치 시에도 티켓을 즉시 폐기해 무차별 대입 시도를 차단한다.
+        if (!matchesVerifier(verifier, handoff.verifierHash)) {
+            idpSessionHandoffRedisRepository.deleteById(ticket)
+            throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
+        }
+
         idpSessionHandoffRedisRepository.deleteById(ticket)
+
+        verifyRedirectUrlStillAllowed(handoff)
 
         val cookie =
             ResponseCookie
@@ -45,4 +61,49 @@ class CompleteIdpSessionHandoffServiceImpl(
             .location(URI.create(handoff.redirectUrl))
             .build()
     }
+
+    // 저장 시점에 화이트리스트를 통과했더라도, Location으로 내보내기 직전에 다시 확인해
+    // 오픈 리다이렉트가 성립하지 않도록 한다.
+    // redirectUrl에는 code/state 쿼리가 덧붙어 있으므로, 등록된 redirect_uri와 동일한 방식으로
+    // 원본 URI만 잘라내 정확히 일치하는지 본다. 접두사 비교는 도메인 위조를 허용하므로 쓰지 않는다.
+    private fun verifyRedirectUrlStillAllowed(handoff: IdpSessionHandoffRedisEntity) {
+        val client =
+            clientJpaRepository
+                .findById(handoff.clientId)
+                .orElseThrow { OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.") }
+
+        val isAllowed = client.redirectUrls.any { it == extractRegisteredRedirectUri(handoff.redirectUrl, it) }
+        if (!isAllowed) {
+            throw OAuthException.InvalidRequest("등록되지 않은 redirect_uri입니다.")
+        }
+    }
+
+    // 발급 시 buildRedirectUrl이 등록 URI 뒤에 '?' 또는 '&'로 code/state를 이어 붙인다.
+    // 후보 URI 길이만큼 잘라낸 값이 그 URI와 같고, 이어지는 문자가 구분자인 경우에만 일치로 본다.
+    private fun extractRegisteredRedirectUri(
+        redirectUrl: String,
+        candidate: String,
+    ): String? {
+        if (!redirectUrl.startsWith(candidate)) return null
+        val remainder = redirectUrl.substring(candidate.length)
+        if (remainder.isNotEmpty() && remainder[0] != '?' && remainder[0] != '&') return null
+        return candidate
+    }
+
+    private fun matchesVerifier(
+        verifier: String,
+        expectedHash: String,
+    ): Boolean {
+        val actualHash = sha256Hex(verifier)
+        return MessageDigest.isEqual(
+            actualHash.toByteArray(Charsets.UTF_8),
+            expectedHash.toByteArray(Charsets.UTF_8),
+        )
+    }
+
+    private fun sha256Hex(value: String): String =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
@@ -22,18 +23,30 @@ class CompleteIdpSessionHandoffServiceImpl(
     private val clientJpaRepository: ClientJpaRepository,
     private val oauthEnvironment: OauthEnvironment,
 ) : CompleteIdpSessionHandoffService {
+    companion object {
+        private const val SEC_FETCH_MODE_NAVIGATE = "navigate"
+        private val ALLOWED_SEC_FETCH_SITES = setOf("same-origin", "same-site", "none")
+    }
+
+    @Transactional(readOnly = true)
     override fun execute(
         ticket: String,
         verifier: String,
+        secFetchSite: String?,
+        secFetchMode: String?,
     ): ResponseEntity<Void> {
+        verifyTopLevelNavigation(secFetchSite, secFetchMode)
+
         val handoff =
             idpSessionHandoffRedisRepository.findByIdOrNull(ticket)
                 ?: throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
 
-        // ticket은 URL에 노출되므로, 실제 브라우저만 가진 verifier까지 일치해야 세션을 발급한다.
-        // 불일치 시에도 티켓을 즉시 폐기해 무차별 대입 시도를 차단한다.
+        // ticket과 verifier는 같은 URL로 전달되므로 verifier만으로 유출을 막지는 못한다.
+        // 로그 등에서 티켓 일부만 새어나간 경우를 위한 추가 방어이며,
+        // 실질적인 재사용 차단은 위의 Sec-Fetch 검사와 일회용 소비가 담당한다.
+        // 불일치해도 티켓을 삭제하지 않는다. 삭제하면 ticket만 아는 공격자가
+        // 요청 한 번으로 정상 사용자의 로그인을 무효화할 수 있다.
         if (!matchesVerifier(verifier, handoff.verifierHash)) {
-            idpSessionHandoffRedisRepository.deleteById(ticket)
             throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
         }
 
@@ -60,6 +73,30 @@ class CompleteIdpSessionHandoffServiceImpl(
             .header(HttpHeaders.SET_COOKIE, cookie.toString())
             .location(URI.create(handoff.redirectUrl))
             .build()
+    }
+
+    // 핸드오프 URL은 로그·Referer·브라우저 히스토리에 남기 때문에, 나중에 그 URL을 입수한
+    // 공격자가 다시 열어보는 것을 막아야 한다. 정상 흐름은 프론트에서 백엔드로 넘어오는
+    // 최상위 내비게이션이므로, 브라우저가 붙여주는 Sec-Fetch 힌트로 그 형태만 통과시킨다.
+    // 헤더를 보내지 않는 구형 브라우저는 정상 로그인을 막지 않도록 설정으로 통과시킬 수 있다.
+    private fun verifyTopLevelNavigation(
+        secFetchSite: String?,
+        secFetchMode: String?,
+    ) {
+        if (secFetchSite == null && secFetchMode == null) {
+            if (oauthEnvironment.idpSessionHandoffRequireFetchMetadata) {
+                throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
+            }
+            return
+        }
+
+        if (secFetchMode != null && secFetchMode != SEC_FETCH_MODE_NAVIGATE) {
+            throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
+        }
+
+        if (secFetchSite != null && secFetchSite !in ALLOWED_SEC_FETCH_SITES) {
+            throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
+        }
     }
 
     // 저장 시점에 화이트리스트를 통과했더라도, Location으로 내보내기 직전에 다시 확인해

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
@@ -1,0 +1,48 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseCookie
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteIdpSessionHandoffService
+import java.net.URI
+import java.time.Duration
+
+@Service
+class CompleteIdpSessionHandoffServiceImpl(
+    private val idpSessionHandoffRedisRepository: IdpSessionHandoffRedisRepository,
+    private val oauthEnvironment: OauthEnvironment,
+) : CompleteIdpSessionHandoffService {
+    override fun execute(ticket: String): ResponseEntity<Void> {
+        val handoff =
+            idpSessionHandoffRedisRepository.findByIdOrNull(ticket)
+                ?: throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
+
+        idpSessionHandoffRedisRepository.deleteById(ticket)
+
+        val cookie =
+            ResponseCookie
+                .from(oauthEnvironment.idpSessionCookieName, handoff.sessionId)
+                .httpOnly(true)
+                .secure(oauthEnvironment.idpSessionCookieSecure)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(Duration.ofSeconds(oauthEnvironment.idpSessionExpirationSeconds))
+                .also { builder ->
+                    oauthEnvironment.idpSessionCookieDomain
+                        ?.takeIf { it.isNotBlank() }
+                        ?.let { builder.domain(it) }
+                }.build()
+
+        return ResponseEntity
+            .status(HttpStatus.FOUND)
+            .header(HttpHeaders.SET_COOKIE, cookie.toString())
+            .location(URI.create(handoff.redirectUrl))
+            .build()
+    }
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
@@ -11,27 +11,30 @@ import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepositor
 import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.common.global.security.util.OpaqueTokenHashUtil
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteIdpSessionHandoffService
 import java.net.URI
-import java.security.MessageDigest
 import java.time.Duration
 
 @Service
 class CompleteIdpSessionHandoffServiceImpl(
     private val idpSessionHandoffRedisRepository: IdpSessionHandoffRedisRepository,
+    private val idpSessionRedisRepository: IdpSessionRedisRepository,
     private val clientJpaRepository: ClientJpaRepository,
     private val oauthEnvironment: OauthEnvironment,
 ) : CompleteIdpSessionHandoffService {
     companion object {
         private const val SEC_FETCH_MODE_NAVIGATE = "navigate"
         private val ALLOWED_SEC_FETCH_SITES = setOf("same-origin", "same-site", "none")
+        private const val INVALID_TICKET_MESSAGE = "인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요."
     }
 
     @Transactional(readOnly = true)
     override fun execute(
         ticket: String,
-        verifier: String,
+        verifier: String?,
         secFetchSite: String?,
         secFetchMode: String?,
     ): ResponseEntity<Void> {
@@ -39,41 +42,43 @@ class CompleteIdpSessionHandoffServiceImpl(
 
         val handoff =
             idpSessionHandoffRedisRepository.findByIdOrNull(ticket)
-                ?: throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
+                ?: throw OAuthException.InvalidRequest(INVALID_TICKET_MESSAGE)
 
         // ticket과 verifier는 같은 URL로 전달되므로 verifier만으로 유출을 막지는 못한다.
-        // 로그 등에서 티켓 일부만 새어나간 경우를 위한 추가 방어이며,
+        // 로그 등에서 티켓 일부만 새어나간 경우를 위한 보조 방어이며,
         // 실질적인 재사용 차단은 위의 Sec-Fetch 검사와 일회용 소비가 담당한다.
         // 불일치해도 티켓을 삭제하지 않는다. 삭제하면 ticket만 아는 공격자가
         // 요청 한 번으로 정상 사용자의 로그인을 무효화할 수 있다.
-        if (!matchesVerifier(verifier, handoff.verifierHash)) {
-            throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
+        if (verifier == null || !OpaqueTokenHashUtil.matches(verifier, handoff.verifierHash)) {
+            throw OAuthException.InvalidRequest(INVALID_TICKET_MESSAGE)
         }
+
+        // 티켓을 소비하기 전에 목적지를 먼저 검증한다.
+        // 순서가 반대면 클라이언트의 redirect_uri가 바뀐 순간 티켓만 날아가고,
+        // 이미 만들어둔 IdP 세션은 브라우저에 전달되지 못한 채 Redis에 남는다.
+        verifyRedirectUrlStillAllowed(handoff)
 
         idpSessionHandoffRedisRepository.deleteById(ticket)
 
-        verifyRedirectUrlStillAllowed(handoff)
-
-        val cookie =
-            ResponseCookie
-                .from(oauthEnvironment.idpSessionCookieName, handoff.sessionId)
-                .httpOnly(true)
-                .secure(oauthEnvironment.idpSessionCookieSecure)
-                .sameSite("Lax")
-                .path("/")
-                .maxAge(Duration.ofSeconds(oauthEnvironment.idpSessionExpirationSeconds))
-                .also { builder ->
-                    oauthEnvironment.idpSessionCookieDomain
-                        ?.takeIf { it.isNotBlank() }
-                        ?.let { builder.domain(it) }
-                }.build()
-
         return ResponseEntity
             .status(HttpStatus.FOUND)
-            .header(HttpHeaders.SET_COOKIE, cookie.toString())
+            .header(HttpHeaders.SET_COOKIE, buildSessionCookie(handoff.sessionId).toString())
             .location(URI.create(handoff.redirectUrl))
             .build()
     }
+
+    // 세션 쿠키를 읽는 곳은 같은 호스트의 GET /v1/oauth/authorize 하나뿐이라 host-only로 충분하다.
+    // Domain을 상위 도메인으로 넓히면 모든 서브도메인이 요청마다 세션 쿠키를 받게 되어,
+    // 서브도메인 하나가 침해되면 SSO 세션 전체가 넘어간다.
+    private fun buildSessionCookie(sessionId: String): ResponseCookie =
+        ResponseCookie
+            .from(oauthEnvironment.idpSessionCookieName, sessionId)
+            .httpOnly(true)
+            .secure(oauthEnvironment.idpSessionCookieSecure)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(Duration.ofSeconds(oauthEnvironment.idpSessionExpirationSeconds))
+            .build()
 
     // 핸드오프 URL은 로그·Referer·브라우저 히스토리에 남기 때문에, 나중에 그 URL을 입수한
     // 공격자가 다시 열어보는 것을 막아야 한다. 정상 흐름은 프론트에서 백엔드로 넘어오는
@@ -85,62 +90,53 @@ class CompleteIdpSessionHandoffServiceImpl(
     ) {
         if (secFetchSite == null && secFetchMode == null) {
             if (oauthEnvironment.idpSessionHandoffRequireFetchMetadata) {
-                throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
+                throw OAuthException.InvalidRequest(INVALID_TICKET_MESSAGE)
             }
             return
         }
 
         if (secFetchMode != null && secFetchMode != SEC_FETCH_MODE_NAVIGATE) {
-            throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
+            throw OAuthException.InvalidRequest(INVALID_TICKET_MESSAGE)
         }
 
         if (secFetchSite != null && secFetchSite !in ALLOWED_SEC_FETCH_SITES) {
-            throw OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
+            throw OAuthException.InvalidRequest(INVALID_TICKET_MESSAGE)
         }
     }
 
     // 저장 시점에 화이트리스트를 통과했더라도, Location으로 내보내기 직전에 다시 확인해
     // 오픈 리다이렉트가 성립하지 않도록 한다.
-    // redirectUrl에는 code/state 쿼리가 덧붙어 있으므로, 등록된 redirect_uri와 동일한 방식으로
-    // 원본 URI만 잘라내 정확히 일치하는지 본다. 접두사 비교는 도메인 위조를 허용하므로 쓰지 않는다.
+    // 검증에 실패하면 쓰이지 못할 세션이 남지 않도록 티켓과 세션을 함께 정리한다.
     private fun verifyRedirectUrlStillAllowed(handoff: IdpSessionHandoffRedisEntity) {
         val client =
             clientJpaRepository
                 .findById(handoff.clientId)
-                .orElseThrow { OAuthException.InvalidRequest("인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.") }
+                .orElseGet { null }
+                ?: throw discardHandoff(handoff, INVALID_TICKET_MESSAGE)
 
-        val isAllowed = client.redirectUrls.any { it == extractRegisteredRedirectUri(handoff.redirectUrl, it) }
-        if (!isAllowed) {
-            throw OAuthException.InvalidRequest("등록되지 않은 redirect_uri입니다.")
+        if (client.redirectUrls.none { matchesRegisteredRedirectUri(handoff.redirectUrl, it) }) {
+            throw discardHandoff(handoff, "등록되지 않은 redirect_uri입니다.")
         }
     }
 
+    private fun discardHandoff(
+        handoff: IdpSessionHandoffRedisEntity,
+        message: String,
+    ): OAuthException.InvalidRequest {
+        idpSessionHandoffRedisRepository.deleteById(handoff.ticket)
+        idpSessionRedisRepository.deleteById(handoff.sessionId)
+        return OAuthException.InvalidRequest(message)
+    }
+
     // 발급 시 buildRedirectUrl이 등록 URI 뒤에 '?' 또는 '&'로 code/state를 이어 붙인다.
-    // 후보 URI 길이만큼 잘라낸 값이 그 URI와 같고, 이어지는 문자가 구분자인 경우에만 일치로 본다.
-    private fun extractRegisteredRedirectUri(
+    // 등록 URI로 시작하고, 이어지는 문자가 그 구분자인 경우에만 일치로 본다.
+    // 접두사만 비교하면 https://example.com.attacker.io 같은 도메인 위조가 통과한다.
+    private fun matchesRegisteredRedirectUri(
         redirectUrl: String,
         candidate: String,
-    ): String? {
-        if (!redirectUrl.startsWith(candidate)) return null
-        val remainder = redirectUrl.substring(candidate.length)
-        if (remainder.isNotEmpty() && remainder[0] != '?' && remainder[0] != '&') return null
-        return candidate
-    }
-
-    private fun matchesVerifier(
-        verifier: String,
-        expectedHash: String,
     ): Boolean {
-        val actualHash = sha256Hex(verifier)
-        return MessageDigest.isEqual(
-            actualHash.toByteArray(Charsets.UTF_8),
-            expectedHash.toByteArray(Charsets.UTF_8),
-        )
+        if (!redirectUrl.startsWith(candidate)) return false
+        val remainder = redirectUrl.substring(candidate.length)
+        return remainder.isEmpty() || remainder[0] == '?' || remainder[0] == '&'
     }
-
-    private fun sha256Hex(value: String): String =
-        MessageDigest
-            .getInstance("SHA-256")
-            .digest(value.toByteArray(Charsets.UTF_8))
-            .joinToString("") { "%02x".format(it) }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.util.UriComponentsBuilder
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatus
 import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
@@ -16,10 +17,14 @@ import team.themoment.datagsm.common.domain.event.dto.payload.EventChangedData
 import team.themoment.datagsm.common.domain.event.dto.payload.StudentEventObject
 import team.themoment.datagsm.common.domain.event.entity.constant.EventType
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeSubmitReqDto
-import team.themoment.datagsm.common.domain.oauth.entity.OauthCodeRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
-import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepository
 import team.themoment.datagsm.common.domain.student.entity.DormitoryRoomNumber
 import team.themoment.datagsm.common.domain.student.entity.StudentDataEditRequestJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
@@ -28,11 +33,13 @@ import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRe
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthAuthorizeFlowService
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
 import team.themoment.sdk.exception.ExpectedException
 import java.net.URI
 import java.security.SecureRandom
 import java.util.Base64
+import java.util.UUID
 
 @Service
 class CompleteOauthAuthorizeFlowServiceImpl(
@@ -40,8 +47,11 @@ class CompleteOauthAuthorizeFlowServiceImpl(
     private val studentJpaRepository: StudentJpaRepository,
     private val clubJpaRepository: ClubJpaRepository,
     private val studentDataEditRequestJpaRepository: StudentDataEditRequestJpaRepository,
-    private val oauthCodeRedisRepository: OauthCodeRedisRepository,
     private val oauthAuthorizeStateRedisRepository: OauthAuthorizeStateRedisRepository,
+    private val idpSessionRedisRepository: IdpSessionRedisRepository,
+    private val idpSessionHandoffRedisRepository: IdpSessionHandoffRedisRepository,
+    private val oauthConsentJpaRepository: OauthConsentJpaRepository,
+    private val issueAuthorizationCodeService: IssueAuthorizationCodeService,
     private val passwordEncoder: PasswordEncoder,
     private val oauthEnvironment: OauthEnvironment,
     private val oauthClientRateLimitService: OAuthClientRateLimitService,
@@ -93,29 +103,73 @@ class CompleteOauthAuthorizeFlowServiceImpl(
             resolveStudentDataEditRequestIfNeeded(account.objectId!!, reqDto)
         }
 
-        val code = generateAuthorizationCode()
-
-        val oauthCodeEntity =
-            OauthCodeRedisEntity(
+        val redirectUrl =
+            issueAuthorizationCodeService.execute(
                 email = account.email,
                 clientId = clientId,
                 redirectUri = redirectUri,
+                state = state,
                 codeChallenge = codeChallenge,
                 codeChallengeMethod = codeChallengeMethod,
                 scopes = scopes,
-                code = code,
-                ttl = oauthEnvironment.codeExpirationSeconds,
             )
-        oauthCodeRedisRepository.save(oauthCodeEntity)
 
         oauthAuthorizeStateRedisRepository.deleteById(reqDto.token)
 
-        val redirectUrl = buildRedirectUrl(redirectUri, code, state)
+        account.id?.let { recordConsent(it, clientId, scopes) }
+
+        val handoffUrl = createSessionHandoff(account.email, redirectUrl)
 
         return ResponseEntity
             .status(HttpStatus.FOUND)
-            .location(URI.create(redirectUrl))
+            .location(URI.create(handoffUrl))
             .build()
+    }
+
+    // BFF가 서버-투-서버로 호출하므로 이 응답에는 브라우저 쿠키를 심을 수 없다.
+    // 세션을 만들어두고, 브라우저가 최상위 이동으로 경유할 일회용 티켓 URL을 돌려준다.
+    private fun createSessionHandoff(
+        email: String,
+        redirectUrl: String,
+    ): String {
+        val sessionId = UUID.randomUUID().toString()
+        idpSessionRedisRepository.save(
+            IdpSessionRedisEntity(
+                sessionId = sessionId,
+                email = email,
+                ttl = oauthEnvironment.idpSessionExpirationSeconds,
+            ),
+        )
+
+        val ticket = generateOpaqueToken()
+        idpSessionHandoffRedisRepository.save(
+            IdpSessionHandoffRedisEntity(
+                ticket = ticket,
+                sessionId = sessionId,
+                redirectUrl = redirectUrl,
+                ttl = oauthEnvironment.idpSessionHandoffExpirationSeconds,
+            ),
+        )
+
+        return UriComponentsBuilder
+            .fromUriString(oauthEnvironment.issuerUrl)
+            .path("/v1/oauth/authorize/session")
+            .queryParam("ticket", ticket)
+            .build()
+            .toUriString()
+    }
+
+    private fun recordConsent(
+        accountId: Long,
+        clientId: String,
+        scopes: Set<String>,
+    ) {
+        val consent =
+            oauthConsentJpaRepository
+                .findByAccountIdAndClientId(accountId, clientId)
+                .orElseGet { OauthConsentJpaEntity.create(accountId, clientId, emptySet()) }
+        consent.grantedScopes.addAll(scopes)
+        oauthConsentJpaRepository.save(consent)
     }
 
     private fun resolveStudentDataEditRequestIfNeeded(
@@ -227,21 +281,9 @@ class CompleteOauthAuthorizeFlowServiceImpl(
             githubId = student.githubId,
         )
 
-    private fun generateAuthorizationCode(): String =
+    private fun generateOpaqueToken(): String =
         Base64
             .getUrlEncoder()
             .withoutPadding()
             .encodeToString(ByteArray(22).also { secureRandom.nextBytes(it) })
-
-    private fun buildRedirectUrl(
-        redirectUri: String,
-        code: String,
-        state: String?,
-    ): String =
-        buildString {
-            append(redirectUri)
-            append(if (redirectUri.contains('?')) '&' else '?')
-            append("code=").append(code)
-            state?.let { append("&state=").append(it) }
-        }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
@@ -1,6 +1,7 @@
 package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
 
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -32,12 +33,13 @@ import team.themoment.datagsm.common.domain.student.entity.StudentNumber
 import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRequestJpaRepository
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.common.global.security.util.OpaqueTokenHashUtil
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthAuthorizeFlowService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
 import team.themoment.sdk.exception.ExpectedException
+import team.themoment.sdk.logging.logger.logger
 import java.net.URI
-import java.security.MessageDigest
 import java.security.SecureRandom
 import java.util.Base64
 import java.util.UUID
@@ -117,7 +119,8 @@ class CompleteOauthAuthorizeFlowServiceImpl(
 
         oauthAuthorizeStateRedisRepository.deleteById(reqDto.token)
 
-        account.id?.let { recordConsent(it, clientId, scopes) }
+        val accountId = requireNotNull(account.id) { "Persisted account must have an id" }
+        recordConsent(accountId, clientId, scopes)
 
         val handoffUrl = createSessionHandoff(account.email, clientId, redirectUrl)
 
@@ -149,7 +152,7 @@ class CompleteOauthAuthorizeFlowServiceImpl(
         idpSessionHandoffRedisRepository.save(
             IdpSessionHandoffRedisEntity(
                 ticket = ticket,
-                verifierHash = sha256Hex(verifier),
+                verifierHash = OpaqueTokenHashUtil.hash(verifier),
                 sessionId = sessionId,
                 clientId = clientId,
                 redirectUrl = redirectUrl,
@@ -166,13 +169,23 @@ class CompleteOauthAuthorizeFlowServiceImpl(
             .toUriString()
     }
 
-    private fun sha256Hex(value: String): String =
-        MessageDigest
-            .getInstance("SHA-256")
-            .digest(value.toByteArray(Charsets.UTF_8))
-            .joinToString("") { "%02x".format(it) }
-
+    // 같은 (account, client)로 첫 로그인이 동시에 들어오면 양쪽 다 insert를 시도해
+    // uk_oauth_consent_account_client 위반이 난다. 이 시점에는 code와 세션이 이미
+    // Redis에 저장돼 롤백되지 않으므로, 제약 위반은 재조회 후 병합으로 흡수한다.
     private fun recordConsent(
+        accountId: Long,
+        clientId: String,
+        scopes: Set<String>,
+    ) {
+        try {
+            saveConsent(accountId, clientId, scopes)
+        } catch (e: DataIntegrityViolationException) {
+            logger().warn("Retrying consent record after unique constraint violation for clientId {}", clientId, e)
+            saveConsent(accountId, clientId, scopes)
+        }
+    }
+
+    private fun saveConsent(
         accountId: Long,
         clientId: String,
         scopes: Set<String>,
@@ -182,7 +195,7 @@ class CompleteOauthAuthorizeFlowServiceImpl(
                 .findByAccountIdAndClientId(accountId, clientId)
                 .orElseGet { OauthConsentJpaEntity.create(accountId, clientId, emptySet()) }
         consent.grantedScopes.addAll(scopes)
-        oauthConsentJpaRepository.save(consent)
+        oauthConsentJpaRepository.saveAndFlush(consent)
     }
 
     private fun resolveStudentDataEditRequestIfNeeded(

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
@@ -37,6 +37,7 @@ import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuth
 import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
 import team.themoment.sdk.exception.ExpectedException
 import java.net.URI
+import java.security.MessageDigest
 import java.security.SecureRandom
 import java.util.Base64
 import java.util.UUID
@@ -118,7 +119,7 @@ class CompleteOauthAuthorizeFlowServiceImpl(
 
         account.id?.let { recordConsent(it, clientId, scopes) }
 
-        val handoffUrl = createSessionHandoff(account.email, redirectUrl)
+        val handoffUrl = createSessionHandoff(account.email, clientId, redirectUrl)
 
         return ResponseEntity
             .status(HttpStatus.FOUND)
@@ -128,8 +129,10 @@ class CompleteOauthAuthorizeFlowServiceImpl(
 
     // BFF가 서버-투-서버로 호출하므로 이 응답에는 브라우저 쿠키를 심을 수 없다.
     // 세션을 만들어두고, 브라우저가 최상위 이동으로 경유할 일회용 티켓 URL을 돌려준다.
+    // ticket은 로그·Referer에 남을 수 있으므로 verifier를 함께 발급하고 해시만 저장한다.
     private fun createSessionHandoff(
         email: String,
+        clientId: String,
         redirectUrl: String,
     ): String {
         val sessionId = UUID.randomUUID().toString()
@@ -142,10 +145,13 @@ class CompleteOauthAuthorizeFlowServiceImpl(
         )
 
         val ticket = generateOpaqueToken()
+        val verifier = generateOpaqueToken()
         idpSessionHandoffRedisRepository.save(
             IdpSessionHandoffRedisEntity(
                 ticket = ticket,
+                verifierHash = sha256Hex(verifier),
                 sessionId = sessionId,
+                clientId = clientId,
                 redirectUrl = redirectUrl,
                 ttl = oauthEnvironment.idpSessionHandoffExpirationSeconds,
             ),
@@ -155,9 +161,16 @@ class CompleteOauthAuthorizeFlowServiceImpl(
             .fromUriString(oauthEnvironment.issuerUrl)
             .path("/v1/oauth/authorize/session")
             .queryParam("ticket", ticket)
+            .queryParam("verifier", verifier)
             .build()
             .toUriString()
     }
+
+    private fun sha256Hex(value: String): String =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
 
     private fun recordConsent(
         accountId: Long,

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/IssueAuthorizationCodeServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/IssueAuthorizationCodeServiceImpl.kt
@@ -5,6 +5,8 @@ import team.themoment.datagsm.common.domain.oauth.entity.OauthCodeRedisEntity
 import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.security.SecureRandom
 import java.util.Base64
 
@@ -50,6 +52,8 @@ class IssueAuthorizationCodeServiceImpl(
             .withoutPadding()
             .encodeToString(ByteArray(22).also { secureRandom.nextBytes(it) })
 
+    // state는 클라이언트가 임의 값을 넣는 CSRF 방어 값이라, 인코딩하지 않으면
+    // '&'나 '=' 삽입으로 리다이렉트 URL의 파라미터가 조작될 수 있다.
     private fun buildRedirectUrl(
         redirectUri: String,
         code: String,
@@ -58,7 +62,9 @@ class IssueAuthorizationCodeServiceImpl(
         buildString {
             append(redirectUri)
             append(if (redirectUri.contains('?')) '&' else '?')
-            append("code=").append(code)
-            state?.let { append("&state=").append(it) }
+            append("code=").append(encodeQueryValue(code))
+            state?.let { append("&state=").append(encodeQueryValue(it)) }
         }
+
+    private fun encodeQueryValue(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8)
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/IssueAuthorizationCodeServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/IssueAuthorizationCodeServiceImpl.kt
@@ -1,0 +1,64 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
+
+import org.springframework.stereotype.Service
+import team.themoment.datagsm.common.domain.oauth.entity.OauthCodeRedisEntity
+import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
+import java.security.SecureRandom
+import java.util.Base64
+
+@Service
+class IssueAuthorizationCodeServiceImpl(
+    private val oauthCodeRedisRepository: OauthCodeRedisRepository,
+    private val oauthEnvironment: OauthEnvironment,
+) : IssueAuthorizationCodeService {
+    companion object {
+        private val secureRandom = SecureRandom()
+    }
+
+    override fun execute(
+        email: String,
+        clientId: String,
+        redirectUri: String,
+        state: String?,
+        codeChallenge: String?,
+        codeChallengeMethod: String?,
+        scopes: Set<String>,
+    ): String {
+        val code = generateAuthorizationCode()
+
+        oauthCodeRedisRepository.save(
+            OauthCodeRedisEntity(
+                email = email,
+                clientId = clientId,
+                redirectUri = redirectUri,
+                codeChallenge = codeChallenge,
+                codeChallengeMethod = codeChallengeMethod,
+                scopes = scopes,
+                code = code,
+                ttl = oauthEnvironment.codeExpirationSeconds,
+            ),
+        )
+
+        return buildRedirectUrl(redirectUri, code, state)
+    }
+
+    private fun generateAuthorizationCode(): String =
+        Base64
+            .getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(ByteArray(22).also { secureRandom.nextBytes(it) })
+
+    private fun buildRedirectUrl(
+        redirectUri: String,
+        code: String,
+        state: String?,
+    ): String =
+        buildString {
+            append(redirectUri)
+            append(if (redirectUri.contains('?')) '&' else '?')
+            append("code=").append(code)
+            state?.let { append("&state=").append(it) }
+        }
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/IssueAuthorizationCodeServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/IssueAuthorizationCodeServiceImpl.kt
@@ -1,10 +1,13 @@
 package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
 
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import team.themoment.datagsm.common.domain.oauth.entity.OauthCodeRedisEntity
 import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
+import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
+import team.themoment.sdk.exception.ExpectedException
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.security.SecureRandom
@@ -13,6 +16,7 @@ import java.util.Base64
 @Service
 class IssueAuthorizationCodeServiceImpl(
     private val oauthCodeRedisRepository: OauthCodeRedisRepository,
+    private val oauthClientRateLimitService: OAuthClientRateLimitService,
     private val oauthEnvironment: OauthEnvironment,
 ) : IssueAuthorizationCodeService {
     companion object {
@@ -28,6 +32,13 @@ class IssueAuthorizationCodeServiceImpl(
         codeChallengeMethod: String?,
         scopes: Set<String>,
     ): String {
+        // 코드 발급은 SSO(GET)와 로그인(POST) 양쪽에서 일어난다.
+        // 한도를 발급 지점에 두어야 두 경로가 같은 정책을 따른다.
+        val rateLimitResult = oauthClientRateLimitService.tryConsumeAndReturnRemaining(clientId)
+        if (!rateLimitResult.consumed) {
+            throw ExpectedException("요청 한도를 초과했습니다.", HttpStatus.TOO_MANY_REQUESTS)
+        }
+
         val code = generateAuthorizationCode()
 
         oauthCodeRedisRepository.save(

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -1,19 +1,30 @@
 package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.util.UriComponentsBuilder
+import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatus
+import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
 import team.themoment.datagsm.common.domain.client.entity.constant.OAuthScope
 import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeReqDto
 import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
 import team.themoment.datagsm.common.domain.oauth.entity.constant.PkceChallengeMethod
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepository
+import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRequestJpaRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.StartOauthAuthorizeFlowService
 import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
+import java.net.URI
 import java.util.UUID
 
 @Service
@@ -22,8 +33,17 @@ class StartOauthAuthorizeFlowServiceImpl(
     private val oauthEnvironment: OauthEnvironment,
     private val oauthAuthorizeStateRedisRepository: OauthAuthorizeStateRedisRepository,
     private val jwtEnvironment: OauthJwtProvisionEnvironment,
+    private val idpSessionRedisRepository: IdpSessionRedisRepository,
+    private val accountJpaRepository: AccountJpaRepository,
+    private val studentDataEditRequestJpaRepository: StudentDataEditRequestJpaRepository,
+    private val oauthConsentJpaRepository: OauthConsentJpaRepository,
+    private val issueAuthorizationCodeService: IssueAuthorizationCodeService,
 ) : StartOauthAuthorizeFlowService {
-    override fun execute(reqDto: OauthAuthorizeReqDto): ResponseEntity<Void> {
+    @Transactional(readOnly = true)
+    override fun execute(
+        reqDto: OauthAuthorizeReqDto,
+        sessionId: String?,
+    ): ResponseEntity<Void> {
         val clientId = reqDto.client_id ?: throw OAuthException.InvalidRequest("client_id는 필수입니다.")
         val redirectUri = reqDto.redirect_uri ?: throw OAuthException.InvalidRequest("redirect_uri는 필수입니다.")
         val responseType = reqDto.response_type
@@ -56,6 +76,24 @@ class StartOauthAuthorizeFlowServiceImpl(
                 ?.toSet()
         val resolvedScopes = resolveScopes(requestedScopes, client.scopes)
 
+        val ssoAccount = resolveSsoAccount(sessionId, clientId, resolvedScopes)
+        if (ssoAccount != null) {
+            val redirectUrl =
+                issueAuthorizationCodeService.execute(
+                    email = ssoAccount.email,
+                    clientId = clientId,
+                    redirectUri = redirectUri,
+                    state = state,
+                    codeChallenge = codeChallenge,
+                    codeChallengeMethod = codeChallengeMethod,
+                    scopes = resolvedScopes,
+                )
+            return ResponseEntity
+                .status(HttpStatus.FOUND)
+                .location(URI.create(redirectUrl))
+                .build()
+        }
+
         val token = UUID.randomUUID().toString()
 
         val stateEntity =
@@ -84,6 +122,37 @@ class StartOauthAuthorizeFlowServiceImpl(
             .status(HttpStatus.FOUND)
             .location(location)
             .build()
+    }
+
+    // SSO 세션으로 로그인을 생략할 수 있는지 판단한다.
+    // 어느 조건이든 충족하지 못하면 null을 반환해 기존 로그인 플로우로 폴백시킨다.
+    private fun resolveSsoAccount(
+        sessionId: String?,
+        clientId: String,
+        resolvedScopes: Set<String>,
+    ): AccountJpaEntity? {
+        if (sessionId.isNullOrBlank()) return null
+
+        val session = idpSessionRedisRepository.findByIdOrNull(sessionId) ?: return null
+        val account = accountJpaRepository.findByEmail(session.email).orElse(null) ?: return null
+        val accountId = account.id ?: return null
+
+        if (account.status != AccountStatus.ACTIVE) return null
+
+        val studentId = account.objectId
+        if (account.objectType == AccountObjectType.STUDENT && studentId != null) {
+            val hasPendingEditRequest = studentDataEditRequestJpaRepository.findByStudentId(studentId).isPresent
+            if (hasPendingEditRequest) return null
+        }
+
+        val consent =
+            oauthConsentJpaRepository
+                .findByAccountIdAndClientId(accountId, clientId)
+                .orElse(null) ?: return null
+
+        if (!consent.grantedScopes.containsAll(resolvedScopes)) return null
+
+        return account
     }
 
     private fun resolveScopes(

--- a/datagsm-oauth-authorization/src/main/resources/application.yml
+++ b/datagsm-oauth-authorization/src/main/resources/application.yml
@@ -63,6 +63,7 @@ spring:
       idp-session-cookie-name: ${OAUTH_IDP_SESSION_COOKIE_NAME:datagsm_idp_session}
       idp-session-cookie-domain: ${OAUTH_IDP_SESSION_COOKIE_DOMAIN:}
       idp-session-cookie-secure: ${OAUTH_IDP_SESSION_COOKIE_SECURE:true}
+      idp-session-handoff-require-fetch-metadata: ${OAUTH_IDP_SESSION_HANDOFF_REQUIRE_FETCH_METADATA:false}
     oauth-client:
       rate-limit:
         enabled: true

--- a/datagsm-oauth-authorization/src/main/resources/application.yml
+++ b/datagsm-oauth-authorization/src/main/resources/application.yml
@@ -61,7 +61,6 @@ spring:
       idp-session-expiration-seconds: ${OAUTH_IDP_SESSION_EXPIRATION_SECONDS:28800}
       idp-session-handoff-expiration-seconds: ${OAUTH_IDP_SESSION_HANDOFF_EXPIRATION_SECONDS:60}
       idp-session-cookie-name: ${OAUTH_IDP_SESSION_COOKIE_NAME:datagsm_idp_session}
-      idp-session-cookie-domain: ${OAUTH_IDP_SESSION_COOKIE_DOMAIN:}
       idp-session-cookie-secure: ${OAUTH_IDP_SESSION_COOKIE_SECURE:true}
       idp-session-handoff-require-fetch-metadata: ${OAUTH_IDP_SESSION_HANDOFF_REQUIRE_FETCH_METADATA:false}
     oauth-client:

--- a/datagsm-oauth-authorization/src/main/resources/application.yml
+++ b/datagsm-oauth-authorization/src/main/resources/application.yml
@@ -57,6 +57,12 @@ spring:
       code-expiration-seconds: ${OAUTH_CODE_EXPIRATION:300}
       frontend-url: ${OAUTH_FRONTEND_URL:http://localhost:3000}
       authorize-state-expiration-ms: ${OAUTH_AUTHORIZE_STATE_EXPIRATION_MS:600000}
+      issuer-url: ${OAUTH_ISSUER_URL:http://localhost:8081}
+      idp-session-expiration-seconds: ${OAUTH_IDP_SESSION_EXPIRATION_SECONDS:28800}
+      idp-session-handoff-expiration-seconds: ${OAUTH_IDP_SESSION_HANDOFF_EXPIRATION_SECONDS:60}
+      idp-session-cookie-name: ${OAUTH_IDP_SESSION_COOKIE_NAME:datagsm_idp_session}
+      idp-session-cookie-domain: ${OAUTH_IDP_SESSION_COOKIE_DOMAIN:}
+      idp-session-cookie-secure: ${OAUTH_IDP_SESSION_COOKIE_SECURE:true}
     oauth-client:
       rate-limit:
         enabled: true

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffServiceTest.kt
@@ -10,22 +10,27 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import team.themoment.datagsm.common.domain.client.entity.ClientJpaEntity
+import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.CompleteIdpSessionHandoffServiceImpl
+import java.security.MessageDigest
 import java.util.Optional
 
 class CompleteIdpSessionHandoffServiceTest :
     DescribeSpec({
 
         val mockIdpSessionHandoffRedisRepository = mockk<IdpSessionHandoffRedisRepository>(relaxed = true)
+        val mockClientJpaRepository = mockk<ClientJpaRepository>()
         val mockOauthEnvironment = mockk<OauthEnvironment>()
 
         val completeIdpSessionHandoffService =
             CompleteIdpSessionHandoffServiceImpl(
                 mockIdpSessionHandoffRedisRepository,
+                mockClientJpaRepository,
                 mockOauthEnvironment,
             )
 
@@ -37,33 +42,45 @@ class CompleteIdpSessionHandoffServiceTest :
             describe("execute 메서드는") {
 
                 val testTicket = "test-ticket-123"
+                val testVerifier = "test-verifier-456"
                 val testSessionId = "session-abc"
-                val testRedirectUrl = "https://example.com/callback?code=test-code&state=random-state"
+                val testClientId = "client-123"
+                val testRedirectUri = "https://example.com/callback"
+                val testRedirectUrl = "$testRedirectUri?code=test-code&state=random-state"
                 val cookieName = "datagsm_idp_session"
                 val sessionTtl = 28800L
 
                 val handoff =
                     IdpSessionHandoffRedisEntity(
                         ticket = testTicket,
+                        verifierHash = sha256Hex(testVerifier),
                         sessionId = testSessionId,
+                        clientId = testClientId,
                         redirectUrl = testRedirectUrl,
                         ttl = 60,
                     )
+
+                val testClient =
+                    ClientJpaEntity().apply {
+                        id = testClientId
+                        redirectUrls = setOf(testRedirectUri)
+                    }
 
                 beforeEach {
                     every { mockOauthEnvironment.idpSessionCookieName } returns cookieName
                     every { mockOauthEnvironment.idpSessionExpirationSeconds } returns sessionTtl
                     every { mockOauthEnvironment.idpSessionCookieSecure } returns true
                     every { mockOauthEnvironment.idpSessionCookieDomain } returns ".datagsm.kr"
+                    every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(testClient)
                 }
 
-                context("유효한 티켓이 주어졌을 때") {
+                context("유효한 티켓과 verifier가 주어졌을 때") {
                     beforeEach {
                         every { mockIdpSessionHandoffRedisRepository.findById(testTicket) } returns Optional.of(handoff)
                     }
 
                     it("세션 쿠키를 설정하고 원래 목적지로 302 리다이렉트되어야 한다") {
-                        val response = completeIdpSessionHandoffService.execute(testTicket)
+                        val response = completeIdpSessionHandoffService.execute(testTicket, testVerifier)
 
                         response.statusCode shouldBe HttpStatus.FOUND
                         response.headers.location?.toString() shouldBe testRedirectUrl
@@ -78,9 +95,82 @@ class CompleteIdpSessionHandoffServiceTest :
                     }
 
                     it("티켓은 일회용이므로 사용 즉시 삭제되어야 한다") {
-                        completeIdpSessionHandoffService.execute(testTicket)
+                        completeIdpSessionHandoffService.execute(testTicket, testVerifier)
 
                         verify(exactly = 1) { mockIdpSessionHandoffRedisRepository.deleteById(testTicket) }
+                    }
+                }
+
+                context("티켓은 맞지만 verifier가 틀렸을 때") {
+                    beforeEach {
+                        every { mockIdpSessionHandoffRedisRepository.findById(testTicket) } returns Optional.of(handoff)
+                    }
+
+                    it("세션을 발급하지 않고 InvalidRequest 예외가 발생해야 한다") {
+                        val exception =
+                            shouldThrow<OAuthException.InvalidRequest> {
+                                completeIdpSessionHandoffService.execute(testTicket, "wrong-verifier")
+                            }
+
+                        exception.error shouldBe "invalid_request"
+                    }
+
+                    it("무차별 대입을 막기 위해 티켓이 폐기되어야 한다") {
+                        shouldThrow<OAuthException.InvalidRequest> {
+                            completeIdpSessionHandoffService.execute(testTicket, "wrong-verifier")
+                        }
+
+                        verify(exactly = 1) { mockIdpSessionHandoffRedisRepository.deleteById(testTicket) }
+                    }
+                }
+
+                context("저장된 redirectUrl이 더 이상 허용되지 않을 때") {
+                    beforeEach {
+                        every { mockIdpSessionHandoffRedisRepository.findById(testTicket) } returns Optional.of(handoff)
+                        every { mockClientJpaRepository.findById(testClientId) } returns
+                            Optional.of(
+                                ClientJpaEntity().apply {
+                                    id = testClientId
+                                    redirectUrls = setOf("https://another.example.com/callback")
+                                },
+                            )
+                    }
+
+                    it("오픈 리다이렉트를 막기 위해 예외가 발생해야 한다") {
+                        shouldThrow<OAuthException.InvalidRequest> {
+                            completeIdpSessionHandoffService.execute(testTicket, testVerifier)
+                        }
+                    }
+                }
+
+                context("등록된 URI의 접두사만 일치하는 위조 도메인일 때") {
+                    val spoofedRedirectUrl = "https://example.com.attacker.io/callback?code=test-code"
+                    val spoofedHandoff =
+                        IdpSessionHandoffRedisEntity(
+                            ticket = testTicket,
+                            verifierHash = sha256Hex(testVerifier),
+                            sessionId = testSessionId,
+                            clientId = testClientId,
+                            redirectUrl = spoofedRedirectUrl,
+                            ttl = 60,
+                        )
+
+                    beforeEach {
+                        every { mockIdpSessionHandoffRedisRepository.findById(testTicket) } returns
+                            Optional.of(spoofedHandoff)
+                        every { mockClientJpaRepository.findById(testClientId) } returns
+                            Optional.of(
+                                ClientJpaEntity().apply {
+                                    id = testClientId
+                                    redirectUrls = setOf("https://example.com")
+                                },
+                            )
+                    }
+
+                    it("접두사 일치만으로는 통과시키지 않아야 한다") {
+                        shouldThrow<OAuthException.InvalidRequest> {
+                            completeIdpSessionHandoffService.execute(testTicket, testVerifier)
+                        }
                     }
                 }
 
@@ -91,7 +181,7 @@ class CompleteIdpSessionHandoffServiceTest :
                     }
 
                     it("Domain 속성 없이 호스트 전용 쿠키가 설정되어야 한다") {
-                        val response = completeIdpSessionHandoffService.execute(testTicket)
+                        val response = completeIdpSessionHandoffService.execute(testTicket, testVerifier)
 
                         val setCookie = response.headers.getFirst(HttpHeaders.SET_COOKIE) ?: ""
                         setCookie shouldContain "$cookieName=$testSessionId"
@@ -107,7 +197,7 @@ class CompleteIdpSessionHandoffServiceTest :
                     it("InvalidRequest 예외가 발생하고 티켓이 삭제되지 않아야 한다") {
                         val exception =
                             shouldThrow<OAuthException.InvalidRequest> {
-                                completeIdpSessionHandoffService.execute("expired-ticket")
+                                completeIdpSessionHandoffService.execute("expired-ticket", testVerifier)
                             }
 
                         exception.error shouldBe "invalid_request"
@@ -118,3 +208,9 @@ class CompleteIdpSessionHandoffServiceTest :
             }
         }
     })
+
+private fun sha256Hex(value: String): String =
+    MessageDigest
+        .getInstance("SHA-256")
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffServiceTest.kt
@@ -1,0 +1,120 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
+import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.CompleteIdpSessionHandoffServiceImpl
+import java.util.Optional
+
+class CompleteIdpSessionHandoffServiceTest :
+    DescribeSpec({
+
+        val mockIdpSessionHandoffRedisRepository = mockk<IdpSessionHandoffRedisRepository>(relaxed = true)
+        val mockOauthEnvironment = mockk<OauthEnvironment>()
+
+        val completeIdpSessionHandoffService =
+            CompleteIdpSessionHandoffServiceImpl(
+                mockIdpSessionHandoffRedisRepository,
+                mockOauthEnvironment,
+            )
+
+        afterEach {
+            clearAllMocks()
+        }
+
+        describe("CompleteIdpSessionHandoffService 클래스의") {
+            describe("execute 메서드는") {
+
+                val testTicket = "test-ticket-123"
+                val testSessionId = "session-abc"
+                val testRedirectUrl = "https://example.com/callback?code=test-code&state=random-state"
+                val cookieName = "datagsm_idp_session"
+                val sessionTtl = 28800L
+
+                val handoff =
+                    IdpSessionHandoffRedisEntity(
+                        ticket = testTicket,
+                        sessionId = testSessionId,
+                        redirectUrl = testRedirectUrl,
+                        ttl = 60,
+                    )
+
+                beforeEach {
+                    every { mockOauthEnvironment.idpSessionCookieName } returns cookieName
+                    every { mockOauthEnvironment.idpSessionExpirationSeconds } returns sessionTtl
+                    every { mockOauthEnvironment.idpSessionCookieSecure } returns true
+                    every { mockOauthEnvironment.idpSessionCookieDomain } returns ".datagsm.kr"
+                }
+
+                context("유효한 티켓이 주어졌을 때") {
+                    beforeEach {
+                        every { mockIdpSessionHandoffRedisRepository.findById(testTicket) } returns Optional.of(handoff)
+                    }
+
+                    it("세션 쿠키를 설정하고 원래 목적지로 302 리다이렉트되어야 한다") {
+                        val response = completeIdpSessionHandoffService.execute(testTicket)
+
+                        response.statusCode shouldBe HttpStatus.FOUND
+                        response.headers.location?.toString() shouldBe testRedirectUrl
+
+                        val setCookie = response.headers.getFirst(HttpHeaders.SET_COOKIE) ?: ""
+                        setCookie shouldContain "$cookieName=$testSessionId"
+                        setCookie shouldContain "HttpOnly"
+                        setCookie shouldContain "Secure"
+                        setCookie shouldContain "SameSite=Lax"
+                        setCookie shouldContain "Domain=.datagsm.kr"
+                        setCookie shouldContain "Max-Age=$sessionTtl"
+                    }
+
+                    it("티켓은 일회용이므로 사용 즉시 삭제되어야 한다") {
+                        completeIdpSessionHandoffService.execute(testTicket)
+
+                        verify(exactly = 1) { mockIdpSessionHandoffRedisRepository.deleteById(testTicket) }
+                    }
+                }
+
+                context("쿠키 도메인이 설정되지 않았을 때") {
+                    beforeEach {
+                        every { mockOauthEnvironment.idpSessionCookieDomain } returns null
+                        every { mockIdpSessionHandoffRedisRepository.findById(testTicket) } returns Optional.of(handoff)
+                    }
+
+                    it("Domain 속성 없이 호스트 전용 쿠키가 설정되어야 한다") {
+                        val response = completeIdpSessionHandoffService.execute(testTicket)
+
+                        val setCookie = response.headers.getFirst(HttpHeaders.SET_COOKIE) ?: ""
+                        setCookie shouldContain "$cookieName=$testSessionId"
+                        setCookie.contains("Domain=") shouldBe false
+                    }
+                }
+
+                context("유효하지 않거나 만료된 티켓이 주어졌을 때") {
+                    beforeEach {
+                        every { mockIdpSessionHandoffRedisRepository.findById(any()) } returns Optional.empty()
+                    }
+
+                    it("InvalidRequest 예외가 발생하고 티켓이 삭제되지 않아야 한다") {
+                        val exception =
+                            shouldThrow<OAuthException.InvalidRequest> {
+                                completeIdpSessionHandoffService.execute("expired-ticket")
+                            }
+
+                        exception.error shouldBe "invalid_request"
+
+                        verify(exactly = 0) { mockIdpSessionHandoffRedisRepository.deleteById(any()) }
+                    }
+                }
+            }
+        }
+    })

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffServiceTest.kt
@@ -15,6 +15,7 @@ import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepositor
 import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.CompleteIdpSessionHandoffServiceImpl
 import java.security.MessageDigest
@@ -24,12 +25,14 @@ class CompleteIdpSessionHandoffServiceTest :
     DescribeSpec({
 
         val mockIdpSessionHandoffRedisRepository = mockk<IdpSessionHandoffRedisRepository>(relaxed = true)
+        val mockIdpSessionRedisRepository = mockk<IdpSessionRedisRepository>(relaxed = true)
         val mockClientJpaRepository = mockk<ClientJpaRepository>()
         val mockOauthEnvironment = mockk<OauthEnvironment>()
 
         val completeIdpSessionHandoffService =
             CompleteIdpSessionHandoffServiceImpl(
                 mockIdpSessionHandoffRedisRepository,
+                mockIdpSessionRedisRepository,
                 mockClientJpaRepository,
                 mockOauthEnvironment,
             )
@@ -70,7 +73,6 @@ class CompleteIdpSessionHandoffServiceTest :
                     every { mockOauthEnvironment.idpSessionCookieName } returns cookieName
                     every { mockOauthEnvironment.idpSessionExpirationSeconds } returns sessionTtl
                     every { mockOauthEnvironment.idpSessionCookieSecure } returns true
-                    every { mockOauthEnvironment.idpSessionCookieDomain } returns ".datagsm.kr"
                     every { mockOauthEnvironment.idpSessionHandoffRequireFetchMetadata } returns false
                     every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(testClient)
                 }
@@ -91,7 +93,7 @@ class CompleteIdpSessionHandoffServiceTest :
                         setCookie shouldContain "HttpOnly"
                         setCookie shouldContain "Secure"
                         setCookie shouldContain "SameSite=Lax"
-                        setCookie shouldContain "Domain=.datagsm.kr"
+                        setCookie.contains("Domain=") shouldBe false
                         setCookie shouldContain "Max-Age=$sessionTtl"
                     }
 
@@ -195,6 +197,16 @@ class CompleteIdpSessionHandoffServiceTest :
                             completeIdpSessionHandoffService.execute(testTicket, testVerifier, "same-site", "navigate")
                         }
                     }
+
+                    it("쓰이지 못할 티켓과 세션이 함께 정리되어야 한다") {
+                        shouldThrow<OAuthException.InvalidRequest> {
+                            completeIdpSessionHandoffService.execute(testTicket, testVerifier, "same-site", "navigate")
+                        }
+
+                        // 검증 실패 시 세션이 남으면 8시간 동안 쓰이지 못한 채 Redis를 차지한다.
+                        verify(exactly = 1) { mockIdpSessionHandoffRedisRepository.deleteById(testTicket) }
+                        verify(exactly = 1) { mockIdpSessionRedisRepository.deleteById(testSessionId) }
+                    }
                 }
 
                 context("등록된 URI의 접두사만 일치하는 위조 도메인일 때") {
@@ -228,18 +240,18 @@ class CompleteIdpSessionHandoffServiceTest :
                     }
                 }
 
-                context("쿠키 도메인이 설정되지 않았을 때") {
+                context("verifier 파라미터가 아예 빠졌을 때") {
                     beforeEach {
-                        every { mockOauthEnvironment.idpSessionCookieDomain } returns null
                         every { mockIdpSessionHandoffRedisRepository.findById(testTicket) } returns Optional.of(handoff)
                     }
 
-                    it("Domain 속성 없이 호스트 전용 쿠키가 설정되어야 한다") {
-                        val response = completeIdpSessionHandoffService.execute(testTicket, testVerifier, "same-site", "navigate")
+                    it("스프링 기본 400이 아닌 InvalidRequest로 처리되어야 한다") {
+                        val exception =
+                            shouldThrow<OAuthException.InvalidRequest> {
+                                completeIdpSessionHandoffService.execute(testTicket, null, "same-site", "navigate")
+                            }
 
-                        val setCookie = response.headers.getFirst(HttpHeaders.SET_COOKIE) ?: ""
-                        setCookie shouldContain "$cookieName=$testSessionId"
-                        setCookie.contains("Domain=") shouldBe false
+                        exception.error shouldBe "invalid_request"
                     }
                 }
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffServiceTest.kt
@@ -71,6 +71,7 @@ class CompleteIdpSessionHandoffServiceTest :
                     every { mockOauthEnvironment.idpSessionExpirationSeconds } returns sessionTtl
                     every { mockOauthEnvironment.idpSessionCookieSecure } returns true
                     every { mockOauthEnvironment.idpSessionCookieDomain } returns ".datagsm.kr"
+                    every { mockOauthEnvironment.idpSessionHandoffRequireFetchMetadata } returns false
                     every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(testClient)
                 }
 
@@ -80,7 +81,7 @@ class CompleteIdpSessionHandoffServiceTest :
                     }
 
                     it("세션 쿠키를 설정하고 원래 목적지로 302 리다이렉트되어야 한다") {
-                        val response = completeIdpSessionHandoffService.execute(testTicket, testVerifier)
+                        val response = completeIdpSessionHandoffService.execute(testTicket, testVerifier, "same-site", "navigate")
 
                         response.statusCode shouldBe HttpStatus.FOUND
                         response.headers.location?.toString() shouldBe testRedirectUrl
@@ -95,7 +96,7 @@ class CompleteIdpSessionHandoffServiceTest :
                     }
 
                     it("티켓은 일회용이므로 사용 즉시 삭제되어야 한다") {
-                        completeIdpSessionHandoffService.execute(testTicket, testVerifier)
+                        completeIdpSessionHandoffService.execute(testTicket, testVerifier, "same-site", "navigate")
 
                         verify(exactly = 1) { mockIdpSessionHandoffRedisRepository.deleteById(testTicket) }
                     }
@@ -109,18 +110,71 @@ class CompleteIdpSessionHandoffServiceTest :
                     it("세션을 발급하지 않고 InvalidRequest 예외가 발생해야 한다") {
                         val exception =
                             shouldThrow<OAuthException.InvalidRequest> {
-                                completeIdpSessionHandoffService.execute(testTicket, "wrong-verifier")
+                                completeIdpSessionHandoffService.execute(testTicket, "wrong-verifier", "same-site", "navigate")
                             }
 
                         exception.error shouldBe "invalid_request"
                     }
 
-                    it("무차별 대입을 막기 위해 티켓이 폐기되어야 한다") {
+                    it("티켓을 삭제하지 않아 정상 사용자의 로그인이 무효화되지 않아야 한다") {
                         shouldThrow<OAuthException.InvalidRequest> {
-                            completeIdpSessionHandoffService.execute(testTicket, "wrong-verifier")
+                            completeIdpSessionHandoffService.execute(testTicket, "wrong-verifier", "same-site", "navigate")
                         }
 
-                        verify(exactly = 1) { mockIdpSessionHandoffRedisRepository.deleteById(testTicket) }
+                        // ticket만 아는 공격자가 요청 한 번으로 피해자 로그인을 깨뜨리는 것을 막는다.
+                        verify(exactly = 0) { mockIdpSessionHandoffRedisRepository.deleteById(any()) }
+                    }
+                }
+
+                context("최상위 내비게이션이 아닌 요청일 때") {
+                    beforeEach {
+                        every { mockIdpSessionHandoffRedisRepository.findById(testTicket) } returns Optional.of(handoff)
+                    }
+
+                    it("cross-site 요청은 거부되어야 한다") {
+                        shouldThrow<OAuthException.InvalidRequest> {
+                            completeIdpSessionHandoffService.execute(testTicket, testVerifier, "cross-site", "navigate")
+                        }
+
+                        verify(exactly = 0) { mockIdpSessionHandoffRedisRepository.deleteById(any()) }
+                    }
+
+                    it("navigate가 아닌 mode는 거부되어야 한다") {
+                        shouldThrow<OAuthException.InvalidRequest> {
+                            completeIdpSessionHandoffService.execute(testTicket, testVerifier, "same-site", "no-cors")
+                        }
+                    }
+
+                    it("URL을 나중에 입수해 이미지로 불러오는 시도는 거부되어야 한다") {
+                        shouldThrow<OAuthException.InvalidRequest> {
+                            completeIdpSessionHandoffService.execute(testTicket, testVerifier, "cross-site", "no-cors")
+                        }
+                    }
+
+                    it("주소창 직접 입력(none)은 정상 흐름이므로 허용되어야 한다") {
+                        val response = completeIdpSessionHandoffService.execute(testTicket, testVerifier, "none", "navigate")
+
+                        response.statusCode shouldBe HttpStatus.FOUND
+                    }
+                }
+
+                context("Sec-Fetch 헤더를 보내지 않는 브라우저일 때") {
+                    beforeEach {
+                        every { mockIdpSessionHandoffRedisRepository.findById(testTicket) } returns Optional.of(handoff)
+                    }
+
+                    it("기본 설정에서는 정상 로그인을 막지 않아야 한다") {
+                        val response = completeIdpSessionHandoffService.execute(testTicket, testVerifier, null, null)
+
+                        response.statusCode shouldBe HttpStatus.FOUND
+                    }
+
+                    it("엄격 모드에서는 거부되어야 한다") {
+                        every { mockOauthEnvironment.idpSessionHandoffRequireFetchMetadata } returns true
+
+                        shouldThrow<OAuthException.InvalidRequest> {
+                            completeIdpSessionHandoffService.execute(testTicket, testVerifier, null, null)
+                        }
                     }
                 }
 
@@ -138,7 +192,7 @@ class CompleteIdpSessionHandoffServiceTest :
 
                     it("오픈 리다이렉트를 막기 위해 예외가 발생해야 한다") {
                         shouldThrow<OAuthException.InvalidRequest> {
-                            completeIdpSessionHandoffService.execute(testTicket, testVerifier)
+                            completeIdpSessionHandoffService.execute(testTicket, testVerifier, "same-site", "navigate")
                         }
                     }
                 }
@@ -169,7 +223,7 @@ class CompleteIdpSessionHandoffServiceTest :
 
                     it("접두사 일치만으로는 통과시키지 않아야 한다") {
                         shouldThrow<OAuthException.InvalidRequest> {
-                            completeIdpSessionHandoffService.execute(testTicket, testVerifier)
+                            completeIdpSessionHandoffService.execute(testTicket, testVerifier, "same-site", "navigate")
                         }
                     }
                 }
@@ -181,7 +235,7 @@ class CompleteIdpSessionHandoffServiceTest :
                     }
 
                     it("Domain 속성 없이 호스트 전용 쿠키가 설정되어야 한다") {
-                        val response = completeIdpSessionHandoffService.execute(testTicket, testVerifier)
+                        val response = completeIdpSessionHandoffService.execute(testTicket, testVerifier, "same-site", "navigate")
 
                         val setCookie = response.headers.getFirst(HttpHeaders.SET_COOKIE) ?: ""
                         setCookie shouldContain "$cookieName=$testSessionId"
@@ -197,7 +251,7 @@ class CompleteIdpSessionHandoffServiceTest :
                     it("InvalidRequest 예외가 발생하고 티켓이 삭제되지 않아야 한다") {
                         val exception =
                             shouldThrow<OAuthException.InvalidRequest> {
-                                completeIdpSessionHandoffService.execute("expired-ticket", testVerifier)
+                                completeIdpSessionHandoffService.execute("expired-ticket", testVerifier, "same-site", "navigate")
                             }
 
                         exception.error shouldBe "invalid_request"

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
@@ -40,6 +40,7 @@ import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuth
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.CompleteOauthAuthorizeFlowServiceImpl
 import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
 import team.themoment.sdk.exception.ExpectedException
+import java.security.MessageDigest
 import java.util.Optional
 
 class CompleteOauthAuthorizeFlowServiceTest :
@@ -154,6 +155,31 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         val redirectUrl = response.headers.location?.toString() ?: ""
                         redirectUrl shouldStartWith "$testIssuerUrl/v1/oauth/authorize/session"
                         redirectUrl shouldContain "ticket="
+                        redirectUrl shouldContain "verifier="
+                    }
+
+                    it("verifier는 평문이 아닌 해시로만 저장되어야 한다") {
+                        val response = completeOauthAuthorizeFlowService.execute(reqDto)
+
+                        val redirectUrl = response.headers.location?.toString() ?: ""
+                        val verifier =
+                            redirectUrl
+                                .substringAfter("verifier=")
+                                .substringBefore("&")
+
+                        verifier.isNotBlank() shouldBe true
+                        handoffSlot.captured.verifierHash shouldNotBe verifier
+                        handoffSlot.captured.verifierHash shouldBe sha256Hex(verifier)
+                    }
+
+                    it("티켓과 verifier는 서로 다른 값이어야 한다") {
+                        val response = completeOauthAuthorizeFlowService.execute(reqDto)
+
+                        val redirectUrl = response.headers.location?.toString() ?: ""
+                        val ticket = redirectUrl.substringAfter("ticket=").substringBefore("&")
+                        val verifier = redirectUrl.substringAfter("verifier=").substringBefore("&")
+
+                        ticket shouldNotBe verifier
                     }
 
                     it("Authorization Code 발급이 위임되어야 한다") {
@@ -180,6 +206,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
 
                         handoffSlot.captured.sessionId shouldBe sessionSlot.captured.sessionId
                         handoffSlot.captured.redirectUrl shouldBe issuedRedirectUrl
+                        handoffSlot.captured.clientId shouldBe testClientId
                         handoffSlot.captured.ttl shouldBe idpSessionHandoffExpirationSeconds
                     }
 
@@ -520,3 +547,9 @@ class CompleteOauthAuthorizeFlowServiceTest :
             }
         }
     })
+
+private fun sha256Hex(value: String): String =
+    MessageDigest
+        .getInstance("SHA-256")
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.security.crypto.password.PasswordEncoder
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
@@ -143,7 +144,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         every { mockIdpSessionRedisRepository.save(capture(sessionSlot)) } answers { firstArg() }
                         every { mockIdpSessionHandoffRedisRepository.save(capture(handoffSlot)) } answers { firstArg() }
                         every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(any(), any()) } returns Optional.empty()
-                        every { mockOauthConsentJpaRepository.save(any<OauthConsentJpaEntity>()) } answers { firstArg() }
+                        every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } answers { firstArg() }
                     }
 
                     it("세션 핸드오프 URL로 302 리다이렉트되어야 한다") {
@@ -210,9 +211,23 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         handoffSlot.captured.ttl shouldBe idpSessionHandoffExpirationSeconds
                     }
 
+                    it("동의 기록이 유니크 제약에 걸려도 재조회로 복구되어야 한다") {
+                        val existing = OauthConsentJpaEntity.create(1L, testClientId, setOf("other:scope"))
+                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(any(), any()) } returnsMany
+                            listOf(Optional.empty(), Optional.of(existing))
+                        every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } throws
+                            DataIntegrityViolationException("duplicate") andThen existing
+
+                        val response = completeOauthAuthorizeFlowService.execute(reqDto)
+
+                        // 동시 로그인으로 제약 위반이 나도 사용자에게 500이 나가지 않아야 한다.
+                        response.statusCode shouldBe HttpStatus.FOUND
+                        existing.grantedScopes shouldBe mutableSetOf("other:scope", "self:read")
+                    }
+
                     it("요청한 scope가 동의 기록으로 저장되어야 한다") {
                         val consentSlot = slot<OauthConsentJpaEntity>()
-                        every { mockOauthConsentJpaRepository.save(capture(consentSlot)) } answers { firstArg() }
+                        every { mockOauthConsentJpaRepository.saveAndFlush(capture(consentSlot)) } answers { firstArg() }
 
                         completeOauthAuthorizeFlowService.execute(reqDto)
 
@@ -526,7 +541,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                             mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
                         } returns "$testRedirectUri?code=test-code&state=random-state"
                         every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(any(), any()) } returns Optional.empty()
-                        every { mockOauthConsentJpaRepository.save(any<OauthConsentJpaEntity>()) } answers { firstArg() }
+                        every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } answers { firstArg() }
                         every { mockIdpSessionRedisRepository.save(any<IdpSessionRedisEntity>()) } answers { firstArg() }
                         every {
                             mockIdpSessionHandoffRedisRepository.save(any<IdpSessionHandoffRedisEntity>())

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
@@ -20,11 +20,15 @@ import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatu
 import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
 import team.themoment.datagsm.common.domain.club.repository.ClubJpaRepository
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeSubmitReqDto
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
 import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
-import team.themoment.datagsm.common.domain.oauth.entity.OauthCodeRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
-import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepository
 import team.themoment.datagsm.common.domain.student.entity.StudentDataEditRequestJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.StudentJpaEntity
 import team.themoment.datagsm.common.domain.student.entity.constant.Sex
@@ -32,6 +36,7 @@ import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRe
 import team.themoment.datagsm.common.domain.student.repository.StudentJpaRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.common.global.dto.internal.RateLimitConsumeResult
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.CompleteOauthAuthorizeFlowServiceImpl
 import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
 import team.themoment.sdk.exception.ExpectedException
@@ -44,8 +49,11 @@ class CompleteOauthAuthorizeFlowServiceTest :
         val mockStudentJpaRepository = mockk<StudentJpaRepository>()
         val mockClubJpaRepository = mockk<ClubJpaRepository>()
         val mockStudentDataEditRequestJpaRepository = mockk<StudentDataEditRequestJpaRepository>(relaxed = true)
-        val mockOauthCodeRedisRepository = mockk<OauthCodeRedisRepository>(relaxed = true)
         val mockOauthAuthorizeStateRedisRepository = mockk<OauthAuthorizeStateRedisRepository>(relaxed = true)
+        val mockIdpSessionRedisRepository = mockk<IdpSessionRedisRepository>(relaxed = true)
+        val mockIdpSessionHandoffRedisRepository = mockk<IdpSessionHandoffRedisRepository>(relaxed = true)
+        val mockOauthConsentJpaRepository = mockk<OauthConsentJpaRepository>(relaxed = true)
+        val mockIssueAuthorizationCodeService = mockk<IssueAuthorizationCodeService>()
         val mockPasswordEncoder = mockk<PasswordEncoder>()
         val mockOauthEnvironment = mockk<OauthEnvironment>()
         val mockOauthClientRateLimitService = mockk<OAuthClientRateLimitService>()
@@ -57,8 +65,11 @@ class CompleteOauthAuthorizeFlowServiceTest :
                 mockStudentJpaRepository,
                 mockClubJpaRepository,
                 mockStudentDataEditRequestJpaRepository,
-                mockOauthCodeRedisRepository,
                 mockOauthAuthorizeStateRedisRepository,
+                mockIdpSessionRedisRepository,
+                mockIdpSessionHandoffRedisRepository,
+                mockOauthConsentJpaRepository,
+                mockIssueAuthorizationCodeService,
                 mockPasswordEncoder,
                 mockOauthEnvironment,
                 mockOauthClientRateLimitService,
@@ -76,7 +87,10 @@ class CompleteOauthAuthorizeFlowServiceTest :
                 val testToken = "test-token-123"
                 val testClientId = "client-123"
                 val testRedirectUri = "https://example.com/callback"
+                val testIssuerUrl = "https://oauth.example.com"
                 val codeExpirationSeconds = 300L
+                val idpSessionExpirationSeconds = 28800L
+                val idpSessionHandoffExpirationSeconds = 60L
 
                 val mockAccount =
                     AccountJpaEntity().apply {
@@ -87,6 +101,9 @@ class CompleteOauthAuthorizeFlowServiceTest :
 
                 beforeEach {
                     every { mockOauthEnvironment.codeExpirationSeconds } returns codeExpirationSeconds
+                    every { mockOauthEnvironment.issuerUrl } returns testIssuerUrl
+                    every { mockOauthEnvironment.idpSessionExpirationSeconds } returns idpSessionExpirationSeconds
+                    every { mockOauthEnvironment.idpSessionHandoffExpirationSeconds } returns idpSessionHandoffExpirationSeconds
                     every { mockOauthClientRateLimitService.tryConsumeAndReturnRemaining(any()) } returns
                         RateLimitConsumeResult(consumed = true, remainingTokens = 299, secondsToWaitForRefill = 0)
                 }
@@ -111,39 +128,69 @@ class CompleteOauthAuthorizeFlowServiceTest :
                             ttl = 600,
                         )
 
-                    val savedEntitySlot = slot<OauthCodeRedisEntity>()
+                    val issuedRedirectUrl = "$testRedirectUri?code=test-code&state=random-state"
+                    val sessionSlot = slot<IdpSessionRedisEntity>()
+                    val handoffSlot = slot<IdpSessionHandoffRedisEntity>()
 
                     beforeEach {
                         every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns Optional.of(mockStateEntity)
                         every { mockAccountJpaRepository.findByEmail(testEmail) } returns Optional.of(mockAccount)
                         every { mockPasswordEncoder.matches("password123!", mockAccount.password) } returns true
-                        every { mockOauthCodeRedisRepository.save(capture(savedEntitySlot)) } answers { firstArg() }
+                        every {
+                            mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                        } returns issuedRedirectUrl
+                        every { mockIdpSessionRedisRepository.save(capture(sessionSlot)) } answers { firstArg() }
+                        every { mockIdpSessionHandoffRedisRepository.save(capture(handoffSlot)) } answers { firstArg() }
+                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(any(), any()) } returns Optional.empty()
+                        every { mockOauthConsentJpaRepository.save(any<OauthConsentJpaEntity>()) } answers { firstArg() }
                     }
 
-                    it("302 리다이렉트 ResponseEntity가 반환되어야 한다") {
+                    it("세션 핸드오프 URL로 302 리다이렉트되어야 한다") {
                         val response = completeOauthAuthorizeFlowService.execute(reqDto)
 
                         response.statusCode shouldBe HttpStatus.FOUND
                         response.headers.location shouldNotBe null
 
                         val redirectUrl = response.headers.location?.toString() ?: ""
-                        redirectUrl shouldStartWith testRedirectUri
-                        redirectUrl shouldContain "code="
-                        redirectUrl shouldContain "state=random-state"
+                        redirectUrl shouldStartWith "$testIssuerUrl/v1/oauth/authorize/session"
+                        redirectUrl shouldContain "ticket="
                     }
 
-                    it("Redis에 Authorization Code가 저장되어야 한다") {
+                    it("Authorization Code 발급이 위임되어야 한다") {
                         completeOauthAuthorizeFlowService.execute(reqDto)
 
-                        verify(exactly = 1) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 1) {
+                            mockIssueAuthorizationCodeService.execute(
+                                testEmail,
+                                testClientId,
+                                testRedirectUri,
+                                "random-state",
+                                "challenge",
+                                "S256",
+                                setOf("self:read"),
+                            )
+                        }
+                    }
 
-                        savedEntitySlot.captured.email shouldBe testEmail
-                        savedEntitySlot.captured.clientId shouldBe testClientId
-                        savedEntitySlot.captured.redirectUri shouldBe testRedirectUri
-                        savedEntitySlot.captured.codeChallenge shouldBe "challenge"
-                        savedEntitySlot.captured.codeChallengeMethod shouldBe "S256"
-                        savedEntitySlot.captured.scopes shouldBe setOf("self:read")
-                        savedEntitySlot.captured.ttl shouldBe codeExpirationSeconds
+                    it("IdP 세션이 생성되고 핸드오프 티켓에 연결되어야 한다") {
+                        completeOauthAuthorizeFlowService.execute(reqDto)
+
+                        sessionSlot.captured.email shouldBe testEmail
+                        sessionSlot.captured.ttl shouldBe idpSessionExpirationSeconds
+
+                        handoffSlot.captured.sessionId shouldBe sessionSlot.captured.sessionId
+                        handoffSlot.captured.redirectUrl shouldBe issuedRedirectUrl
+                        handoffSlot.captured.ttl shouldBe idpSessionHandoffExpirationSeconds
+                    }
+
+                    it("요청한 scope가 동의 기록으로 저장되어야 한다") {
+                        val consentSlot = slot<OauthConsentJpaEntity>()
+                        every { mockOauthConsentJpaRepository.save(capture(consentSlot)) } answers { firstArg() }
+
+                        completeOauthAuthorizeFlowService.execute(reqDto)
+
+                        consentSlot.captured.clientId shouldBe testClientId
+                        consentSlot.captured.grantedScopes shouldBe mutableSetOf("self:read")
                     }
 
                     it("Redis에서 인증 상태가 삭제되어야 한다") {
@@ -174,7 +221,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         exception.errorDescription shouldBe "인증 토큰이 유효하지 않거나 만료되었습니다. 다시 시도해주세요."
 
                         verify(exactly = 0) { mockAccountJpaRepository.findByEmail(any()) }
-                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 0) { mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any()) }
                     }
                 }
 
@@ -212,7 +259,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         exception.message shouldBe "이메일 또는 비밀번호가 일치하지 않습니다."
                         exception.statusCode shouldBe HttpStatus.UNAUTHORIZED
 
-                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 0) { mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any()) }
                     }
                 }
 
@@ -251,7 +298,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         exception.message shouldBe "이메일 또는 비밀번호가 일치하지 않습니다."
                         exception.statusCode shouldBe HttpStatus.UNAUTHORIZED
 
-                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 0) { mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any()) }
                     }
                 }
 
@@ -289,7 +336,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         exception.statusCode shouldBe HttpStatus.UNAUTHORIZED
 
                         verify(exactly = 0) { mockAccountJpaRepository.findByEmail(any()) }
-                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 0) { mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any()) }
                     }
                 }
 
@@ -336,7 +383,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         exception.message shouldBe "아직 승인되지 않은 계정입니다."
                         exception.statusCode shouldBe HttpStatus.FORBIDDEN
 
-                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 0) { mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any()) }
                     }
                 }
 
@@ -391,7 +438,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         exception.message shouldBe "정보 수정이 필요합니다. 정보를 수정한 후 다시 로그인해주세요."
                         exception.statusCode shouldBe HttpStatus.UNPROCESSABLE_ENTITY
 
-                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any()) }
+                        verify(exactly = 0) { mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any()) }
                     }
                 }
 
@@ -448,7 +495,15 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         every { mockStudentDataEditRequestJpaRepository.findByStudentId(10L) } returns Optional.of(editRequest)
                         every { mockStudentJpaRepository.findById(10L) } returns Optional.of(mockStudent)
                         every { mockStudentJpaRepository.existsByStudentNumberAndNotId(2, 1, 5, 10L) } returns false
-                        every { mockOauthCodeRedisRepository.save(any()) } answers { firstArg() }
+                        every {
+                            mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                        } returns "$testRedirectUri?code=test-code&state=random-state"
+                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(any(), any()) } returns Optional.empty()
+                        every { mockOauthConsentJpaRepository.save(any<OauthConsentJpaEntity>()) } answers { firstArg() }
+                        every { mockIdpSessionRedisRepository.save(any<IdpSessionRedisEntity>()) } answers { firstArg() }
+                        every {
+                            mockIdpSessionHandoffRedisRepository.save(any<IdpSessionHandoffRedisEntity>())
+                        } answers { firstArg() }
                     }
 
                     it("정보가 수정되고 302 리다이렉트 ResponseEntity가 반환되어야 한다") {

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/IssueAuthorizationCodeServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/IssueAuthorizationCodeServiceTest.kt
@@ -1,5 +1,6 @@
 package team.themoment.datagsm.oauth.authorization.domain.oauth.service
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -8,21 +9,28 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
+import org.springframework.http.HttpStatus
 import team.themoment.datagsm.common.domain.oauth.entity.OauthCodeRedisEntity
 import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.common.global.dto.internal.RateLimitConsumeResult
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.IssueAuthorizationCodeServiceImpl
+import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
+import team.themoment.sdk.exception.ExpectedException
 import java.net.URI
 
 class IssueAuthorizationCodeServiceTest :
     DescribeSpec({
 
         val mockOauthCodeRedisRepository = mockk<OauthCodeRedisRepository>(relaxed = true)
+        val mockOauthClientRateLimitService = mockk<OAuthClientRateLimitService>()
         val mockOauthEnvironment = mockk<OauthEnvironment>()
 
         val issueAuthorizationCodeService =
             IssueAuthorizationCodeServiceImpl(
                 mockOauthCodeRedisRepository,
+                mockOauthClientRateLimitService,
                 mockOauthEnvironment,
             )
 
@@ -39,6 +47,8 @@ class IssueAuthorizationCodeServiceTest :
                 val testScopes = setOf("datagsm:account_read")
 
                 beforeEach {
+                    every { mockOauthClientRateLimitService.tryConsumeAndReturnRemaining(any()) } returns
+                        RateLimitConsumeResult(consumed = true, remainingTokens = 299, secondsToWaitForRefill = 0)
                     every { mockOauthEnvironment.codeExpirationSeconds } returns 300L
                     every { mockOauthCodeRedisRepository.save(any<OauthCodeRedisEntity>()) } answers { firstArg() }
                 }
@@ -111,6 +121,23 @@ class IssueAuthorizationCodeServiceTest :
                             )
 
                         redirectUrl shouldStartWith "https://example.com/callback?tenant=gsm&code="
+                    }
+                }
+
+                context("클라이언트가 요청 한도를 초과했을 때") {
+                    beforeEach {
+                        every { mockOauthClientRateLimitService.tryConsumeAndReturnRemaining(any()) } returns
+                            RateLimitConsumeResult(consumed = false, remainingTokens = 0, secondsToWaitForRefill = 30)
+                    }
+
+                    it("코드를 발급하지 않고 429가 반환되어야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                issue("random-state")
+                            }
+
+                        exception.statusCode shouldBe HttpStatus.TOO_MANY_REQUESTS
+                        verify(exactly = 0) { mockOauthCodeRedisRepository.save(any<OauthCodeRedisEntity>()) }
                     }
                 }
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/IssueAuthorizationCodeServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/IssueAuthorizationCodeServiceTest.kt
@@ -1,0 +1,139 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import team.themoment.datagsm.common.domain.oauth.entity.OauthCodeRedisEntity
+import team.themoment.datagsm.common.domain.oauth.repository.OauthCodeRedisRepository
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.IssueAuthorizationCodeServiceImpl
+import java.net.URI
+
+class IssueAuthorizationCodeServiceTest :
+    DescribeSpec({
+
+        val mockOauthCodeRedisRepository = mockk<OauthCodeRedisRepository>(relaxed = true)
+        val mockOauthEnvironment = mockk<OauthEnvironment>()
+
+        val issueAuthorizationCodeService =
+            IssueAuthorizationCodeServiceImpl(
+                mockOauthCodeRedisRepository,
+                mockOauthEnvironment,
+            )
+
+        afterEach {
+            clearAllMocks()
+        }
+
+        describe("IssueAuthorizationCodeService 클래스의") {
+            describe("execute 메서드는") {
+
+                val testEmail = "user@gsm.hs.kr"
+                val testClientId = "client-123"
+                val testRedirectUri = "https://example.com/callback"
+                val testScopes = setOf("datagsm:account_read")
+
+                beforeEach {
+                    every { mockOauthEnvironment.codeExpirationSeconds } returns 300L
+                    every { mockOauthCodeRedisRepository.save(any<OauthCodeRedisEntity>()) } answers { firstArg() }
+                }
+
+                fun issue(state: String?): String =
+                    issueAuthorizationCodeService.execute(
+                        email = testEmail,
+                        clientId = testClientId,
+                        redirectUri = testRedirectUri,
+                        state = state,
+                        codeChallenge = null,
+                        codeChallengeMethod = null,
+                        scopes = testScopes,
+                    )
+
+                context("state가 주어졌을 때") {
+                    it("code와 state를 담은 리다이렉트 URL을 반환해야 한다") {
+                        val redirectUrl = issue("random-state")
+
+                        redirectUrl shouldStartWith "$testRedirectUri?code="
+                        redirectUrl shouldContain "&state=random-state"
+                    }
+                }
+
+                context("state에 URL 예약 문자가 포함됐을 때") {
+                    it("파라미터가 주입되지 않도록 인코딩되어야 한다") {
+                        val redirectUrl = issue("a&injected=evil")
+
+                        redirectUrl shouldContain "state=a%26injected%3Devil"
+
+                        // 인코딩되지 않으면 injected가 별도 쿼리 파라미터로 분리된다.
+                        // rawQuery는 디코딩하지 않으므로 실제 전송되는 형태를 그대로 검증할 수 있다.
+                        val parsedKeys =
+                            URI
+                                .create(redirectUrl)
+                                .rawQuery
+                                .split("&")
+                                .map { it.substringBefore("=") }
+                        parsedKeys.contains("injected") shouldBe false
+                        parsedKeys shouldBe listOf("code", "state")
+                    }
+
+                    it("공백이 포함돼도 URL이 깨지지 않아야 한다") {
+                        val redirectUrl = issue("with space")
+
+                        redirectUrl shouldContain "state=with+space"
+                    }
+                }
+
+                context("state가 없을 때") {
+                    it("state 파라미터를 붙이지 않아야 한다") {
+                        val redirectUrl = issue(null)
+
+                        redirectUrl shouldStartWith "$testRedirectUri?code="
+                        redirectUrl.contains("state=") shouldBe false
+                    }
+                }
+
+                context("redirect_uri에 이미 쿼리가 있을 때") {
+                    it("'&'로 이어 붙여야 한다") {
+                        val redirectUrl =
+                            issueAuthorizationCodeService.execute(
+                                email = testEmail,
+                                clientId = testClientId,
+                                redirectUri = "https://example.com/callback?tenant=gsm",
+                                state = null,
+                                codeChallenge = null,
+                                codeChallengeMethod = null,
+                                scopes = testScopes,
+                            )
+
+                        redirectUrl shouldStartWith "https://example.com/callback?tenant=gsm&code="
+                    }
+                }
+
+                context("코드를 발급할 때") {
+                    it("Redis에 이메일과 scope가 저장되어야 한다") {
+                        val codeSlot = slot<OauthCodeRedisEntity>()
+                        every { mockOauthCodeRedisRepository.save(capture(codeSlot)) } answers { firstArg() }
+
+                        val redirectUrl = issue("random-state")
+                        val issuedCode =
+                            URI
+                                .create(redirectUrl)
+                                .rawQuery
+                                .substringAfter("code=")
+                                .substringBefore("&")
+
+                        codeSlot.captured.email shouldBe testEmail
+                        codeSlot.captured.clientId shouldBe testClientId
+                        codeSlot.captured.scopes shouldBe testScopes
+                        codeSlot.captured.code shouldBe issuedCode
+                        codeSlot.captured.ttl shouldBe 300L
+                    }
+                }
+            }
+        }
+    })

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -11,13 +11,24 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.springframework.http.HttpStatus
+import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatus
+import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
 import team.themoment.datagsm.common.domain.client.entity.ClientJpaEntity
 import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeReqDto
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
 import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepository
+import team.themoment.datagsm.common.domain.student.entity.StudentDataEditRequestJpaEntity
+import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRequestJpaRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.StartOauthAuthorizeFlowServiceImpl
 import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
 import java.util.Optional
@@ -37,12 +48,23 @@ class StartOauthAuthorizeFlowServiceTest :
                 every { datagsmApplicationId } returns "datagsm"
             }
 
+        val mockIdpSessionRedisRepository = mockk<IdpSessionRedisRepository>(relaxed = true)
+        val mockAccountJpaRepository = mockk<AccountJpaRepository>(relaxed = true)
+        val mockStudentDataEditRequestJpaRepository = mockk<StudentDataEditRequestJpaRepository>(relaxed = true)
+        val mockOauthConsentJpaRepository = mockk<OauthConsentJpaRepository>(relaxed = true)
+        val mockIssueAuthorizationCodeService = mockk<IssueAuthorizationCodeService>(relaxed = true)
+
         val startOauthAuthorizeFlowService =
             StartOauthAuthorizeFlowServiceImpl(
                 mockClientJpaRepository,
                 mockOauthEnvironment,
                 mockOauthAuthorizeStateRedisRepository,
                 mockJwtEnvironment,
+                mockIdpSessionRedisRepository,
+                mockAccountJpaRepository,
+                mockStudentDataEditRequestJpaRepository,
+                mockOauthConsentJpaRepository,
+                mockIssueAuthorizationCodeService,
             )
 
         afterEach {
@@ -87,7 +109,7 @@ class StartOauthAuthorizeFlowServiceTest :
                                 code_challenge = "challenge",
                                 code_challenge_method = "S256",
                             )
-                        val response = startOauthAuthorizeFlowService.execute(reqDto)
+                        val response = startOauthAuthorizeFlowService.execute(reqDto, null)
 
                         response.statusCode shouldBe HttpStatus.FOUND
                         response.headers.location shouldNotBe null
@@ -125,7 +147,7 @@ class StartOauthAuthorizeFlowServiceTest :
                                 redirect_uri = testRedirectUri,
                                 response_type = "code",
                             )
-                        startOauthAuthorizeFlowService.execute(reqDto)
+                        startOauthAuthorizeFlowService.execute(reqDto, null)
 
                         savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read", "datagsm:student_read")
                     }
@@ -157,7 +179,7 @@ class StartOauthAuthorizeFlowServiceTest :
                                 redirect_uri = testRedirectUri,
                                 response_type = "code",
                             )
-                        startOauthAuthorizeFlowService.execute(reqDto)
+                        startOauthAuthorizeFlowService.execute(reqDto, null)
 
                         savedEntitySlot.captured.scopes shouldBe setOf("datagsm:self_read")
                     }
@@ -189,7 +211,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
 
                         shouldThrow<OAuthException.InvalidScope> {
-                            startOauthAuthorizeFlowService.execute(reqDto)
+                            startOauthAuthorizeFlowService.execute(reqDto, null)
                         }
                     }
                 }
@@ -212,7 +234,7 @@ class StartOauthAuthorizeFlowServiceTest :
                                 response_type = "code",
                                 scope = "datagsm:account_read",
                             )
-                        startOauthAuthorizeFlowService.execute(reqDto)
+                        startOauthAuthorizeFlowService.execute(reqDto, null)
 
                         savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read")
                     }
@@ -247,7 +269,7 @@ class StartOauthAuthorizeFlowServiceTest :
                                 response_type = "code",
                                 scope = "datagsm:account_read datagsm:club_read",
                             )
-                        startOauthAuthorizeFlowService.execute(reqDto)
+                        startOauthAuthorizeFlowService.execute(reqDto, null)
 
                         savedEntitySlot.captured.scopes shouldBe setOf("datagsm:account_read", "datagsm:club_read")
                     }
@@ -268,7 +290,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         val exception =
                             shouldThrow<OAuthException.InvalidScope> {
-                                startOauthAuthorizeFlowService.execute(reqDto)
+                                startOauthAuthorizeFlowService.execute(reqDto, null)
                             }
 
                         exception.error shouldBe "invalid_scope"
@@ -290,7 +312,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         val exception =
                             shouldThrow<OAuthException.InvalidRequest> {
-                                startOauthAuthorizeFlowService.execute(reqDto)
+                                startOauthAuthorizeFlowService.execute(reqDto, null)
                             }
 
                         exception.error shouldBe "invalid_request"
@@ -315,7 +337,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         val exception =
                             shouldThrow<OAuthException.InvalidClient> {
-                                startOauthAuthorizeFlowService.execute(reqDto)
+                                startOauthAuthorizeFlowService.execute(reqDto, null)
                             }
 
                         exception.error shouldBe "invalid_client"
@@ -342,7 +364,7 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         val exception =
                             shouldThrow<OAuthException.InvalidRequest> {
-                                startOauthAuthorizeFlowService.execute(reqDto)
+                                startOauthAuthorizeFlowService.execute(reqDto, null)
                             }
 
                         exception.errorDescription shouldBe "등록되지 않은 redirect_uri입니다."
@@ -368,12 +390,156 @@ class StartOauthAuthorizeFlowServiceTest :
                             )
                         val exception =
                             shouldThrow<OAuthException.InvalidRequest> {
-                                startOauthAuthorizeFlowService.execute(reqDto)
+                                startOauthAuthorizeFlowService.execute(reqDto, null)
                             }
 
                         exception.errorDescription shouldBe "지원하지 않는 code_challenge_method입니다."
 
                         verify(exactly = 0) { mockOauthAuthorizeStateRedisRepository.save(any()) }
+                    }
+                }
+
+                describe("SSO 세션이 주어졌을 때") {
+                    val testSessionId = "session-abc"
+                    val testEmail = "user@gsm.hs.kr"
+                    val issuedRedirectUrl = "$testRedirectUri?code=test-code"
+                    val loginPageUrl = "http://localhost:3000/oauth/authorize"
+
+                    val ssoReqDto =
+                        OauthAuthorizeReqDto(
+                            client_id = testClientId,
+                            redirect_uri = testRedirectUri,
+                            response_type = "code",
+                            scope = "datagsm:account_read",
+                        )
+
+                    fun activeAccount() =
+                        AccountJpaEntity().apply {
+                            id = 1L
+                            email = testEmail
+                            password = "hashedPassword"
+                            status = AccountStatus.ACTIVE
+                        }
+
+                    beforeEach {
+                        every { mockOauthEnvironment.frontendUrl } returns "http://localhost:3000"
+                        every { mockOauthEnvironment.authorizeStateExpirationMs } returns 600000L
+                        every {
+                            mockOauthAuthorizeStateRedisRepository.save(any<OauthAuthorizeStateRedisEntity>())
+                        } answers { firstArg() }
+                        every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(mockClient)
+                        every { mockIdpSessionRedisRepository.findById(testSessionId) } returns
+                            Optional.of(IdpSessionRedisEntity(testSessionId, testEmail, 28800))
+                        every { mockAccountJpaRepository.findByEmail(testEmail) } returns Optional.of(activeAccount())
+                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returns
+                            Optional.of(OauthConsentJpaEntity.create(1L, testClientId, setOf("datagsm:account_read")))
+                        every {
+                            mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                        } returns issuedRedirectUrl
+                    }
+
+                    context("모든 검증 항목을 충족할 때") {
+                        it("로그인 페이지를 거치지 않고 클라이언트로 바로 리다이렉트되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
+
+                            response.statusCode shouldBe HttpStatus.FOUND
+                            response.headers.location?.toString() shouldBe issuedRedirectUrl
+
+                            verify(exactly = 0) { mockOauthAuthorizeStateRedisRepository.save(any()) }
+                        }
+                    }
+
+                    context("세션 쿠키가 없을 때") {
+                        it("기존 로그인 플로우로 폴백되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, null)
+
+                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            verify(exactly = 1) { mockOauthAuthorizeStateRedisRepository.save(any()) }
+                        }
+                    }
+
+                    context("세션이 만료되었을 때") {
+                        beforeEach {
+                            every { mockIdpSessionRedisRepository.findById(testSessionId) } returns Optional.empty()
+                        }
+
+                        it("기존 로그인 플로우로 폴백되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
+
+                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            verify(exactly = 1) { mockOauthAuthorizeStateRedisRepository.save(any()) }
+                        }
+                    }
+
+                    context("계정이 ACTIVE 상태가 아닐 때") {
+                        beforeEach {
+                            every { mockAccountJpaRepository.findByEmail(testEmail) } returns
+                                Optional.of(activeAccount().apply { status = AccountStatus.PENDING })
+                        }
+
+                        it("기존 로그인 플로우로 폴백되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
+
+                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            verify(exactly = 0) {
+                                mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                            }
+                        }
+                    }
+
+                    context("해소되지 않은 학생 정보 수정 요청이 있을 때") {
+                        beforeEach {
+                            every { mockAccountJpaRepository.findByEmail(testEmail) } returns
+                                Optional.of(
+                                    activeAccount().apply {
+                                        objectType = AccountObjectType.STUDENT
+                                        objectId = 10L
+                                    },
+                                )
+                            every { mockStudentDataEditRequestJpaRepository.findByStudentId(10L) } returns
+                                Optional.of(StudentDataEditRequestJpaEntity())
+                        }
+
+                        it("정보 수정 강제가 우회되지 않도록 로그인 플로우로 폴백되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
+
+                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            verify(exactly = 0) {
+                                mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                            }
+                        }
+                    }
+
+                    context("해당 클라이언트에 대한 동의 기록이 없을 때") {
+                        beforeEach {
+                            every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returns
+                                Optional.empty()
+                        }
+
+                        it("기존 로그인 플로우로 폴백되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
+
+                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            verify(exactly = 0) {
+                                mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                            }
+                        }
+                    }
+
+                    context("동의 기록이 요청한 scope를 모두 포함하지 않을 때") {
+                        beforeEach {
+                            every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returns
+                                Optional.of(OauthConsentJpaEntity.create(1L, testClientId, setOf("datagsm:student_read")))
+                        }
+
+                        it("기존 로그인 플로우로 폴백되어야 한다") {
+                            val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
+
+                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            verify(exactly = 0) {
+                                mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 개요

OAuth 로그인 상태를 IdP(datagsm-server)에 보관해, 여러 클라이언트를 오갈 때 재로그인 없이 인증이 이어지도록 합니다.

기존에는 로그인 성공 결과가 어디에도 남지 않아(요청 1건에 대한 code 발급 후 종료) 다른 클라이언트로 이동하면 항상 다시 로그인해야 했습니다. 이 PR은 "로그인 성공"과 "code 발급"을 분리해 SSO를 가능하게 합니다.

## 변경 흐름

```
GET /v1/oauth/authorize  (브라우저 최상위 이동 → 쿠키 자동 실림)
  ├─ 세션 유효 ∧ 계정 ACTIVE ∧ 미해소 정보수정요청 없음 ∧ 요청 scope가 동의 기록에 포함
  │    → 로그인 생략하고 code 발급 → 클라이언트로 302
  └─ 하나라도 미충족 → 기존 로그인 페이지로 302 (폴백)

POST /v1/oauth/authorize  (BFF 서버-투-서버)
  → 자격증명 검증 → 동의 기록 → 세션 생성 → 핸드오프 URL로 302

GET /v1/oauth/authorize/session?ticket=  (신규, 브라우저 최상위 이동)
  → 티켓 검증 후 즉시 삭제(일회용) → Set-Cookie → 클라이언트로 302
```

### 핸드오프 단계가 필요한 이유

`POST /v1/oauth/authorize`는 프론트 BFF가 서버-투-서버 fetch로 호출하므로, 이 응답에 `Set-Cookie`를 실어도 브라우저가 아닌 Next.js 서버가 받게 됩니다. 따라서 브라우저가 최상위 내비게이션으로 백엔드를 한 번 경유하도록 일회용 티켓을 두고, 그 지점에서 세션 쿠키를 심습니다.

## 보안 고려

- **정보 수정 강제가 SSO로 우회되지 않습니다.** 세션이 있어도 미해소 `StudentDataEditRequest`가 있으면 code를 발급하지 않고 로그인 페이지로 폴백합니다.
- 세션 쿠키는 `HttpOnly` / `Secure` / `SameSite=Lax` / `Max-Age` 적용.
- 핸드오프 티켓은 일회용이며 사용 즉시 삭제됩니다(기본 TTL 60초).
- 클라이언트별 scope 동의를 기록해, 동의하지 않은 scope는 세션이 있어도 자동 승인되지 않습니다.

## 주요 변경 파일

**신규**
- `IdpSessionRedisEntity` / `IdpSessionRedisRepository` — 로그인 세션 (기본 8시간)
- `IdpSessionHandoffRedisEntity` / `IdpSessionHandoffRedisRepository` — 일회용 핸드오프 티켓
- `OauthConsentJpaEntity` / `OauthConsentJpaRepository` — 클라이언트별 scope 동의 기록
- `IssueAuthorizationCodeService(+Impl)` — code 발급 로직을 GET/POST 양쪽에서 재사용하도록 추출
- `CompleteIdpSessionHandoffService(+Impl)` — 티켓 소비 및 쿠키 설정

**수정**
- `StartOauthAuthorizeFlowServiceImpl` — SSO 세션 분기 추가 (#431의 스코프 변경과 별개)
- `CompleteOauthAuthorizeFlowServiceImpl` — 세션·동의·핸드오프 생성, code 발급 위임
- `OauthController` — 쿠키 파라미터, 핸드오프 엔드포인트
- `OauthEnvironment` / `application.yml` — 세션·쿠키 설정 추가

## ⚠️ Breaking Change (프론트 수정 필요)

`POST /v1/oauth/authorize`의 응답 `Location`이 변경됩니다.

```
변경 전: https://client.example.com/callback?code=xxx&state=yyy
변경 후: https://oauth.authorization.datagsm.kr/v1/oauth/authorize/session?ticket=zzz
```

BFF가 이 Location을 **가공 없이 그대로 브라우저에 반환하면 정상 동작**합니다. 다만 다음에 해당하면 수정이 필요합니다.

- fetch에 `redirect: 'follow'`가 걸려 있으면 → **`redirect: 'manual'`로 변경 필수** (서버가 리다이렉트를 따라가면 쿠키가 브라우저에 심기지 않습니다)
- Location이 클라이언트 주소인지 검증하는 로직이 있으면 → 백엔드 도메인도 허용
- Location에서 `code`/`state`를 파싱해 쓰고 있으면 → 제거

프론트 수정은 이 PR 머지 전에 완료될 예정입니다.

## 배포 환경변수

```bash
OAUTH_ISSUER_URL=https://oauth.authorization.datagsm.kr
OAUTH_IDP_SESSION_COOKIE_DOMAIN=.datagsm.kr
```

`OAUTH_ISSUER_URL`이 잘못되면 핸드오프 리다이렉트가 깨집니다. 나머지(세션 8시간, 쿠키명, `Secure=true`)는 기본값으로 충분합니다.

## 테스트

- 전 모듈 643개 통과 (authorization 모듈 111개)
- 신규 11개: SSO 성공 경로 1, 폴백 6(세션 없음/만료/비ACTIVE/정보수정요청/동의없음/scope부족), 핸드오프 4

## 후속 작업 (별도 PR)

- 동의 화면 UI — 현재는 처음 쓰는 클라이언트에서 재로그인 후 자동 동의
- 로그아웃 및 전파 — 현재 로그아웃 기능 자체가 없어 세션 만료(8시간)에 의존
- 비밀번호 변경 시 기존 세션 무효화 — 현재 비밀번호를 바꿔도 세션이 유지됨
- `id_token` + `openid` scope, OIDC discovery 문서

---

## 코드리뷰 반영 (보안 수정)

셀프 코드리뷰에서 발견한 결함 3건을 이 PR 내에서 수정했습니다.

### 1. 핸드오프 URL 재사용으로 세션이 탈취되던 문제 (CRITICAL)

`ticket`은 URL 쿼리라 `Location` 헤더·Referer·BFF 로그·브라우저 히스토리에 남습니다. 그것만으로 세션 쿠키를 내주면, 티켓을 입수한 공격자가 만료 전에 먼저 열어 **피해자 계정의 SSO 세션을 획득**할 수 있었습니다.

처음에는 `verifier`를 추가 발급해 해시만 저장하는 방식으로 접근했으나, **교차 리뷰에서 이 방식이 목적을 달성하지 못한다는 점이 드러났습니다.** `ticket`과 `verifier`가 같은 URL 쿼리에 함께 실리므로, 위 채널들에서 둘은 **항상 같이** 노출됩니다. 비밀을 둘로 쪼갰지만 같은 봉투에 넣은 셈입니다.

BFF가 서버-투-서버라 POST 응답에 쿠키를 심을 수 없다는 제약 때문에, 리다이렉트 URL만으로는 채널 분리가 원리적으로 불가능합니다. 그래서 **요청의 형태**를 검증하는 방향으로 전환했습니다.

- `Sec-Fetch-Site` / `Sec-Fetch-Mode`로 **브라우저 최상위 내비게이션만** 허용
- 나중에 URL을 입수해 `fetch`·`<img>`로 재사용하는 시도가 차단됨
- 헤더 미전송 클라이언트는 기본 통과(로그인 차단 방지), 엄격 모드는 `OAUTH_IDP_SESSION_HANDOFF_REQUIRE_FETCH_METADATA=true`
- `verifier` 대조는 부분 유출 대비 보조 방어로 유지 (`MessageDigest.isEqual`)

> ⚠️ **프론트 주의**: 핸드오프 URL을 서버에서 `fetch`로 열면 400이 납니다. 반드시 브라우저가 직접 이동해야 합니다.

### 2. 오픈 리다이렉트 (HIGH)

저장된 `redirectUrl`을 검증 없이 `Location`에 넣고 있었습니다. 화이트리스트 검증이 **저장 이전 단계에만** 있어 방어가 한 겹뿐이었습니다.

- 소비 시점에 `client.redirectUrls`로 재검증
- 접두사 비교는 `https://example.com.attacker.io` 같은 도메인 위조를 허용하므로, 이어지는 문자가 `?`/`&` 구분자인지까지 확인

### 3. `state` URL 인코딩 누락 (HIGH)

`state`는 클라이언트가 임의 값을 넣는 CSRF 방어 값이라, 인코딩 없이 붙이면 `&` 삽입으로 파라미터를 조작할 수 있었습니다.

- `code`/`state` 모두 `URLEncoder`로 인코딩

### 테스트

`IssueAuthorizationCodeServiceTest`를 신설하고(6개), 핸드오프 테스트에 verifier 불일치·오픈 리다이렉트·접두사 위조·Sec-Fetch 차단 케이스를 추가했습니다. 모듈 전체 **129개 테스트 통과**.

두 방어(Sec-Fetch 검증, 티켓 보존)는 뮤테이션 테스트로 실효성을 확인했습니다 — 검증을 제거하면 각각 6건, 1건이 실패합니다.

### 2차 교차 리뷰에서 함께 제거한 문제

**티켓 삭제 DoS (HIGH)** — verifier 불일치 시 티켓을 삭제하던 동작을 걷어냈습니다. `ticket`만 아는 공격자가 아무 값이나 verifier로 넣어 **요청 한 번으로 정상 사용자의 로그인을 무효화**할 수 있었습니다. 탈취(두 값 모두 필요)보다 적은 정보로 가능한 공격이라, 무차별 대입 차단 이득보다 손실이 컸습니다.

### 남은 후속 과제

로그아웃 부재, 비밀번호 변경 시 세션 무효화, 동의 화면 UI는 별도 PR로 진행합니다.

2차 리뷰에서 추가로 확인된 항목(별도 PR 예정):
- `recordConsent`의 동시성 — 인가 코드가 Redis에 발급된 **뒤** consent를 기록하는데, `@Transactional`은 Redis를 롤백하지 않아 동시 요청 시 코드는 발급된 채 500이 반환될 수 있음
- SSO 세션 무효화 경로 부재 — `idpSessionRedisRepository`에 `delete` 호출이 없어 쿠키 유출 시 8시간 동안 서버에서 끊을 수 없음
- `resolveSsoAccount`의 6중 폴백에 진단 로그 부재 (폴백 자체는 안전한 설계로 확인됨)
- **계정 삭제 기능이 추가될 때 `tb_oauth_consent` 행도 함께 정리해야 함** — `accountId`가 FK 없는 단순 컬럼이라 자동 정리되지 않음 (현재 계정 삭제 경로 자체가 없어 이번 PR 범위 밖)


