### PR TITLE
[oauth] IdP 로그아웃 및 비밀번호 변경 시 세션 무효화

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionRedisEntity.kt
@@ -3,11 +3,14 @@ package team.themoment.datagsm.common.domain.oauth.entity
 import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash
 import org.springframework.data.redis.core.TimeToLive
+import org.springframework.data.redis.core.index.Indexed
 
 @RedisHash("idp_session")
 data class IdpSessionRedisEntity(
     @Id
     val sessionId: String,
+    // 비밀번호 변경 시 해당 계정의 모든 세션을 끊어야 하므로 역방향 조회가 필요하다.
+    @Indexed
     val email: String,
     @TimeToLive
     val ttl: Long,

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/IdpSessionRedisRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/IdpSessionRedisRepository.kt
@@ -3,4 +3,6 @@ package team.themoment.datagsm.common.domain.oauth.repository
 import org.springframework.data.repository.CrudRepository
 import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
 
-interface IdpSessionRedisRepository : CrudRepository<IdpSessionRedisEntity, String>
+interface IdpSessionRedisRepository : CrudRepository<IdpSessionRedisEntity, String> {
+    fun findAllByEmail(email: String): List<IdpSessionRedisEntity>
+}

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/security/util/IdpSessionCookieFactory.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/security/util/IdpSessionCookieFactory.kt
@@ -1,0 +1,42 @@
+package team.themoment.datagsm.common.global.security.util
+
+import org.springframework.http.ResponseCookie
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import java.time.Duration
+
+/**
+ * IdP 세션 쿠키를 만드는 유일한 지점.
+ *
+ * 브라우저는 name/path/domain이 모두 일치해야 기존 쿠키를 덮어쓴다.
+ * 발급과 만료를 각각 따로 조립하면 속성이 어긋나는 순간 로그아웃이 조용히 실패하므로
+ * 두 형태를 같은 자리에서 만든다.
+ *
+ * 세션 쿠키를 읽는 곳은 같은 호스트의 인가 엔드포인트뿐이라 host-only로 둔다.
+ * Domain을 상위 도메인으로 넓히면 모든 서브도메인이 세션 쿠키를 받게 되어,
+ * 서브도메인 하나가 침해되면 SSO 세션 전체가 넘어간다.
+ */
+object IdpSessionCookieFactory {
+    fun issued(
+        oauthEnvironment: OauthEnvironment,
+        sessionId: String,
+    ): ResponseCookie =
+        baseBuilder(oauthEnvironment, sessionId)
+            .maxAge(Duration.ofSeconds(oauthEnvironment.idpSessionExpirationSeconds))
+            .build()
+
+    fun expired(oauthEnvironment: OauthEnvironment): ResponseCookie =
+        baseBuilder(oauthEnvironment, "")
+            .maxAge(Duration.ZERO)
+            .build()
+
+    private fun baseBuilder(
+        oauthEnvironment: OauthEnvironment,
+        value: String,
+    ): ResponseCookie.ResponseCookieBuilder =
+        ResponseCookie
+            .from(oauthEnvironment.idpSessionCookieName, value)
+            .httpOnly(true)
+            .secure(oauthEnvironment.idpSessionCookieSecure)
+            .sameSite("Lax")
+            .path("/")
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/service/impl/ModifyPasswordServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/service/impl/ModifyPasswordServiceImpl.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import team.themoment.datagsm.common.domain.account.dto.request.ChangePasswordReqDto
 import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
 import team.themoment.datagsm.common.domain.account.repository.PasswordResetCodeRedisRepository
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthRefreshTokenRedisRepository
 import team.themoment.datagsm.oauth.authorization.domain.account.service.ModifyPasswordService
 import team.themoment.datagsm.oauth.authorization.global.security.annotation.PasswordResetRateLimitType
@@ -18,6 +19,7 @@ class ModifyPasswordServiceImpl(
     private val accountJpaRepository: AccountJpaRepository,
     private val passwordEncoder: PasswordEncoder,
     private val oauthRefreshTokenRedisRepository: OauthRefreshTokenRedisRepository,
+    private val idpSessionRedisRepository: IdpSessionRedisRepository,
 ) : ModifyPasswordService {
     @PasswordResetRateLimited(type = PasswordResetRateLimitType.MODIFY_PASSWORD)
     override fun execute(reqDto: ChangePasswordReqDto) {
@@ -50,5 +52,11 @@ class ModifyPasswordServiceImpl(
 
         val tokens = oauthRefreshTokenRedisRepository.findAllByEmail(reqDto.email)
         oauthRefreshTokenRedisRepository.deleteAll(tokens)
+
+        // 비밀번호를 바꾸는 이유는 계정 탈취 대응인 경우가 많다.
+        // IdP 세션이 살아 있으면 공격자가 기존 쿠키로 계속 새 인가를 받을 수 있으므로
+        // refresh token과 함께 세션도 전부 끊는다.
+        val sessions = idpSessionRedisRepository.findAllByEmail(reqDto.email)
+        idpSessionRedisRepository.deleteAll(sessions)
     }
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
@@ -29,6 +29,7 @@ import team.themoment.datagsm.common.domain.student.dto.response.StudentDataEdit
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteIdpSessionHandoffService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthAuthorizeFlowService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthConsentService
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.LogoutIdpSessionService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.Oauth2TokenService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryJwkSetService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryOauthSessionService
@@ -44,6 +45,7 @@ class OauthController(
     val completeOauthAuthorizeFlowService: CompleteOauthAuthorizeFlowService,
     val completeOauthConsentService: CompleteOauthConsentService,
     val completeIdpSessionHandoffService: CompleteIdpSessionHandoffService,
+    val logoutIdpSessionService: LogoutIdpSessionService,
     val queryOauthSessionService: QueryOauthSessionService,
     val queryJwkSetService: QueryJwkSetService,
     val queryStudentDataEditRequestService: QueryStudentDataEditRequestService,
@@ -133,6 +135,20 @@ class OauthController(
     fun queryStudentDataEditRequirements(
         @Valid @RequestBody reqDto: QueryStudentDataEditRequestReqDto,
     ): StudentDataEditRequestResDto = queryStudentDataEditRequestService.execute(reqDto)
+
+    @PostMapping("/logout")
+    @Operation(
+        summary = "IdP 세션 로그아웃",
+        description = "SSO 세션을 삭제하고 세션 쿠키를 만료시킵니다. 이미 발급된 access token은 만료 전까지 유효합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "로그아웃 완료 (세션이 없던 경우에도 동일)"),
+        ],
+    )
+    fun logout(
+        @CookieValue(name = "\${spring.security.oauth.idp-session-cookie-name}", required = false) sessionId: String?,
+    ): ResponseEntity<Void> = logoutIdpSessionService.execute(sessionId)
 
     @GetMapping("/sessions/{token}")
     @Operation(

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/LogoutIdpSessionService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/LogoutIdpSessionService.kt
@@ -1,0 +1,7 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import org.springframework.http.ResponseEntity
+
+interface LogoutIdpSessionService {
+    fun execute(sessionId: String?): ResponseEntity<Void>
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
@@ -3,7 +3,6 @@ package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,10 +12,10 @@ import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.common.global.security.util.IdpSessionCookieFactory
 import team.themoment.datagsm.common.global.security.util.OpaqueTokenHashUtil
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteIdpSessionHandoffService
 import java.net.URI
-import java.time.Duration
 
 @Service
 class CompleteIdpSessionHandoffServiceImpl(
@@ -62,23 +61,12 @@ class CompleteIdpSessionHandoffServiceImpl(
 
         return ResponseEntity
             .status(HttpStatus.FOUND)
-            .header(HttpHeaders.SET_COOKIE, buildSessionCookie(handoff.sessionId).toString())
-            .location(URI.create(handoff.redirectUrl))
+            .header(
+                HttpHeaders.SET_COOKIE,
+                IdpSessionCookieFactory.issued(oauthEnvironment, handoff.sessionId).toString(),
+            ).location(URI.create(handoff.redirectUrl))
             .build()
     }
-
-    // 세션 쿠키를 읽는 곳은 같은 호스트의 GET /v1/oauth/authorize 하나뿐이라 host-only로 충분하다.
-    // Domain을 상위 도메인으로 넓히면 모든 서브도메인이 요청마다 세션 쿠키를 받게 되어,
-    // 서브도메인 하나가 침해되면 SSO 세션 전체가 넘어간다.
-    private fun buildSessionCookie(sessionId: String): ResponseCookie =
-        ResponseCookie
-            .from(oauthEnvironment.idpSessionCookieName, sessionId)
-            .httpOnly(true)
-            .secure(oauthEnvironment.idpSessionCookieSecure)
-            .sameSite("Lax")
-            .path("/")
-            .maxAge(Duration.ofSeconds(oauthEnvironment.idpSessionExpirationSeconds))
-            .build()
 
     // 핸드오프 URL은 로그·Referer·브라우저 히스토리에 남기 때문에, 나중에 그 URL을 입수한
     // 공격자가 다시 열어보는 것을 막아야 한다. 정상 흐름은 프론트에서 백엔드로 넘어오는

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/LogoutIdpSessionServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/LogoutIdpSessionServiceImpl.kt
@@ -1,0 +1,31 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.common.global.security.util.IdpSessionCookieFactory
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.LogoutIdpSessionService
+
+@Service
+class LogoutIdpSessionServiceImpl(
+    private val idpSessionRedisRepository: IdpSessionRedisRepository,
+    private val oauthEnvironment: OauthEnvironment,
+) : LogoutIdpSessionService {
+    // 세션이 이미 없더라도 204로 응답한다. 존재 여부를 알려주면 쿠키 값만 가진 쪽에
+    // 유효한 세션인지 판별할 단서를 주게 되고, 사용자 입장에서도 결과는 동일하다.
+    override fun execute(sessionId: String?): ResponseEntity<Void> {
+        if (!sessionId.isNullOrBlank()) {
+            idpSessionRedisRepository.deleteById(sessionId)
+        }
+
+        return ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .header(
+                HttpHeaders.SET_COOKIE,
+                IdpSessionCookieFactory.expired(oauthEnvironment).toString(),
+            ).build()
+    }
+}

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/password/service/impl/ModifyPasswordServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/password/service/impl/ModifyPasswordServiceImplTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.springframework.security.crypto.password.PasswordEncoder
 import team.themoment.datagsm.common.domain.account.dto.request.ChangePasswordReqDto
@@ -12,7 +13,9 @@ import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.entity.PasswordResetCodeRedisEntity
 import team.themoment.datagsm.common.domain.account.repository.AccountJpaRepository
 import team.themoment.datagsm.common.domain.account.repository.PasswordResetCodeRedisRepository
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
 import team.themoment.datagsm.common.domain.oauth.entity.OauthRefreshTokenRedisEntity
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthRefreshTokenRedisRepository
 import team.themoment.datagsm.oauth.authorization.domain.account.service.impl.ModifyPasswordServiceImpl
 import team.themoment.sdk.exception.ExpectedException
@@ -24,6 +27,7 @@ class ModifyPasswordServiceImplTest :
         val accountJpaRepository = mockk<AccountJpaRepository>()
         val passwordEncoder = mockk<PasswordEncoder>()
         val oauthRefreshTokenRedisRepository = mockk<OauthRefreshTokenRedisRepository>(relaxed = true)
+        val idpSessionRedisRepository = mockk<IdpSessionRedisRepository>(relaxed = true)
 
         val service =
             ModifyPasswordServiceImpl(
@@ -31,6 +35,7 @@ class ModifyPasswordServiceImplTest :
                 accountJpaRepository,
                 passwordEncoder,
                 oauthRefreshTokenRedisRepository,
+                idpSessionRedisRepository,
             )
 
         Given("verified가 false일 때") {
@@ -193,6 +198,12 @@ class ModifyPasswordServiceImplTest :
             every { accountJpaRepository.save(any()) } returns account
             every { oauthRefreshTokenRedisRepository.findAllByEmail(email) } returns listOf(token1, token2)
             every { oauthRefreshTokenRedisRepository.deleteAll(any<Iterable<OauthRefreshTokenRedisEntity>>()) } returns Unit
+            every { idpSessionRedisRepository.findAllByEmail(email) } returns
+                listOf(
+                    IdpSessionRedisEntity("session-1", email, 28800),
+                    IdpSessionRedisEntity("session-2", email, 28800),
+                )
+            every { idpSessionRedisRepository.deleteAll(any<Iterable<IdpSessionRedisEntity>>()) } returns Unit
 
             When("새 비밀번호로 변경하면") {
                 service.execute(reqDto)
@@ -204,6 +215,12 @@ class ModifyPasswordServiceImplTest :
                     verify(exactly = 1) { oauthRefreshTokenRedisRepository.deleteAll(any<Iterable<OauthRefreshTokenRedisEntity>>()) }
                     verify(exactly = 1) { passwordEncoder.encode(newPassword) }
                     verify(exactly = 1) { passwordEncoder.matches(newPassword, "hashedOldPassword") }
+                }
+
+                Then("탈취된 쿠키로 인가가 이어지지 않도록 IdP 세션이 전부 삭제된다") {
+                    val deletedSlot = slot<Iterable<IdpSessionRedisEntity>>()
+                    verify(exactly = 1) { idpSessionRedisRepository.deleteAll(capture(deletedSlot)) }
+                    deletedSlot.captured.map { it.sessionId } shouldBe listOf("session-1", "session-2")
                 }
             }
         }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/LogoutIdpSessionServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/LogoutIdpSessionServiceTest.kt
@@ -1,0 +1,109 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.LogoutIdpSessionServiceImpl
+
+class LogoutIdpSessionServiceTest :
+    DescribeSpec({
+
+        val mockIdpSessionRedisRepository = mockk<IdpSessionRedisRepository>(relaxed = true)
+        val mockOauthEnvironment = mockk<OauthEnvironment>()
+
+        val logoutIdpSessionService =
+            LogoutIdpSessionServiceImpl(
+                mockIdpSessionRedisRepository,
+                mockOauthEnvironment,
+            )
+
+        afterEach {
+            clearAllMocks()
+        }
+
+        describe("LogoutIdpSessionService 클래스의") {
+            describe("execute 메서드는") {
+
+                val testSessionId = "session-1"
+
+                beforeEach {
+                    every { mockOauthEnvironment.idpSessionCookieName } returns "datagsm_idp_session"
+                    every { mockOauthEnvironment.idpSessionCookieSecure } returns true
+                    every { mockOauthEnvironment.idpSessionExpirationSeconds } returns 28800L
+                }
+
+                context("유효한 세션 쿠키가 주어졌을 때") {
+                    it("세션을 삭제하고 204를 반환해야 한다") {
+                        val response = logoutIdpSessionService.execute(testSessionId)
+
+                        response.statusCode shouldBe HttpStatus.NO_CONTENT
+                        verify(exactly = 1) { mockIdpSessionRedisRepository.deleteById(testSessionId) }
+                    }
+
+                    it("쿠키를 즉시 만료시켜야 한다") {
+                        val response = logoutIdpSessionService.execute(testSessionId)
+
+                        val setCookie = response.headers.getFirst(HttpHeaders.SET_COOKIE) ?: ""
+                        setCookie shouldContain "datagsm_idp_session="
+                        setCookie shouldContain "Max-Age=0"
+                    }
+
+                    // 브라우저는 name/path/domain이 모두 일치해야 기존 쿠키를 덮어쓴다.
+                    // 발급 시 속성과 어긋나면 로그아웃이 조용히 실패한다.
+                    it("발급 시와 같은 속성으로 쿠키를 덮어써야 한다") {
+                        val response = logoutIdpSessionService.execute(testSessionId)
+
+                        val setCookie = response.headers.getFirst(HttpHeaders.SET_COOKIE) ?: ""
+                        // "Path=/" 부분 일치로 검사하면 Path=/v1 같은 불일치도 통과하므로
+                        // 속성 단위로 잘라 정확히 비교한다.
+                        val attributes = setCookie.split("; ").map { it.trim() }
+                        attributes.contains("Path=/") shouldBe true
+                        setCookie shouldContain "HttpOnly"
+                        setCookie shouldContain "Secure"
+                        setCookie shouldContain "SameSite=Lax"
+                    }
+                }
+
+                context("세션 쿠키가 없을 때") {
+                    it("세션 존재 여부를 노출하지 않도록 동일하게 204를 반환해야 한다") {
+                        val response = logoutIdpSessionService.execute(null)
+
+                        response.statusCode shouldBe HttpStatus.NO_CONTENT
+                        verify(exactly = 0) { mockIdpSessionRedisRepository.deleteById(any()) }
+                    }
+
+                    it("잔여 쿠키가 남지 않도록 만료 쿠키는 내려줘야 한다") {
+                        val response = logoutIdpSessionService.execute(null)
+
+                        (response.headers.getFirst(HttpHeaders.SET_COOKIE) ?: "") shouldContain "Max-Age=0"
+                    }
+                }
+
+                context("빈 문자열 쿠키가 주어졌을 때") {
+                    it("삭제를 시도하지 않아야 한다") {
+                        logoutIdpSessionService.execute("")
+
+                        verify(exactly = 0) { mockIdpSessionRedisRepository.deleteById(any()) }
+                    }
+                }
+
+                context("HTTP 로컬 환경일 때") {
+                    it("Secure 속성 없이 쿠키를 만료시켜야 한다") {
+                        every { mockOauthEnvironment.idpSessionCookieSecure } returns false
+
+                        val response = logoutIdpSessionService.execute(testSessionId)
+
+                        (response.headers.getFirst(HttpHeaders.SET_COOKIE) ?: "").contains("Secure") shouldBe false
+                    }
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## 개요

SSO 로드맵 **우선순위 2 — 로그아웃 및 전파**의 최소 구현과, **우선순위 5에서 떼어낸 "비밀번호 변경 시 세션 무효화"** 를 함께 처리합니다. 로드맵이 이 둘을 묶어 권장한 항목입니다.

> 스택 PR입니다. base는 #436입니다.

## 본문

### 왜 필요한가

**로그아웃 기능이 아예 없었습니다.** 세션 쿠키가 만료(기본 8시간)될 때까지 유지되어 공용 PC에서 특히 위험합니다.

그리고 **비밀번호를 바꿔도 기존 IdP 세션이 그대로 살아있었습니다.** 비밀번호 변경은 계정 탈취 대응인 경우가 많은데, 세션이 남아 있으면 공격자가 기존 쿠키로 계속 새 인가를 받을 수 있습니다. 기존 코드는 refresh token만 지우고 있었습니다.

### 변경 내용

**1. `POST /v1/oauth/logout`**

세션을 삭제하고 쿠키를 즉시 만료시킵니다. 세션이 이미 없어도 동일하게 204를 반환합니다 — 존재 여부를 알려주면 쿠키 값만 가진 쪽에 유효한 세션인지 판별할 단서를 주게 되고, 사용자 입장에서 결과는 어차피 같습니다.

**2. `IdpSessionCookieFactory` 도입**

브라우저는 `name`/`path`/`domain`이 모두 일치해야 기존 쿠키를 덮어씁니다. 발급과 만료를 각각 따로 조립하면 **속성이 어긋나는 순간 로그아웃이 조용히 실패**하므로, 두 형태를 같은 자리에서 만들도록 모았습니다.

**3. 비밀번호 변경 시 세션 전체 삭제**

역방향 조회를 위해 `IdpSessionRedisEntity.email`에 `@Indexed`를 추가했습니다. 같은 모듈의 `OauthRefreshTokenRedisEntity`가 이미 쓰는 방식과 동일합니다.

### 검증

- 신규 테스트 8건 포함 **153건 통과**, `ktlintCheck build` 통과
- 뮤테이션 테스트:
  - 세션 무효화 제거 → 1건 실패
  - 만료 쿠키 `Max-Age=0` 제거 → 2건 실패
  - 만료 쿠키 `Path` 불일치 → 1건 실패

> `Path` 검증은 처음에 `shouldContain "Path=/"` 로 짰다가 뮤테이션이 **살아남는 것**을 보고 고쳤습니다. `Path=/v1`도 그 부분 문자열을 포함해 통과해버려서, 속성 단위로 잘라 정확 비교하도록 바꿨습니다.

### 알려진 한계

이미 발급된 access token은 만료 전까지 유효하므로, 각 SP는 자기 토큰이 만료될 때까지(기본 1시간) 로그인 상태로 보입니다. 완전한 전파(back-channel logout)는 SP별 `backchannel_logout_uri` 등록이 필요해 SP가 여러 개로 늘어난 뒤 판단하는 것이 낫다고 보고 별도 과제로 남겼습니다.

절충안으로 access token 만료를 15~30분으로 줄이면 로그아웃 후 그 시간 내에 모든 SP가 자연스럽게 수렴합니다(`OAUTH_ACCESS_TOKEN_EXPIRATION`).

### 프론트엔드 필요 작업

- 로그아웃 버튼 → `POST /v1/oauth/logout` (쿠키가 실려야 하므로 credentials 포함)