### PR TITLE
[oauth] 동의 화면 분기 및 동의 승인/거부 엔드포인트

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthConsentReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthConsentReqDto.kt
@@ -1,0 +1,12 @@
+package team.themoment.datagsm.common.domain.oauth.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+data class OauthConsentReqDto(
+    @field:NotBlank(message = "토큰은 필수입니다.")
+    @field:Schema(description = "인증 시작 시 발급된 세션 토큰")
+    val token: String,
+    @field:Schema(description = "동의 여부. false면 access_denied로 클라이언트에 리다이렉트합니다.")
+    val approved: Boolean,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/OauthConsentJpaRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/OauthConsentJpaRepository.kt
@@ -1,6 +1,9 @@
 package team.themoment.datagsm.common.domain.oauth.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
 import java.util.Optional
 
@@ -9,4 +12,62 @@ interface OauthConsentJpaRepository : JpaRepository<OauthConsentJpaEntity, Long>
         accountId: Long,
         clientId: String,
     ): Optional<OauthConsentJpaEntity>
+
+    /**
+     * 동의 기록 행을 upsert하고 그 id를 확보한다.
+     *
+     * 같은 (account, client)로 첫 로그인이 동시에 들어오면 양쪽이 insert를 시도해
+     * uk_oauth_consent_account_client 위반이 난다. 애플리케이션에서 조회 후 분기하면
+     * 두 요청이 같은 순간 "없음"을 보고 둘 다 insert하는 창이 남으므로, DB가 원자적으로
+     * 판단하도록 맡긴다.
+     *
+     * 중복 시 갱신할 값이 따로 없어 updated_at만 건드린다. 이 구문은 행이 반드시
+     * 존재하도록 보장하는 것이 목적이고, id는 이어지는 findIdByAccountIdAndClientId로 읽는다.
+     */
+    @Modifying
+    @Query(
+        value =
+            "INSERT INTO tb_oauth_consent (account_id, client_id, updated_at) " +
+                "VALUES (:accountId, :clientId, NOW()) " +
+                "ON DUPLICATE KEY UPDATE updated_at = VALUES(updated_at)",
+        nativeQuery = true,
+    )
+    fun upsertConsent(
+        @Param("accountId") accountId: Long,
+        @Param("clientId") clientId: String,
+    )
+
+    /**
+     * upsert 직후 행의 id를 읽는다.
+     *
+     * 네이티브 쿼리라 영속성 컨텍스트의 1차 캐시나 REPEATABLE READ 스냅샷이 아니라
+     * upsert가 방금 확정한 행을 그대로 본다.
+     */
+    @Query(
+        value = "SELECT id FROM tb_oauth_consent WHERE account_id = :accountId AND client_id = :clientId",
+        nativeQuery = true,
+    )
+    fun findIdByAccountIdAndClientId(
+        @Param("accountId") accountId: Long,
+        @Param("clientId") clientId: String,
+    ): Long?
+
+    /**
+     * scope를 추가한다. 이미 있는 scope는 무시한다.
+     *
+     * tb_oauth_consent_scope에는 유니크 제약이 없어 INSERT IGNORE로는 중복이 쌓이므로,
+     * 존재하지 않을 때만 넣도록 NOT EXISTS로 거른다.
+     */
+    @Modifying
+    @Query(
+        value =
+            "INSERT INTO tb_oauth_consent_scope (consent_id, scope) " +
+                "SELECT :consentId, :scope FROM DUAL WHERE NOT EXISTS (" +
+                "SELECT 1 FROM tb_oauth_consent_scope WHERE consent_id = :consentId AND scope = :scope)",
+        nativeQuery = true,
+    )
+    fun addScopeIfAbsent(
+        @Param("consentId") consentId: Long,
+        @Param("scope") scope: String,
+    )
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/component/IdpSessionResolver.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/component/IdpSessionResolver.kt
@@ -1,0 +1,42 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.component
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatus
+import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
+import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRequestJpaRepository
+
+/**
+ * IdP 세션 쿠키만으로 비밀번호 재입력을 생략해도 되는 계정인지 판별한다.
+ *
+ * 세션으로 로그인을 건너뛰는 경로가 SSO 인가(GET /authorize)와 동의 승인(POST /authorize/consent)
+ * 두 곳이라, 판정이 한쪽에만 적용돼 갈라지지 않도록 여기에 모은다.
+ * 특히 학생 정보 수정 요청 확인은 강제 수정 절차가 SSO로 우회되는 것을 막는 불변 조건이다.
+ */
+@Component
+class IdpSessionResolver(
+    private val idpSessionRedisRepository: IdpSessionRedisRepository,
+    private val accountJpaRepository: AccountJpaRepository,
+    private val studentDataEditRequestJpaRepository: StudentDataEditRequestJpaRepository,
+) {
+    fun resolveEligibleAccount(sessionId: String?): AccountJpaEntity? {
+        if (sessionId.isNullOrBlank()) return null
+
+        val session = idpSessionRedisRepository.findByIdOrNull(sessionId) ?: return null
+        val account = accountJpaRepository.findByEmail(session.email).orElse(null) ?: return null
+        if (account.id == null) return null
+
+        if (account.status != AccountStatus.ACTIVE) return null
+
+        val studentId = account.objectId
+        if (account.objectType == AccountObjectType.STUDENT && studentId != null) {
+            val hasPendingEditRequest = studentDataEditRequestJpaRepository.findByStudentId(studentId).isPresent
+            if (hasPendingEditRequest) return null
+        }
+
+        return account
+    }
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 import team.themoment.datagsm.common.domain.oauth.dto.request.Oauth2TokenReqDto
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeReqDto
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeSubmitReqDto
+import team.themoment.datagsm.common.domain.oauth.dto.request.OauthConsentReqDto
 import team.themoment.datagsm.common.domain.oauth.dto.response.JwkSetResDto
 import team.themoment.datagsm.common.domain.oauth.dto.response.Oauth2TokenResDto
 import team.themoment.datagsm.common.domain.oauth.dto.response.OauthSessionResDto
@@ -27,6 +28,7 @@ import team.themoment.datagsm.common.domain.student.dto.request.QueryStudentData
 import team.themoment.datagsm.common.domain.student.dto.response.StudentDataEditRequestResDto
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteIdpSessionHandoffService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthAuthorizeFlowService
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthConsentService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.Oauth2TokenService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryJwkSetService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryOauthSessionService
@@ -40,6 +42,7 @@ class OauthController(
     val oauth2TokenService: Oauth2TokenService,
     val startOauthAuthorizeFlowService: StartOauthAuthorizeFlowService,
     val completeOauthAuthorizeFlowService: CompleteOauthAuthorizeFlowService,
+    val completeOauthConsentService: CompleteOauthConsentService,
     val completeIdpSessionHandoffService: CompleteIdpSessionHandoffService,
     val queryOauthSessionService: QueryOauthSessionService,
     val queryJwkSetService: QueryJwkSetService,
@@ -96,6 +99,23 @@ class OauthController(
     fun authorizePost(
         @Valid @RequestBody reqDto: OauthAuthorizeSubmitReqDto,
     ): ResponseEntity<Void> = completeOauthAuthorizeFlowService.execute(reqDto)
+
+    @PostMapping("/authorize/consent")
+    @Operation(
+        summary = "OAuth 동의 처리",
+        description = "SSO 세션이 있는 사용자가 요청된 scope를 승인하거나 거부합니다. 거부 시 access_denied로 리다이렉트합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "302", description = "동의 승인 후 코드 발급, 또는 거부 시 access_denied 리다이렉트"),
+            ApiResponse(responseCode = "400", description = "세션 만료 또는 잘못된 요청", content = [Content()]),
+            ApiResponse(responseCode = "401", description = "IdP 세션이 없거나 유효하지 않음", content = [Content()]),
+        ],
+    )
+    fun authorizeConsent(
+        @Valid @RequestBody reqDto: OauthConsentReqDto,
+        @CookieValue(name = "\${spring.security.oauth.idp-session-cookie-name}", required = false) sessionId: String?,
+    ): ResponseEntity<Void> = completeOauthConsentService.execute(reqDto, sessionId)
 
     @PostMapping("/authorize/data-edit-requirements")
     @Operation(

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthConsentService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthConsentService.kt
@@ -1,0 +1,11 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import org.springframework.http.ResponseEntity
+import team.themoment.datagsm.common.domain.oauth.dto.request.OauthConsentReqDto
+
+interface CompleteOauthConsentService {
+    fun execute(
+        reqDto: OauthConsentReqDto,
+        sessionId: String?,
+    ): ResponseEntity<Void>
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
@@ -1,7 +1,6 @@
 package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
 
 import org.springframework.context.ApplicationEventPublisher
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -20,7 +19,6 @@ import team.themoment.datagsm.common.domain.event.entity.constant.EventType
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeSubmitReqDto
 import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
 import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
-import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
@@ -38,7 +36,6 @@ import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteO
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
 import team.themoment.sdk.exception.ExpectedException
-import team.themoment.sdk.logging.logger.logger
 import java.net.URI
 import java.security.SecureRandom
 import java.util.Base64
@@ -169,33 +166,30 @@ class CompleteOauthAuthorizeFlowServiceImpl(
             .toUriString()
     }
 
-    // 같은 (account, client)로 첫 로그인이 동시에 들어오면 양쪽 다 insert를 시도해
-    // uk_oauth_consent_account_client 위반이 난다. 이 시점에는 code와 세션이 이미
-    // Redis에 저장돼 롤백되지 않으므로, 제약 위반은 재조회 후 병합으로 흡수한다.
+    // 동의 기록은 DB의 원자적 upsert에 맡긴다.
+    //
+    // 조회 후 없으면 insert하는 방식은 같은 (account, client)로 첫 로그인이 동시에
+    // 들어올 때 둘 다 "없음"을 보고 insert해 uk_oauth_consent_account_client 위반이 난다.
+    // 제약 위반을 잡아 같은 트랜잭션에서 재시도하는 것도 답이 아니다. flush 중 제약 위반이
+    // 나면 영속성 컨텍스트를 더 이상 신뢰할 수 없고, REPEATABLE READ에서는 재조회가 다른
+    // 트랜잭션이 방금 커밋한 행을 보지 못해 같은 예외를 다시 던질 수 있다.
+    //
+    // 이 자리에서 실패하면 특히 곤란하다. 인가 코드와 세션은 이미 Redis에 저장돼
+    // 롤백되지 않으므로, 사용자는 500을 받는데 코드만 남는 상태가 된다.
     private fun recordConsent(
         accountId: Long,
         clientId: String,
         scopes: Set<String>,
     ) {
-        try {
-            saveConsent(accountId, clientId, scopes)
-        } catch (e: DataIntegrityViolationException) {
-            logger().warn("Retrying consent record after unique constraint violation for clientId {}", clientId, e)
-            saveConsent(accountId, clientId, scopes)
-        }
-    }
+        oauthConsentJpaRepository.upsertConsent(accountId, clientId)
 
-    private fun saveConsent(
-        accountId: Long,
-        clientId: String,
-        scopes: Set<String>,
-    ) {
-        val consent =
-            oauthConsentJpaRepository
-                .findByAccountIdAndClientId(accountId, clientId)
-                .orElseGet { OauthConsentJpaEntity.create(accountId, clientId, emptySet()) }
-        consent.grantedScopes.addAll(scopes)
-        oauthConsentJpaRepository.saveAndFlush(consent)
+        val consentId =
+            oauthConsentJpaRepository.findIdByAccountIdAndClientId(accountId, clientId)
+                ?: throw ExpectedException("동의 정보를 저장하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
+
+        scopes.forEach { scope ->
+            oauthConsentJpaRepository.addScopeIfAbsent(consentId, scope)
+        }
     }
 
     private fun resolveStudentDataEditRequestIfNeeded(

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthConsentServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthConsentServiceImpl.kt
@@ -1,0 +1,127 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
+
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.datagsm.common.domain.oauth.dto.request.OauthConsentReqDto
+import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
+import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepository
+import team.themoment.datagsm.oauth.authorization.domain.oauth.component.IdpSessionResolver
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthConsentService
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
+import team.themoment.sdk.exception.ExpectedException
+import team.themoment.sdk.logging.logger.logger
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+@Service
+class CompleteOauthConsentServiceImpl(
+    private val oauthAuthorizeStateRedisRepository: OauthAuthorizeStateRedisRepository,
+    private val oauthConsentJpaRepository: OauthConsentJpaRepository,
+    private val issueAuthorizationCodeService: IssueAuthorizationCodeService,
+    private val idpSessionResolver: IdpSessionResolver,
+) : CompleteOauthConsentService {
+    companion object {
+        private const val ACCESS_DENIED_ERROR = "access_denied"
+        private const val ACCESS_DENIED_DESCRIPTION = "사용자가 접근 권한 요청을 거부했습니다."
+    }
+
+    @Transactional
+    override fun execute(
+        reqDto: OauthConsentReqDto,
+        sessionId: String?,
+    ): ResponseEntity<Void> {
+        val stateEntity =
+            oauthAuthorizeStateRedisRepository
+                .findByIdOrNull(reqDto.token)
+                ?: throw OAuthException.InvalidRequest("인증 토큰이 유효하지 않거나 만료되었습니다. 다시 시도해주세요.")
+
+        // 이 엔드포인트는 비밀번호 없이 세션 쿠키만으로 코드를 발급한다.
+        // 따라서 SSO 인가와 완전히 같은 자격 조건을 여기서 다시 확인해야 한다.
+        val account =
+            idpSessionResolver.resolveEligibleAccount(sessionId)
+                ?: throw ExpectedException("로그인이 필요합니다.", HttpStatus.UNAUTHORIZED)
+
+        if (!reqDto.approved) {
+            return denyConsent(stateEntity)
+        }
+
+        val redirectUrl =
+            issueAuthorizationCodeService.execute(
+                email = account.email,
+                clientId = stateEntity.clientId,
+                redirectUri = stateEntity.redirectUri,
+                state = stateEntity.state,
+                codeChallenge = stateEntity.codeChallenge,
+                codeChallengeMethod = stateEntity.codeChallengeMethod,
+                scopes = stateEntity.scopes,
+            )
+
+        oauthAuthorizeStateRedisRepository.deleteById(reqDto.token)
+
+        val accountId = requireNotNull(account.id) { "Persisted account must have an id" }
+        recordConsent(accountId, stateEntity.clientId, stateEntity.scopes)
+
+        return ResponseEntity
+            .status(HttpStatus.FOUND)
+            .location(URI.create(redirectUrl))
+            .build()
+    }
+
+    // 거부는 OAuth 2.0 표준(RFC 6749 4.1.2.1)대로 클라이언트에 error=access_denied로 돌려준다.
+    // 토큰을 소비해 같은 화면을 다시 승인으로 뒤집지 못하게 한다.
+    private fun denyConsent(stateEntity: OauthAuthorizeStateRedisEntity): ResponseEntity<Void> {
+        oauthAuthorizeStateRedisRepository.deleteById(stateEntity.token)
+
+        val redirectUrl =
+            buildString {
+                append(stateEntity.redirectUri)
+                append(if (stateEntity.redirectUri.contains('?')) '&' else '?')
+                append("error=").append(ACCESS_DENIED_ERROR)
+                append("&error_description=").append(encodeQueryValue(ACCESS_DENIED_DESCRIPTION))
+                stateEntity.state?.let { append("&state=").append(encodeQueryValue(it)) }
+            }
+
+        return ResponseEntity
+            .status(HttpStatus.FOUND)
+            .location(URI.create(redirectUrl))
+            .build()
+    }
+
+    // 동시 요청으로 같은 (account, client) 행을 함께 insert하면 제약 위반이 난다.
+    // 이 시점에는 code가 이미 Redis에 저장돼 롤백되지 않으므로 재조회 후 병합으로 흡수한다.
+    private fun recordConsent(
+        accountId: Long,
+        clientId: String,
+        scopes: Set<String>,
+    ) {
+        try {
+            saveConsent(accountId, clientId, scopes)
+        } catch (e: DataIntegrityViolationException) {
+            logger().warn("Retrying consent record after unique constraint violation for clientId {}", clientId, e)
+            saveConsent(accountId, clientId, scopes)
+        }
+    }
+
+    private fun saveConsent(
+        accountId: Long,
+        clientId: String,
+        scopes: Set<String>,
+    ) {
+        val consent =
+            oauthConsentJpaRepository
+                .findByAccountIdAndClientId(accountId, clientId)
+                .orElseGet { OauthConsentJpaEntity.create(accountId, clientId, emptySet()) }
+        consent.grantedScopes.addAll(scopes)
+        oauthConsentJpaRepository.saveAndFlush(consent)
+    }
+
+    private fun encodeQueryValue(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8)
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthConsentServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthConsentServiceImpl.kt
@@ -1,6 +1,5 @@
 package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
 
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -8,7 +7,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthConsentReqDto
 import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
-import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepository
@@ -16,7 +14,6 @@ import team.themoment.datagsm.oauth.authorization.domain.oauth.component.IdpSess
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthConsentService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.sdk.exception.ExpectedException
-import team.themoment.sdk.logging.logger.logger
 import java.net.URI
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -95,32 +92,30 @@ class CompleteOauthConsentServiceImpl(
             .build()
     }
 
-    // 동시 요청으로 같은 (account, client) 행을 함께 insert하면 제약 위반이 난다.
-    // 이 시점에는 code가 이미 Redis에 저장돼 롤백되지 않으므로 재조회 후 병합으로 흡수한다.
+    // 동의 기록은 DB의 원자적 upsert에 맡긴다.
+    //
+    // 조회 후 없으면 insert하는 방식은 같은 (account, client)로 첫 로그인이 동시에
+    // 들어올 때 둘 다 "없음"을 보고 insert해 uk_oauth_consent_account_client 위반이 난다.
+    // 제약 위반을 잡아 같은 트랜잭션에서 재시도하는 것도 답이 아니다. flush 중 제약 위반이
+    // 나면 영속성 컨텍스트를 더 이상 신뢰할 수 없고, REPEATABLE READ에서는 재조회가 다른
+    // 트랜잭션이 방금 커밋한 행을 보지 못해 같은 예외를 다시 던질 수 있다.
+    //
+    // 이 자리에서 실패하면 특히 곤란하다. 인가 코드는 이미 Redis에 저장돼 롤백되지 않으므로,
+    // 사용자는 500을 받는데 코드만 남는 상태가 된다.
     private fun recordConsent(
         accountId: Long,
         clientId: String,
         scopes: Set<String>,
     ) {
-        try {
-            saveConsent(accountId, clientId, scopes)
-        } catch (e: DataIntegrityViolationException) {
-            logger().warn("Retrying consent record after unique constraint violation for clientId {}", clientId, e)
-            saveConsent(accountId, clientId, scopes)
-        }
-    }
+        oauthConsentJpaRepository.upsertConsent(accountId, clientId)
 
-    private fun saveConsent(
-        accountId: Long,
-        clientId: String,
-        scopes: Set<String>,
-    ) {
-        val consent =
-            oauthConsentJpaRepository
-                .findByAccountIdAndClientId(accountId, clientId)
-                .orElseGet { OauthConsentJpaEntity.create(accountId, clientId, emptySet()) }
-        consent.grantedScopes.addAll(scopes)
-        oauthConsentJpaRepository.saveAndFlush(consent)
+        val consentId =
+            oauthConsentJpaRepository.findIdByAccountIdAndClientId(accountId, clientId)
+                ?: throw ExpectedException("동의 정보를 저장하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
+
+        scopes.forEach { scope ->
+            oauthConsentJpaRepository.addScopeIfAbsent(consentId, scope)
+        }
     }
 
     private fun encodeQueryValue(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8)

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -1,26 +1,21 @@
 package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
 
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.util.UriComponentsBuilder
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
-import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
-import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatus
-import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
 import team.themoment.datagsm.common.domain.client.entity.constant.OAuthScope
 import team.themoment.datagsm.common.domain.client.repository.ClientJpaRepository
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeReqDto
 import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
 import team.themoment.datagsm.common.domain.oauth.entity.constant.PkceChallengeMethod
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
-import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepository
-import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRequestJpaRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.component.IdpSessionResolver
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.StartOauthAuthorizeFlowService
 import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
@@ -33,12 +28,15 @@ class StartOauthAuthorizeFlowServiceImpl(
     private val oauthEnvironment: OauthEnvironment,
     private val oauthAuthorizeStateRedisRepository: OauthAuthorizeStateRedisRepository,
     private val jwtEnvironment: OauthJwtProvisionEnvironment,
-    private val idpSessionRedisRepository: IdpSessionRedisRepository,
-    private val accountJpaRepository: AccountJpaRepository,
-    private val studentDataEditRequestJpaRepository: StudentDataEditRequestJpaRepository,
+    private val idpSessionResolver: IdpSessionResolver,
     private val oauthConsentJpaRepository: OauthConsentJpaRepository,
     private val issueAuthorizationCodeService: IssueAuthorizationCodeService,
 ) : StartOauthAuthorizeFlowService {
+    companion object {
+        private const val LOGIN_PATH = "/oauth/authorize"
+        private const val CONSENT_PATH = "/oauth/consent"
+    }
+
     @Transactional(readOnly = true)
     override fun execute(
         reqDto: OauthAuthorizeReqDto,
@@ -76,8 +74,8 @@ class StartOauthAuthorizeFlowServiceImpl(
                 ?.toSet()
         val resolvedScopes = resolveScopes(requestedScopes, client.scopes)
 
-        val ssoAccount = resolveSsoAccount(sessionId, clientId, resolvedScopes)
-        if (ssoAccount != null) {
+        val ssoAccount = idpSessionResolver.resolveEligibleAccount(sessionId)
+        if (ssoAccount != null && hasConsentFor(ssoAccount, clientId, resolvedScopes)) {
             val redirectUrl =
                 issueAuthorizationCodeService.execute(
                     email = ssoAccount.email,
@@ -110,10 +108,14 @@ class StartOauthAuthorizeFlowServiceImpl(
 
         oauthAuthorizeStateRedisRepository.save(stateEntity)
 
+        // 세션은 유효한데 동의만 없는 경우, 비밀번호를 다시 받을 이유가 없으므로 동의 화면으로 보낸다.
+        // 세션 자체가 없거나 자격을 잃은 경우에만 로그인 폼으로 되돌린다.
+        val frontendPath = if (ssoAccount != null) CONSENT_PATH else LOGIN_PATH
+
         val location =
             UriComponentsBuilder
                 .fromUriString(oauthEnvironment.frontendUrl)
-                .path("/oauth/authorize")
+                .path(frontendPath)
                 .queryParam("token", token)
                 .build()
                 .toUri()
@@ -124,35 +126,20 @@ class StartOauthAuthorizeFlowServiceImpl(
             .build()
     }
 
-    // SSO 세션으로 로그인을 생략할 수 있는지 판단한다.
-    // 어느 조건이든 충족하지 못하면 null을 반환해 기존 로그인 플로우로 폴백시킨다.
-    private fun resolveSsoAccount(
-        sessionId: String?,
+    // 요청된 scope가 이미 동의 기록에 전부 포함되어 있는지 확인한다.
+    // 하나라도 새 scope가 섞여 있으면 그 scope에 대한 동의를 다시 받아야 한다.
+    private fun hasConsentFor(
+        account: AccountJpaEntity,
         clientId: String,
         resolvedScopes: Set<String>,
-    ): AccountJpaEntity? {
-        if (sessionId.isNullOrBlank()) return null
-
-        val session = idpSessionRedisRepository.findByIdOrNull(sessionId) ?: return null
-        val account = accountJpaRepository.findByEmail(session.email).orElse(null) ?: return null
-        val accountId = account.id ?: return null
-
-        if (account.status != AccountStatus.ACTIVE) return null
-
-        val studentId = account.objectId
-        if (account.objectType == AccountObjectType.STUDENT && studentId != null) {
-            val hasPendingEditRequest = studentDataEditRequestJpaRepository.findByStudentId(studentId).isPresent
-            if (hasPendingEditRequest) return null
-        }
-
+    ): Boolean {
+        val accountId = account.id ?: return false
         val consent =
             oauthConsentJpaRepository
                 .findByAccountIdAndClientId(accountId, clientId)
-                .orElse(null) ?: return null
+                .orElse(null) ?: return false
 
-        if (!consent.grantedScopes.containsAll(resolvedScopes)) return null
-
-        return account
+        return consent.grantedScopes.containsAll(resolvedScopes)
     }
 
     private fun resolveScopes(

--- a/datagsm-oauth-authorization/src/main/resources/application.yml
+++ b/datagsm-oauth-authorization/src/main/resources/application.yml
@@ -116,6 +116,7 @@ sdk:
       - "/swagger-ui/**"
       - "/actuator/**"
       - "/v1/oauth/authorize"
+      - "/v1/oauth/authorize/consent"
       - "/v1/oauth/token"
       - "/v1/oauth/jwks"
   swagger:

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
@@ -12,7 +12,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.springframework.context.ApplicationEventPublisher
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.security.crypto.password.PasswordEncoder
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
@@ -143,8 +142,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         } returns issuedRedirectUrl
                         every { mockIdpSessionRedisRepository.save(capture(sessionSlot)) } answers { firstArg() }
                         every { mockIdpSessionHandoffRedisRepository.save(capture(handoffSlot)) } answers { firstArg() }
-                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(any(), any()) } returns Optional.empty()
-                        every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } answers { firstArg() }
+                        every { mockOauthConsentJpaRepository.findIdByAccountIdAndClientId(any(), any()) } returns 7L
                     }
 
                     it("세션 핸드오프 URL로 302 리다이렉트되어야 한다") {
@@ -211,28 +209,29 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         handoffSlot.captured.ttl shouldBe idpSessionHandoffExpirationSeconds
                     }
 
-                    it("동의 기록이 유니크 제약에 걸려도 재조회로 복구되어야 한다") {
-                        val existing = OauthConsentJpaEntity.create(1L, testClientId, setOf("other:scope"))
-                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(any(), any()) } returnsMany
-                            listOf(Optional.empty(), Optional.of(existing))
-                        every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } throws
-                            DataIntegrityViolationException("duplicate") andThen existing
-
+                    // 조회 후 insert는 동시 로그인 시 둘 다 "없음"을 보고 insert해 제약 위반이 난다.
+                    // 이 시점엔 code와 세션이 이미 Redis에 있어 롤백되지 않으므로,
+                    // 애플리케이션 재시도가 아니라 원자적 upsert로 처리한다.
+                    it("동의 기록은 조회 후 분기가 아닌 원자적 upsert로 저장되어야 한다") {
                         val response = completeOauthAuthorizeFlowService.execute(reqDto)
 
-                        // 동시 로그인으로 제약 위반이 나도 사용자에게 500이 나가지 않아야 한다.
                         response.statusCode shouldBe HttpStatus.FOUND
-                        existing.grantedScopes shouldBe mutableSetOf("other:scope", "self:read")
+                        verify(exactly = 1) { mockOauthConsentJpaRepository.upsertConsent(1L, testClientId) }
+                        verify(exactly = 0) {
+                            mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>())
+                        }
                     }
 
                     it("요청한 scope가 동의 기록으로 저장되어야 한다") {
-                        val consentSlot = slot<OauthConsentJpaEntity>()
-                        every { mockOauthConsentJpaRepository.saveAndFlush(capture(consentSlot)) } answers { firstArg() }
+                        val scopeSlot = mutableListOf<String>()
+                        every {
+                            mockOauthConsentJpaRepository.addScopeIfAbsent(7L, capture(scopeSlot))
+                        } returns Unit
 
                         completeOauthAuthorizeFlowService.execute(reqDto)
 
-                        consentSlot.captured.clientId shouldBe testClientId
-                        consentSlot.captured.grantedScopes shouldBe mutableSetOf("self:read")
+                        verify(exactly = 1) { mockOauthConsentJpaRepository.upsertConsent(1L, testClientId) }
+                        scopeSlot.toSet() shouldBe setOf("self:read")
                     }
 
                     it("Redis에서 인증 상태가 삭제되어야 한다") {
@@ -540,8 +539,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         every {
                             mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
                         } returns "$testRedirectUri?code=test-code&state=random-state"
-                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(any(), any()) } returns Optional.empty()
-                        every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } answers { firstArg() }
+                        every { mockOauthConsentJpaRepository.findIdByAccountIdAndClientId(any(), any()) } returns 7L
                         every { mockIdpSessionRedisRepository.save(any<IdpSessionRedisEntity>()) } answers { firstArg() }
                         every {
                             mockIdpSessionHandoffRedisRepository.save(any<IdpSessionHandoffRedisEntity>())

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthConsentServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthConsentServiceTest.kt
@@ -8,9 +8,7 @@ import io.kotest.matchers.string.shouldStartWith
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
@@ -104,9 +102,7 @@ class CompleteOauthConsentServiceTest :
                     every { mockIdpSessionRedisRepository.findById(testSessionId) } returns
                         Optional.of(IdpSessionRedisEntity(testSessionId, testEmail, 28800))
                     every { mockAccountJpaRepository.findByEmail(testEmail) } returns Optional.of(activeAccount())
-                    every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returns
-                        Optional.empty()
-                    every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } answers { firstArg() }
+                    every { mockOauthConsentJpaRepository.findIdByAccountIdAndClientId(1L, testClientId) } returns 7L
                     every {
                         mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
                     } returns issuedRedirectUrl
@@ -125,17 +121,18 @@ class CompleteOauthConsentServiceTest :
                     }
 
                     it("승인한 scope가 동의 기록으로 저장되어야 한다") {
-                        val consentSlot = slot<OauthConsentJpaEntity>()
-                        every { mockOauthConsentJpaRepository.saveAndFlush(capture(consentSlot)) } answers { firstArg() }
+                        val scopeSlot = mutableListOf<String>()
+                        every {
+                            mockOauthConsentJpaRepository.addScopeIfAbsent(7L, capture(scopeSlot))
+                        } returns Unit
 
                         completeOauthConsentService.execute(
                             OauthConsentReqDto(testToken, approved = true),
                             testSessionId,
                         )
 
-                        consentSlot.captured.accountId shouldBe 1L
-                        consentSlot.captured.clientId shouldBe testClientId
-                        consentSlot.captured.grantedScopes shouldBe testScopes
+                        verify(exactly = 1) { mockOauthConsentJpaRepository.upsertConsent(1L, testClientId) }
+                        scopeSlot.toSet() shouldBe testScopes
                     }
 
                     it("재사용되지 않도록 state 토큰을 소비해야 한다") {
@@ -290,22 +287,44 @@ class CompleteOauthConsentServiceTest :
                     }
                 }
 
-                context("동의 기록 저장이 유니크 제약에 걸렸을 때") {
-                    it("재조회 후 병합해 코드 발급이 실패하지 않아야 한다") {
-                        val existing = OauthConsentJpaEntity.create(1L, testClientId, setOf("datagsm:account_read"))
-                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returnsMany
-                            listOf(Optional.empty(), Optional.of(existing))
-                        every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } throws
-                            DataIntegrityViolationException("duplicate") andThen existing
+                // 조회 후 insert 방식은 동시 요청 시 둘 다 "없음"을 보고 insert해 제약 위반이 난다.
+                // 원자적 upsert에 맡겨, 애플리케이션에서 제약 위반을 잡아 재시도하지 않는다.
+                context("동의 기록을 저장할 때") {
+                    it("조회 후 분기하지 않고 원자적 upsert를 써야 한다") {
+                        completeOauthConsentService.execute(
+                            OauthConsentReqDto(testToken, approved = true),
+                            testSessionId,
+                        )
 
-                        val response =
+                        verify(exactly = 1) { mockOauthConsentJpaRepository.upsertConsent(1L, testClientId) }
+                        verify(exactly = 0) {
+                            mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>())
+                        }
+                    }
+
+                    it("이미 동의한 scope를 다시 넣어도 중복이 쌓이지 않아야 한다") {
+                        completeOauthConsentService.execute(
+                            OauthConsentReqDto(testToken, approved = true),
+                            testSessionId,
+                        )
+
+                        // addScopeIfAbsent가 NOT EXISTS로 거르므로 scope당 한 번만 호출된다.
+                        testScopes.forEach { scope ->
+                            verify(exactly = 1) { mockOauthConsentJpaRepository.addScopeIfAbsent(7L, scope) }
+                        }
+                    }
+
+                    it("행 id를 읽지 못하면 scope를 매달지 않고 실패해야 한다") {
+                        every { mockOauthConsentJpaRepository.findIdByAccountIdAndClientId(1L, testClientId) } returns null
+
+                        shouldThrow<ExpectedException> {
                             completeOauthConsentService.execute(
                                 OauthConsentReqDto(testToken, approved = true),
                                 testSessionId,
                             )
+                        }
 
-                        response.statusCode shouldBe HttpStatus.FOUND
-                        existing.grantedScopes shouldBe testScopes
+                        verify(exactly = 0) { mockOauthConsentJpaRepository.addScopeIfAbsent(any(), any()) }
                     }
                 }
             }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthConsentServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthConsentServiceTest.kt
@@ -1,0 +1,313 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.http.HttpStatus
+import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
+import team.themoment.datagsm.common.domain.account.entity.constant.AccountStatus
+import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
+import team.themoment.datagsm.common.domain.oauth.dto.request.OauthConsentReqDto
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
+import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
+import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepository
+import team.themoment.datagsm.common.domain.student.entity.StudentDataEditRequestJpaEntity
+import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRequestJpaRepository
+import team.themoment.datagsm.oauth.authorization.domain.oauth.component.IdpSessionResolver
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.CompleteOauthConsentServiceImpl
+import team.themoment.sdk.exception.ExpectedException
+import java.net.URI
+import java.util.Optional
+
+class CompleteOauthConsentServiceTest :
+    DescribeSpec({
+
+        val mockOauthAuthorizeStateRedisRepository = mockk<OauthAuthorizeStateRedisRepository>(relaxed = true)
+        val mockOauthConsentJpaRepository = mockk<OauthConsentJpaRepository>(relaxed = true)
+        val mockIssueAuthorizationCodeService = mockk<IssueAuthorizationCodeService>(relaxed = true)
+        val mockIdpSessionRedisRepository = mockk<IdpSessionRedisRepository>(relaxed = true)
+        val mockAccountJpaRepository = mockk<AccountJpaRepository>(relaxed = true)
+        val mockStudentDataEditRequestJpaRepository = mockk<StudentDataEditRequestJpaRepository>(relaxed = true)
+
+        // 실제 IdpSessionResolver를 태워, 동의 경로에서도 계정 상태·정보 수정 요청 게이트가
+        // 그대로 적용되는지 검증한다. 이 엔드포인트는 비밀번호 없이 코드를 발급하므로 중요하다.
+        val idpSessionResolver =
+            IdpSessionResolver(
+                mockIdpSessionRedisRepository,
+                mockAccountJpaRepository,
+                mockStudentDataEditRequestJpaRepository,
+            )
+
+        val completeOauthConsentService =
+            CompleteOauthConsentServiceImpl(
+                mockOauthAuthorizeStateRedisRepository,
+                mockOauthConsentJpaRepository,
+                mockIssueAuthorizationCodeService,
+                idpSessionResolver,
+            )
+
+        afterEach {
+            clearAllMocks()
+        }
+
+        describe("CompleteOauthConsentService 클래스의") {
+            describe("execute 메서드는") {
+
+                val testToken = "state-token-1"
+                val testSessionId = "session-1"
+                val testEmail = "user@gsm.hs.kr"
+                val testClientId = "client-123"
+                val testRedirectUri = "https://example.com/callback"
+                val testScopes = setOf("datagsm:account_read", "datagsm:student_read")
+                val issuedRedirectUrl = "$testRedirectUri?code=issued-code&state=xyz"
+
+                fun activeAccount(): AccountJpaEntity =
+                    AccountJpaEntity().apply {
+                        id = 1L
+                        email = testEmail
+                        password = "encoded"
+                        status = AccountStatus.ACTIVE
+                        role = AccountRole.USER
+                        objectType = AccountObjectType.STUDENT
+                        objectId = null
+                    }
+
+                fun stateEntity(state: String? = "xyz"): OauthAuthorizeStateRedisEntity =
+                    OauthAuthorizeStateRedisEntity(
+                        token = testToken,
+                        clientId = testClientId,
+                        redirectUri = testRedirectUri,
+                        state = state,
+                        codeChallenge = null,
+                        codeChallengeMethod = null,
+                        scopes = testScopes,
+                        ttl = 600,
+                    )
+
+                beforeEach {
+                    every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns
+                        Optional.of(stateEntity())
+                    every { mockIdpSessionRedisRepository.findById(testSessionId) } returns
+                        Optional.of(IdpSessionRedisEntity(testSessionId, testEmail, 28800))
+                    every { mockAccountJpaRepository.findByEmail(testEmail) } returns Optional.of(activeAccount())
+                    every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returns
+                        Optional.empty()
+                    every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } answers { firstArg() }
+                    every {
+                        mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                    } returns issuedRedirectUrl
+                }
+
+                context("사용자가 동의를 승인했을 때") {
+                    it("코드를 발급하고 클라이언트로 리다이렉트해야 한다") {
+                        val response =
+                            completeOauthConsentService.execute(
+                                OauthConsentReqDto(testToken, approved = true),
+                                testSessionId,
+                            )
+
+                        response.statusCode shouldBe HttpStatus.FOUND
+                        response.headers.location?.toString() shouldBe issuedRedirectUrl
+                    }
+
+                    it("승인한 scope가 동의 기록으로 저장되어야 한다") {
+                        val consentSlot = slot<OauthConsentJpaEntity>()
+                        every { mockOauthConsentJpaRepository.saveAndFlush(capture(consentSlot)) } answers { firstArg() }
+
+                        completeOauthConsentService.execute(
+                            OauthConsentReqDto(testToken, approved = true),
+                            testSessionId,
+                        )
+
+                        consentSlot.captured.accountId shouldBe 1L
+                        consentSlot.captured.clientId shouldBe testClientId
+                        consentSlot.captured.grantedScopes shouldBe testScopes
+                    }
+
+                    it("재사용되지 않도록 state 토큰을 소비해야 한다") {
+                        completeOauthConsentService.execute(
+                            OauthConsentReqDto(testToken, approved = true),
+                            testSessionId,
+                        )
+
+                        verify(exactly = 1) { mockOauthAuthorizeStateRedisRepository.deleteById(testToken) }
+                    }
+                }
+
+                context("사용자가 동의를 거부했을 때") {
+                    it("access_denied로 클라이언트에 리다이렉트해야 한다") {
+                        val response =
+                            completeOauthConsentService.execute(
+                                OauthConsentReqDto(testToken, approved = false),
+                                testSessionId,
+                            )
+
+                        response.statusCode shouldBe HttpStatus.FOUND
+                        val location = response.headers.location?.toString() ?: ""
+                        location shouldStartWith "$testRedirectUri?error=access_denied"
+                        location shouldContain "state=xyz"
+                    }
+
+                    it("코드를 발급하거나 동의를 기록하지 않아야 한다") {
+                        completeOauthConsentService.execute(
+                            OauthConsentReqDto(testToken, approved = false),
+                            testSessionId,
+                        )
+
+                        verify(exactly = 0) {
+                            mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                        }
+                        verify(exactly = 0) { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) }
+                    }
+
+                    it("승인으로 뒤집지 못하도록 state 토큰을 소비해야 한다") {
+                        completeOauthConsentService.execute(
+                            OauthConsentReqDto(testToken, approved = false),
+                            testSessionId,
+                        )
+
+                        verify(exactly = 1) { mockOauthAuthorizeStateRedisRepository.deleteById(testToken) }
+                    }
+
+                    it("state에 URL 예약 문자가 있어도 파라미터가 주입되지 않아야 한다") {
+                        every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns
+                            Optional.of(stateEntity(state = "a&injected=evil"))
+
+                        val response =
+                            completeOauthConsentService.execute(
+                                OauthConsentReqDto(testToken, approved = false),
+                                testSessionId,
+                            )
+
+                        val location = response.headers.location?.toString() ?: ""
+                        val parsedKeys =
+                            URI
+                                .create(location)
+                                .rawQuery
+                                .split("&")
+                                .map { it.substringBefore("=") }
+                        parsedKeys.contains("injected") shouldBe false
+                        parsedKeys shouldBe listOf("error", "error_description", "state")
+                    }
+                }
+
+                context("세션 쿠키가 없을 때") {
+                    it("코드를 발급하지 않고 401이 반환되어야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                completeOauthConsentService.execute(
+                                    OauthConsentReqDto(testToken, approved = true),
+                                    null,
+                                )
+                            }
+
+                        exception.statusCode shouldBe HttpStatus.UNAUTHORIZED
+                        verify(exactly = 0) {
+                            mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                        }
+                    }
+                }
+
+                context("세션이 만료되었을 때") {
+                    it("코드를 발급하지 않고 401이 반환되어야 한다") {
+                        every { mockIdpSessionRedisRepository.findById(testSessionId) } returns Optional.empty()
+
+                        shouldThrow<ExpectedException> {
+                            completeOauthConsentService.execute(
+                                OauthConsentReqDto(testToken, approved = true),
+                                testSessionId,
+                            )
+                        }
+
+                        verify(exactly = 0) {
+                            mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                        }
+                    }
+                }
+
+                context("계정이 ACTIVE 상태가 아닐 때") {
+                    it("코드를 발급하지 않아야 한다") {
+                        every { mockAccountJpaRepository.findByEmail(testEmail) } returns
+                            Optional.of(activeAccount().apply { status = AccountStatus.PENDING })
+
+                        shouldThrow<ExpectedException> {
+                            completeOauthConsentService.execute(
+                                OauthConsentReqDto(testToken, approved = true),
+                                testSessionId,
+                            )
+                        }
+
+                        verify(exactly = 0) {
+                            mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                        }
+                    }
+                }
+
+                context("해소되지 않은 학생 정보 수정 요청이 있을 때") {
+                    it("정보 수정 강제가 동의 화면으로 우회되지 않아야 한다") {
+                        every { mockAccountJpaRepository.findByEmail(testEmail) } returns
+                            Optional.of(activeAccount().apply { objectId = 10L })
+                        every { mockStudentDataEditRequestJpaRepository.findByStudentId(10L) } returns
+                            Optional.of(StudentDataEditRequestJpaEntity())
+
+                        shouldThrow<ExpectedException> {
+                            completeOauthConsentService.execute(
+                                OauthConsentReqDto(testToken, approved = true),
+                                testSessionId,
+                            )
+                        }
+
+                        verify(exactly = 0) {
+                            mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
+                        }
+                    }
+                }
+
+                context("state 토큰이 유효하지 않을 때") {
+                    it("400이 반환되어야 한다") {
+                        every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns Optional.empty()
+
+                        shouldThrow<OAuthException.InvalidRequest> {
+                            completeOauthConsentService.execute(
+                                OauthConsentReqDto(testToken, approved = true),
+                                testSessionId,
+                            )
+                        }
+                    }
+                }
+
+                context("동의 기록 저장이 유니크 제약에 걸렸을 때") {
+                    it("재조회 후 병합해 코드 발급이 실패하지 않아야 한다") {
+                        val existing = OauthConsentJpaEntity.create(1L, testClientId, setOf("datagsm:account_read"))
+                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returnsMany
+                            listOf(Optional.empty(), Optional.of(existing))
+                        every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } throws
+                            DataIntegrityViolationException("duplicate") andThen existing
+
+                        val response =
+                            completeOauthConsentService.execute(
+                                OauthConsentReqDto(testToken, approved = true),
+                                testSessionId,
+                            )
+
+                        response.statusCode shouldBe HttpStatus.FOUND
+                        existing.grantedScopes shouldBe testScopes
+                    }
+                }
+            }
+        }
+    })

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -28,6 +28,7 @@ import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepo
 import team.themoment.datagsm.common.domain.student.entity.StudentDataEditRequestJpaEntity
 import team.themoment.datagsm.common.domain.student.repository.StudentDataEditRequestJpaRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.component.IdpSessionResolver
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.StartOauthAuthorizeFlowServiceImpl
 import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
@@ -54,15 +55,22 @@ class StartOauthAuthorizeFlowServiceTest :
         val mockOauthConsentJpaRepository = mockk<OauthConsentJpaRepository>(relaxed = true)
         val mockIssueAuthorizationCodeService = mockk<IssueAuthorizationCodeService>(relaxed = true)
 
+        // 세션 자격 판정은 실제 IdpSessionResolver를 그대로 태워, 계정 상태/정보 수정 요청
+        // 게이트가 목으로 우회되지 않고 이 테스트에서 함께 검증되게 한다.
+        val idpSessionResolver =
+            IdpSessionResolver(
+                mockIdpSessionRedisRepository,
+                mockAccountJpaRepository,
+                mockStudentDataEditRequestJpaRepository,
+            )
+
         val startOauthAuthorizeFlowService =
             StartOauthAuthorizeFlowServiceImpl(
                 mockClientJpaRepository,
                 mockOauthEnvironment,
                 mockOauthAuthorizeStateRedisRepository,
                 mockJwtEnvironment,
-                mockIdpSessionRedisRepository,
-                mockAccountJpaRepository,
-                mockStudentDataEditRequestJpaRepository,
+                idpSessionResolver,
                 mockOauthConsentJpaRepository,
                 mockIssueAuthorizationCodeService,
             )
@@ -404,6 +412,7 @@ class StartOauthAuthorizeFlowServiceTest :
                     val testEmail = "user@gsm.hs.kr"
                     val issuedRedirectUrl = "$testRedirectUri?code=test-code"
                     val loginPageUrl = "http://localhost:3000/oauth/authorize"
+                    val consentPageUrl = "http://localhost:3000/oauth/consent"
 
                     val ssoReqDto =
                         OauthAuthorizeReqDto(
@@ -516,10 +525,11 @@ class StartOauthAuthorizeFlowServiceTest :
                                 Optional.empty()
                         }
 
-                        it("기존 로그인 플로우로 폴백되어야 한다") {
+                        it("비밀번호를 다시 받지 않고 동의 화면으로 보내야 한다") {
                             val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
 
-                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            (response.headers.location?.toString() ?: "") shouldContain consentPageUrl
+                            verify(exactly = 1) { mockOauthAuthorizeStateRedisRepository.save(any()) }
                             verify(exactly = 0) {
                                 mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
                             }
@@ -532,10 +542,10 @@ class StartOauthAuthorizeFlowServiceTest :
                                 Optional.of(OauthConsentJpaEntity.create(1L, testClientId, setOf("datagsm:student_read")))
                         }
 
-                        it("기존 로그인 플로우로 폴백되어야 한다") {
+                        it("추가 동의를 받도록 동의 화면으로 보내야 한다") {
                             val response = startOauthAuthorizeFlowService.execute(ssoReqDto, testSessionId)
 
-                            (response.headers.location?.toString() ?: "") shouldContain loginPageUrl
+                            (response.headers.location?.toString() ?: "") shouldContain consentPageUrl
                             verify(exactly = 0) {
                                 mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
                             }


### PR DESCRIPTION
## 개요

SSO 로드맵 **우선순위 1 — 동의(Consent) 화면**의 백엔드 작업입니다. 세션은 유효하지만 동의 기록이 없을 때 로그인 폼으로 되돌리던 동작을, 동의 화면으로 보내도록 바꿉니다.

> 스택 PR입니다. base는 #433 (`add/oauth-sso-idp-session`)입니다.

## 본문

### 왜 필요한가

백엔드에 동의 기록 구조(`tb_oauth_consent`)는 이미 있지만 UI로 이어지는 분기가 없었습니다. 그래서 처음 쓰는 클라이언트는 세션이 있어도 로그인 페이지로 폴백해 **비밀번호를 다시 입력**해야 했고, 사용자가 "이 서비스에 어떤 정보를 주는지" 확인할 기회도 없었습니다.

### 변경 내용

**1. 세션 유효 + 동의 없음 → 동의 화면**

`StartOauthAuthorizeFlowServiceImpl`이 지금까지는 "세션 없음"과 "세션은 있지만 동의 없음"을 모두 `null`로 뭉뚱그려 로그인 폼으로 보냈습니다. 이 둘을 분리해 후자는 `/oauth/consent`로 보냅니다.

**2. `POST /v1/oauth/authorize/consent` 추가**

거부 시 OAuth 2.0 표준(RFC 6749 4.1.2.1)대로 `error=access_denied`로 클라이언트에 리다이렉트합니다. 승인·거부 모두 state 토큰을 소비해, 같은 화면을 다시 열어 승인으로 뒤집을 수 없게 했습니다.

**3. `IdpSessionResolver` 분리**

이 엔드포인트는 **비밀번호 없이 세션 쿠키만으로 인가 코드를 발급**합니다. 그래서 SSO 인가 경로와 완전히 같은 자격 조건(계정 ACTIVE 여부, 미해소 학생 정보 수정 요청)을 다시 확인해야 합니다. 두 경로에 같은 검사를 복사해두면 한쪽만 고쳐질 때 게이트가 갈라지므로, 판정을 한 곳으로 모았습니다.

특히 **학생 정보 수정 강제가 동의 화면으로 우회되지 않는 것**은 불변 조건이라 별도 테스트로 못박았습니다.

### 검증

- 신규 테스트 13건 포함 **145건 통과**, `ktlintCheck build` 통과
- 뮤테이션 테스트로 테스트가 실제로 회귀를 잡는지 확인:
  - 정보 수정 요청 게이트 제거 → 2건 실패 (두 경로 각각)
  - 계정 ACTIVE 검사 제거 → 2건 실패
  - 거부를 승인처럼 처리 → 3건 실패

### 프론트엔드 필요 작업

- `/oauth/consent?token=...` 페이지 신설 — 기존 `GET /v1/oauth/sessions/{token}`이 `serviceName`과 `requestedScopes`를 이미 내려주므로 그대로 재사용할 수 있습니다.
- 승인/거부 버튼 → `POST /api/oauth/authorize/consent` → 백엔드 `POST /v1/oauth/authorize/consent` (`redirect: 'manual'` 필요)

### 남은 과제

동의 화면이 붙기 전까지는 기존처럼 "비밀번호 재입력 → 자동 동의" 흐름이 유지됩니다. 이 PR은 그 분기를 열어두는 백엔드 작업입니다.