### PR TITLE
[oauth] id_token 발급 및 OIDC Discovery 문서

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/constant/OAuthScope.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/client/entity/constant/OAuthScope.kt
@@ -20,6 +20,13 @@ class OAuthScope(
     override fun hashCode(): Int = scope.hashCode()
 
     companion object {
+        /**
+         * OIDC 표준 scope. 다른 scope와 달리 applicationId 접두어가 없고
+         * tb_oauth_scope에도 존재하지 않는다. 권한을 부여하는 값이 아니라
+         * "id_token을 함께 발급하라"는 프로토콜 지시자이므로 별도로 취급한다.
+         */
+        const val OPENID = "openid"
+
         const val ACCOUNT_READ = "account_read"
         const val STUDENT_READ = "student_read"
         const val SELF_READ = "self_read"

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/request/OauthAuthorizeReqDto.kt
@@ -35,4 +35,10 @@ data class OauthAuthorizeReqDto(
         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
     )
     val scope: String? = null,
+    @param:Schema(
+        description = "OIDC nonce (replay 방지). openid scope 요청 시 권장됩니다.",
+        example = "n-0S6_WzA2Mj",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val nonce: String? = null,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/response/Oauth2TokenResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/response/Oauth2TokenResDto.kt
@@ -19,4 +19,7 @@ data class Oauth2TokenResDto(
     @field:JsonProperty("scope")
     @field:Schema(description = "Granted scopes (space-separated)", example = "self:read self:write")
     val scope: String,
+    @field:JsonProperty("id_token")
+    @field:Schema(description = "ID Token (openid scope 요청 시에만 발급)", example = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...")
+    val idToken: String? = null,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/response/OidcDiscoveryResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/response/OidcDiscoveryResDto.kt
@@ -1,0 +1,45 @@
+package team.themoment.datagsm.common.domain.oauth.dto.response
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * OIDC Discovery 문서. SP가 issuer만 설정하면 나머지 엔드포인트를 스스로 찾게 해준다.
+ * 필드명은 OpenID Connect Discovery 1.0 규격이 정한 snake_case를 그대로 따른다.
+ */
+data class OidcDiscoveryResDto(
+    @field:JsonProperty("issuer")
+    @field:Schema(description = "발급자 식별자")
+    val issuer: String,
+    @field:JsonProperty("authorization_endpoint")
+    @field:Schema(description = "인가 엔드포인트")
+    val authorizationEndpoint: String,
+    @field:JsonProperty("token_endpoint")
+    @field:Schema(description = "토큰 엔드포인트")
+    val tokenEndpoint: String,
+    @field:JsonProperty("jwks_uri")
+    @field:Schema(description = "JWK Set 엔드포인트")
+    val jwksUri: String,
+    @field:JsonProperty("userinfo_endpoint")
+    @field:Schema(description = "UserInfo 엔드포인트")
+    val userinfoEndpoint: String,
+    @field:JsonProperty("end_session_endpoint")
+    @field:Schema(description = "로그아웃 엔드포인트")
+    val endSessionEndpoint: String,
+    @field:JsonProperty("response_types_supported")
+    val responseTypesSupported: List<String>,
+    @field:JsonProperty("grant_types_supported")
+    val grantTypesSupported: List<String>,
+    @field:JsonProperty("subject_types_supported")
+    val subjectTypesSupported: List<String>,
+    @field:JsonProperty("id_token_signing_alg_values_supported")
+    val idTokenSigningAlgValuesSupported: List<String>,
+    @field:JsonProperty("code_challenge_methods_supported")
+    val codeChallengeMethodsSupported: List<String>,
+    @field:JsonProperty("scopes_supported")
+    val scopesSupported: List<String>,
+    @field:JsonProperty("token_endpoint_auth_methods_supported")
+    val tokenEndpointAuthMethodsSupported: List<String>,
+    @field:JsonProperty("claims_supported")
+    val claimsSupported: List<String>,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthAuthorizeStateRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthAuthorizeStateRedisEntity.kt
@@ -14,6 +14,7 @@ data class OauthAuthorizeStateRedisEntity(
     val codeChallenge: String?,
     val codeChallengeMethod: String?,
     val scopes: Set<String>,
+    val nonce: String? = null,
     @TimeToLive
     val ttl: Long = 600,
 )

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthCodeRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/OauthCodeRedisEntity.kt
@@ -12,6 +12,8 @@ data class OauthCodeRedisEntity(
     val codeChallenge: String?,
     val codeChallengeMethod: String?,
     val scopes: Set<String>,
+    // OIDC replay 방지 값. authorize에서 받아 id_token 클레임으로 그대로 되돌려준다.
+    val nonce: String? = null,
     @Id
     val code: String,
     @TimeToLive

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/OauthConsentJpaRepository.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/repository/OauthConsentJpaRepository.kt
@@ -1,6 +1,9 @@
 package team.themoment.datagsm.common.domain.oauth.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
 import java.util.Optional
 
@@ -9,4 +12,62 @@ interface OauthConsentJpaRepository : JpaRepository<OauthConsentJpaEntity, Long>
         accountId: Long,
         clientId: String,
     ): Optional<OauthConsentJpaEntity>
+
+    /**
+     * 동의 기록 행을 upsert하고 그 id를 확보한다.
+     *
+     * 같은 (account, client)로 첫 로그인이 동시에 들어오면 양쪽이 insert를 시도해
+     * uk_oauth_consent_account_client 위반이 난다. 애플리케이션에서 조회 후 분기하면
+     * 두 요청이 같은 순간 "없음"을 보고 둘 다 insert하는 창이 남으므로, DB가 원자적으로
+     * 판단하도록 맡긴다.
+     *
+     * 중복 시 갱신할 값이 따로 없어 updated_at만 건드린다. 이 구문은 행이 반드시
+     * 존재하도록 보장하는 것이 목적이고, id는 이어지는 findIdByAccountIdAndClientId로 읽는다.
+     */
+    @Modifying
+    @Query(
+        value =
+            "INSERT INTO tb_oauth_consent (account_id, client_id, updated_at) " +
+                "VALUES (:accountId, :clientId, NOW()) " +
+                "ON DUPLICATE KEY UPDATE updated_at = VALUES(updated_at)",
+        nativeQuery = true,
+    )
+    fun upsertConsent(
+        @Param("accountId") accountId: Long,
+        @Param("clientId") clientId: String,
+    )
+
+    /**
+     * upsert 직후 행의 id를 읽는다.
+     *
+     * 네이티브 쿼리라 영속성 컨텍스트의 1차 캐시나 REPEATABLE READ 스냅샷이 아니라
+     * upsert가 방금 확정한 행을 그대로 본다.
+     */
+    @Query(
+        value = "SELECT id FROM tb_oauth_consent WHERE account_id = :accountId AND client_id = :clientId",
+        nativeQuery = true,
+    )
+    fun findIdByAccountIdAndClientId(
+        @Param("accountId") accountId: Long,
+        @Param("clientId") clientId: String,
+    ): Long?
+
+    /**
+     * scope를 추가한다. 이미 있는 scope는 무시한다.
+     *
+     * tb_oauth_consent_scope에는 유니크 제약이 없어 INSERT IGNORE로는 중복이 쌓이므로,
+     * 존재하지 않을 때만 넣도록 NOT EXISTS로 거른다.
+     */
+    @Modifying
+    @Query(
+        value =
+            "INSERT INTO tb_oauth_consent_scope (consent_id, scope) " +
+                "SELECT :consentId, :scope FROM DUAL WHERE NOT EXISTS (" +
+                "SELECT 1 FROM tb_oauth_consent_scope WHERE consent_id = :consentId AND scope = :scope)",
+        nativeQuery = true,
+    )
+    fun addScopeIfAbsent(
+        @Param("consentId") consentId: Long,
+        @Param("scope") scope: String,
+    )
 }

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/data/OauthEnvironment.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/global/data/OauthEnvironment.kt
@@ -8,6 +8,8 @@ data class OauthEnvironment(
     val frontendUrl: String,
     val authorizeStateExpirationMs: Long,
     val issuerUrl: String,
+    // UserInfo는 별도 모듈(datagsm-oauth-userinfo)의 다른 호스트라 issuerUrl에서 유도할 수 없다.
+    val userinfoUrl: String,
     val idpSessionExpirationSeconds: Long,
     val idpSessionHandoffExpirationSeconds: Long,
     val idpSessionCookieName: String,

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OidcDiscoveryController.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OidcDiscoveryController.kt
@@ -1,0 +1,32 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import team.themoment.datagsm.common.domain.oauth.dto.response.OidcDiscoveryResDto
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryOidcDiscoveryService
+
+/**
+ * OIDC Discovery는 경로가 규격으로 고정되어 있어 /v1 하위에 둘 수 없다.
+ * CommonApiResponse 래핑도 하지 않는다 (application.yml의 not-wrapping-urls 참고).
+ */
+@Tag(name = "OIDC", description = "OpenID Connect Discovery")
+@RestController
+class OidcDiscoveryController(
+    val queryOidcDiscoveryService: QueryOidcDiscoveryService,
+) {
+    @GetMapping("/.well-known/openid-configuration")
+    @Operation(
+        summary = "OIDC Discovery 문서 조회",
+        description = "SP가 issuer만 설정하면 나머지 엔드포인트를 자동으로 찾을 수 있도록 메타데이터를 반환합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "조회 성공"),
+        ],
+    )
+    fun getOidcDiscovery(): OidcDiscoveryResDto = queryOidcDiscoveryService.execute()
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/IssueAuthorizationCodeService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/IssueAuthorizationCodeService.kt
@@ -9,5 +9,6 @@ interface IssueAuthorizationCodeService {
         codeChallenge: String?,
         codeChallengeMethod: String?,
         scopes: Set<String>,
+        nonce: String? = null,
     ): String
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOidcDiscoveryService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOidcDiscoveryService.kt
@@ -1,0 +1,7 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import team.themoment.datagsm.common.domain.oauth.dto.response.OidcDiscoveryResDto
+
+interface QueryOidcDiscoveryService {
+    fun execute(): OidcDiscoveryResDto
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
@@ -115,6 +115,7 @@ class CompleteOauthAuthorizeFlowServiceImpl(
                 codeChallenge = codeChallenge,
                 codeChallengeMethod = codeChallengeMethod,
                 scopes = scopes,
+                nonce = stateEntity.nonce,
             )
 
         oauthAuthorizeStateRedisRepository.deleteById(reqDto.token)

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
@@ -1,7 +1,6 @@
 package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
 
 import org.springframework.context.ApplicationEventPublisher
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -20,7 +19,6 @@ import team.themoment.datagsm.common.domain.event.entity.constant.EventType
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeSubmitReqDto
 import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionHandoffRedisEntity
 import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
-import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionHandoffRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
@@ -38,7 +36,6 @@ import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteO
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.datagsm.oauth.authorization.global.security.service.OAuthClientRateLimitService
 import team.themoment.sdk.exception.ExpectedException
-import team.themoment.sdk.logging.logger.logger
 import java.net.URI
 import java.security.SecureRandom
 import java.util.Base64
@@ -170,33 +167,30 @@ class CompleteOauthAuthorizeFlowServiceImpl(
             .toUriString()
     }
 
-    // 같은 (account, client)로 첫 로그인이 동시에 들어오면 양쪽 다 insert를 시도해
-    // uk_oauth_consent_account_client 위반이 난다. 이 시점에는 code와 세션이 이미
-    // Redis에 저장돼 롤백되지 않으므로, 제약 위반은 재조회 후 병합으로 흡수한다.
+    // 동의 기록은 DB의 원자적 upsert에 맡긴다.
+    //
+    // 조회 후 없으면 insert하는 방식은 같은 (account, client)로 첫 로그인이 동시에
+    // 들어올 때 둘 다 "없음"을 보고 insert해 uk_oauth_consent_account_client 위반이 난다.
+    // 제약 위반을 잡아 같은 트랜잭션에서 재시도하는 것도 답이 아니다. flush 중 제약 위반이
+    // 나면 영속성 컨텍스트를 더 이상 신뢰할 수 없고, REPEATABLE READ에서는 재조회가 다른
+    // 트랜잭션이 방금 커밋한 행을 보지 못해 같은 예외를 다시 던질 수 있다.
+    //
+    // 이 자리에서 실패하면 특히 곤란하다. 인가 코드와 세션은 이미 Redis에 저장돼
+    // 롤백되지 않으므로, 사용자는 500을 받는데 코드만 남는 상태가 된다.
     private fun recordConsent(
         accountId: Long,
         clientId: String,
         scopes: Set<String>,
     ) {
-        try {
-            saveConsent(accountId, clientId, scopes)
-        } catch (e: DataIntegrityViolationException) {
-            logger().warn("Retrying consent record after unique constraint violation for clientId {}", clientId, e)
-            saveConsent(accountId, clientId, scopes)
-        }
-    }
+        oauthConsentJpaRepository.upsertConsent(accountId, clientId)
 
-    private fun saveConsent(
-        accountId: Long,
-        clientId: String,
-        scopes: Set<String>,
-    ) {
-        val consent =
-            oauthConsentJpaRepository
-                .findByAccountIdAndClientId(accountId, clientId)
-                .orElseGet { OauthConsentJpaEntity.create(accountId, clientId, emptySet()) }
-        consent.grantedScopes.addAll(scopes)
-        oauthConsentJpaRepository.saveAndFlush(consent)
+        val consentId =
+            oauthConsentJpaRepository.findIdByAccountIdAndClientId(accountId, clientId)
+                ?: throw ExpectedException("동의 정보를 저장하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
+
+        scopes.forEach { scope ->
+            oauthConsentJpaRepository.addScopeIfAbsent(consentId, scope)
+        }
     }
 
     private fun resolveStudentDataEditRequestIfNeeded(

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthConsentServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthConsentServiceImpl.kt
@@ -1,6 +1,5 @@
 package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
 
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -8,7 +7,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthConsentReqDto
 import team.themoment.datagsm.common.domain.oauth.entity.OauthAuthorizeStateRedisEntity
-import team.themoment.datagsm.common.domain.oauth.entity.OauthConsentJpaEntity
 import team.themoment.datagsm.common.domain.oauth.exception.OAuthException
 import team.themoment.datagsm.common.domain.oauth.repository.OauthAuthorizeStateRedisRepository
 import team.themoment.datagsm.common.domain.oauth.repository.OauthConsentJpaRepository
@@ -16,7 +14,6 @@ import team.themoment.datagsm.oauth.authorization.domain.oauth.component.IdpSess
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthConsentService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.IssueAuthorizationCodeService
 import team.themoment.sdk.exception.ExpectedException
-import team.themoment.sdk.logging.logger.logger
 import java.net.URI
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -96,32 +93,30 @@ class CompleteOauthConsentServiceImpl(
             .build()
     }
 
-    // 동시 요청으로 같은 (account, client) 행을 함께 insert하면 제약 위반이 난다.
-    // 이 시점에는 code가 이미 Redis에 저장돼 롤백되지 않으므로 재조회 후 병합으로 흡수한다.
+    // 동의 기록은 DB의 원자적 upsert에 맡긴다.
+    //
+    // 조회 후 없으면 insert하는 방식은 같은 (account, client)로 첫 로그인이 동시에
+    // 들어올 때 둘 다 "없음"을 보고 insert해 uk_oauth_consent_account_client 위반이 난다.
+    // 제약 위반을 잡아 같은 트랜잭션에서 재시도하는 것도 답이 아니다. flush 중 제약 위반이
+    // 나면 영속성 컨텍스트를 더 이상 신뢰할 수 없고, REPEATABLE READ에서는 재조회가 다른
+    // 트랜잭션이 방금 커밋한 행을 보지 못해 같은 예외를 다시 던질 수 있다.
+    //
+    // 이 자리에서 실패하면 특히 곤란하다. 인가 코드는 이미 Redis에 저장돼 롤백되지 않으므로,
+    // 사용자는 500을 받는데 코드만 남는 상태가 된다.
     private fun recordConsent(
         accountId: Long,
         clientId: String,
         scopes: Set<String>,
     ) {
-        try {
-            saveConsent(accountId, clientId, scopes)
-        } catch (e: DataIntegrityViolationException) {
-            logger().warn("Retrying consent record after unique constraint violation for clientId {}", clientId, e)
-            saveConsent(accountId, clientId, scopes)
-        }
-    }
+        oauthConsentJpaRepository.upsertConsent(accountId, clientId)
 
-    private fun saveConsent(
-        accountId: Long,
-        clientId: String,
-        scopes: Set<String>,
-    ) {
-        val consent =
-            oauthConsentJpaRepository
-                .findByAccountIdAndClientId(accountId, clientId)
-                .orElseGet { OauthConsentJpaEntity.create(accountId, clientId, emptySet()) }
-        consent.grantedScopes.addAll(scopes)
-        oauthConsentJpaRepository.saveAndFlush(consent)
+        val consentId =
+            oauthConsentJpaRepository.findIdByAccountIdAndClientId(accountId, clientId)
+                ?: throw ExpectedException("동의 정보를 저장하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
+
+        scopes.forEach { scope ->
+            oauthConsentJpaRepository.addScopeIfAbsent(consentId, scope)
+        }
     }
 
     private fun encodeQueryValue(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8)

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthConsentServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthConsentServiceImpl.kt
@@ -62,6 +62,7 @@ class CompleteOauthConsentServiceImpl(
                 codeChallenge = stateEntity.codeChallenge,
                 codeChallengeMethod = stateEntity.codeChallengeMethod,
                 scopes = stateEntity.scopes,
+                nonce = stateEntity.nonce,
             )
 
         oauthAuthorizeStateRedisRepository.deleteById(reqDto.token)

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/IssueAuthorizationCodeServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/IssueAuthorizationCodeServiceImpl.kt
@@ -31,6 +31,7 @@ class IssueAuthorizationCodeServiceImpl(
         codeChallenge: String?,
         codeChallengeMethod: String?,
         scopes: Set<String>,
+        nonce: String?,
     ): String {
         // 코드 발급은 SSO(GET)와 로그인(POST) 양쪽에서 일어난다.
         // 한도를 발급 지점에 두어야 두 경로가 같은 정책을 따른다.
@@ -49,6 +50,7 @@ class IssueAuthorizationCodeServiceImpl(
                 codeChallenge = codeChallenge,
                 codeChallengeMethod = codeChallengeMethod,
                 scopes = scopes,
+                nonce = nonce,
                 code = code,
                 ttl = oauthEnvironment.codeExpirationSeconds,
             ),

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
@@ -126,6 +126,14 @@ class Oauth2TokenServiceImpl(
         val accessToken = jwtProvider.generateOauthAccessToken(account.email, account.role, client.id, grantedScopes)
         val refreshToken = jwtProvider.generateOauthRefreshToken(account.email, client.id)
 
+        val idToken =
+            if (OAuthScope.OPENID in scopesToGrant) {
+                val accountId = requireNotNull(account.id) { "Persisted account must have an id" }
+                jwtProvider.generateIdToken(accountId, account.email, client.id, oauthCode.nonce)
+            } else {
+                null
+            }
+
         saveRefreshToken(account.email, client.id, refreshToken, scopesToGrant)
         oauthCodeRedisRepository.delete(oauthCode)
 
@@ -134,7 +142,8 @@ class Oauth2TokenServiceImpl(
             tokenType = "Bearer",
             expiresIn = jwtEnvironment.accessTokenExpiration / 1000,
             refreshToken = refreshToken,
-            scope = grantedScopes.joinToString(" ") { it.scope },
+            scope = formatScopes(grantedScopes, scopesToGrant),
+            idToken = idToken,
         )
     }
 
@@ -202,7 +211,7 @@ class Oauth2TokenServiceImpl(
             tokenType = "Bearer",
             expiresIn = jwtEnvironment.accessTokenExpiration / 1000,
             refreshToken = newRefreshToken,
-            scope = grantedScopes.joinToString(" ") { it.scope },
+            scope = formatScopes(grantedScopes, scopesToGrant),
         )
     }
 
@@ -258,14 +267,29 @@ class Oauth2TokenServiceImpl(
         return stringsToScopes(scopesToGrant)
     }
 
+    // openid는 tb_oauth_scope에 없는 프로토콜 지시자라 DB 조회 대상에서 뺀다.
+    // 넣은 채로 조회하면 "권한 데이터가 잘못되었습니다" 500이 난다.
+    // 응답 scope에는 openid도 그대로 되돌려준다. SP가 요청한 scope가
+    // 부여됐는지 확인하는 근거이기 때문이다.
+    private fun formatScopes(
+        grantedScopes: Set<OAuthScope>,
+        requestedScopes: Set<String>,
+    ): String {
+        val scopeNames = grantedScopes.map { it.scope }
+        val withOpenid =
+            if (OAuthScope.OPENID in requestedScopes) listOf(OAuthScope.OPENID) + scopeNames else scopeNames
+        return withOpenid.joinToString(" ")
+    }
+
     private fun stringsToScopes(strings: Set<String>): Set<OAuthScope> {
-        val appIds = strings.map { it.substringBefore(':') }.toSet()
+        val permissionScopes = strings - OAuthScope.OPENID
+        val appIds = permissionScopes.map { it.substringBefore(':') }.toSet()
         val fetched =
             oauthScopeJpaRepository
                 .findAllByApplicationIdIn(appIds)
                 .associateBy { "${it.application.id}:${it.scopeName}" }
 
-        return strings
+        return permissionScopes
             .map { scopeStr ->
                 val entity = fetched[scopeStr]
                 if (entity == null) {

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImpl.kt
@@ -128,8 +128,7 @@ class Oauth2TokenServiceImpl(
 
         val idToken =
             if (OAuthScope.OPENID in scopesToGrant) {
-                val accountId = requireNotNull(account.id) { "Persisted account must have an id" }
-                jwtProvider.generateIdToken(accountId, account.email, client.id, oauthCode.nonce)
+                jwtProvider.generateIdToken(account.email, client.id, oauthCode.nonce)
             } else {
                 null
             }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryOidcDiscoveryServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryOidcDiscoveryServiceImpl.kt
@@ -1,0 +1,54 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
+
+import org.springframework.stereotype.Service
+import team.themoment.datagsm.common.domain.client.entity.constant.OAuthScope
+import team.themoment.datagsm.common.domain.oauth.dto.response.OidcDiscoveryResDto
+import team.themoment.datagsm.common.domain.oauth.entity.constant.GrantType
+import team.themoment.datagsm.common.domain.oauth.entity.constant.PkceChallengeMethod
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryOidcDiscoveryService
+import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
+
+@Service
+class QueryOidcDiscoveryServiceImpl(
+    private val oauthEnvironment: OauthEnvironment,
+    private val jwtEnvironment: OauthJwtProvisionEnvironment,
+) : QueryOidcDiscoveryService {
+    companion object {
+        private const val SIGNING_ALGORITHM = "RS256"
+
+        // sub는 모든 클라이언트에 같은 account.id를 내려주므로 public이다.
+        private const val SUBJECT_TYPE_PUBLIC = "public"
+    }
+
+    // 지원 목록은 실제 구현에서 끌어온다. 손으로 적으면 grant_type이나 PKCE 방식이
+    // 늘거나 줄었을 때 문서만 남아 SP가 지원하지 않는 값을 쓰게 된다.
+    override fun execute(): OidcDiscoveryResDto {
+        val issuer = oauthEnvironment.issuerUrl.trimEnd('/')
+        val applicationId = jwtEnvironment.datagsmApplicationId
+
+        return OidcDiscoveryResDto(
+            issuer = issuer,
+            authorizationEndpoint = "$issuer/v1/oauth/authorize",
+            tokenEndpoint = "$issuer/v1/oauth/token",
+            jwksUri = "$issuer/v1/oauth/jwks",
+            userinfoEndpoint = oauthEnvironment.userinfoUrl,
+            endSessionEndpoint = "$issuer/v1/oauth/logout",
+            responseTypesSupported = listOf("code"),
+            grantTypesSupported = GrantType.entries.map { it.value },
+            subjectTypesSupported = listOf(SUBJECT_TYPE_PUBLIC),
+            idTokenSigningAlgValuesSupported = listOf(SIGNING_ALGORITHM),
+            codeChallengeMethodsSupported = PkceChallengeMethod.entries.map { it.value },
+            scopesSupported =
+                listOf(
+                    OAuthScope.OPENID,
+                    "$applicationId:${OAuthScope.ACCOUNT_READ}",
+                    "$applicationId:${OAuthScope.STUDENT_READ}",
+                    "$applicationId:${OAuthScope.CLUB_READ}",
+                    "$applicationId:${OAuthScope.PROJECT_READ}",
+                ),
+            tokenEndpointAuthMethodsSupported = listOf("client_secret_post", "none"),
+            claimsSupported = listOf("iss", "sub", "aud", "exp", "iat", "nonce", "email"),
+        )
+    }
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/StartOauthAuthorizeFlowServiceImpl.kt
@@ -85,6 +85,7 @@ class StartOauthAuthorizeFlowServiceImpl(
                     codeChallenge = codeChallenge,
                     codeChallengeMethod = codeChallengeMethod,
                     scopes = resolvedScopes,
+                    nonce = reqDto.nonce,
                 )
             return ResponseEntity
                 .status(HttpStatus.FOUND)
@@ -103,6 +104,7 @@ class StartOauthAuthorizeFlowServiceImpl(
                 codeChallenge = codeChallenge,
                 codeChallengeMethod = codeChallengeMethod,
                 scopes = resolvedScopes,
+                nonce = reqDto.nonce,
                 ttl = oauthEnvironment.authorizeStateExpirationMs / 1000,
             )
 
@@ -142,16 +144,26 @@ class StartOauthAuthorizeFlowServiceImpl(
         return consent.grantedScopes.containsAll(resolvedScopes)
     }
 
+    // openid는 권한이 아니라 "id_token을 함께 달라"는 OIDC 프로토콜 지시자다.
+    // tb_oauth_scope에도 client 등록 scope에도 없으므로 허용 검사에서 제외하고,
+    // 요청에 있었다면 그대로 통과시킨다.
     private fun resolveScopes(
         requestedScopes: Set<String>?,
         clientScopes: Set<String>,
     ): Set<String> {
         if (requestedScopes == null) return defaultScopes(clientScopes)
-        val invalid = requestedScopes - clientScopes
+
+        val hasOpenid = OAuthScope.OPENID in requestedScopes
+        val permissionScopes = requestedScopes - OAuthScope.OPENID
+
+        val invalid = permissionScopes - clientScopes
         if (invalid.isNotEmpty()) {
             throw OAuthException.InvalidScope("클라이언트에 허용되지 않은 권한 범위가 포함되어 있습니다.")
         }
-        return requestedScopes
+
+        // openid만 요청한 경우에도 UserInfo 조회를 위한 기본 scope는 부여한다.
+        val resolved = permissionScopes.ifEmpty { defaultScopes(clientScopes) }
+        return if (hasOpenid) resolved + OAuthScope.OPENID else resolved
     }
 
     // scope 파라미터 미입력 시 client의 전체 허용 scope가 아닌 기본 UserInfo scope만 요청된 것으로 처리한다.

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/security/jwt/JwtProvider.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/security/jwt/JwtProvider.kt
@@ -57,13 +57,13 @@ class JwtProvider(
     /**
      * OIDC ID Token을 발급한다.
      *
-     * sub에는 email이 아닌 account.id를 넣는다. OIDC는 sub가 발급자 내에서
-     * 영구적이고 재사용되지 않는 값일 것을 요구하는데, email은 변경될 수 있어
-     * 바뀌는 순간 SP가 같은 사람을 다른 사용자로 인식하기 때문이다.
-     * access token의 sub는 기존 소비자와의 호환을 위해 email을 유지한다.
+     * sub에는 email을 넣는다. OIDC는 sub가 발급자 내에서 영구적이고 재사용되지
+     * 않는 값일 것을 요구하는데, 이 시스템의 계정 email은 학교 계정에 묶여
+     * 변경되지 않으므로 그 조건을 만족한다.
+     * access token과 /userinfo도 같은 값을 sub로 쓰고 있어, 세 곳의 식별자가
+     * 어긋나지 않는 편이 SP 연동에서도 혼란이 없다.
      */
     fun generateIdToken(
-        accountId: Long,
         email: String,
         clientId: String,
         nonce: String?,
@@ -77,7 +77,7 @@ class JwtProvider(
             .keyId(keyId)
             .and()
             .issuer(oauthEnvironment.issuerUrl)
-            .subject(accountId.toString())
+            .subject(email)
             .audience()
             .add(clientId)
             .and()

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/security/jwt/JwtProvider.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/global/security/jwt/JwtProvider.kt
@@ -7,6 +7,7 @@ import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Component
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountRole
 import team.themoment.datagsm.common.domain.client.entity.constant.OAuthScope
+import team.themoment.datagsm.common.global.data.OauthEnvironment
 import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
 import team.themoment.datagsm.oauth.authorization.global.security.authentication.OauthAuthenticationToken
 import team.themoment.datagsm.oauth.authorization.global.security.authentication.principal.OauthUserPrincipal
@@ -23,6 +24,7 @@ import java.util.Date
 @Component
 class JwtProvider(
     private val jwtEnvironment: OauthJwtProvisionEnvironment,
+    private val oauthEnvironment: OauthEnvironment,
 ) {
     private val privateKey: PrivateKey = loadPrivateKey(jwtEnvironment.privateKey)
     private val publicKey: PublicKey = loadPublicKey(jwtEnvironment.publicKey)
@@ -46,6 +48,41 @@ class JwtProvider(
             .claim("role", role.name)
             .claim("clientId", clientId)
             .claim("scopes", scopes.map { it.scope })
+            .issuedAt(now)
+            .expiration(expiration)
+            .signWith(privateKey, Jwts.SIG.RS256)
+            .compact()
+    }
+
+    /**
+     * OIDC ID Token을 발급한다.
+     *
+     * sub에는 email이 아닌 account.id를 넣는다. OIDC는 sub가 발급자 내에서
+     * 영구적이고 재사용되지 않는 값일 것을 요구하는데, email은 변경될 수 있어
+     * 바뀌는 순간 SP가 같은 사람을 다른 사용자로 인식하기 때문이다.
+     * access token의 sub는 기존 소비자와의 호환을 위해 email을 유지한다.
+     */
+    fun generateIdToken(
+        accountId: Long,
+        email: String,
+        clientId: String,
+        nonce: String?,
+    ): String {
+        val now = Date()
+        val expiration = Date(now.time + jwtEnvironment.accessTokenExpiration)
+
+        return Jwts
+            .builder()
+            .header()
+            .keyId(keyId)
+            .and()
+            .issuer(oauthEnvironment.issuerUrl)
+            .subject(accountId.toString())
+            .audience()
+            .add(clientId)
+            .and()
+            .claim("email", email)
+            .apply { nonce?.let { claim("nonce", it) } }
             .issuedAt(now)
             .expiration(expiration)
             .signWith(privateKey, Jwts.SIG.RS256)

--- a/datagsm-oauth-authorization/src/main/resources/application.yml
+++ b/datagsm-oauth-authorization/src/main/resources/application.yml
@@ -58,6 +58,7 @@ spring:
       frontend-url: ${OAUTH_FRONTEND_URL:http://localhost:3000}
       authorize-state-expiration-ms: ${OAUTH_AUTHORIZE_STATE_EXPIRATION_MS:600000}
       issuer-url: ${OAUTH_ISSUER_URL:http://localhost:8081}
+      userinfo-url: ${OAUTH_USERINFO_URL:http://localhost:8082/userinfo}
       idp-session-expiration-seconds: ${OAUTH_IDP_SESSION_EXPIRATION_SECONDS:28800}
       idp-session-handoff-expiration-seconds: ${OAUTH_IDP_SESSION_HANDOFF_EXPIRATION_SECONDS:60}
       idp-session-cookie-name: ${OAUTH_IDP_SESSION_COOKIE_NAME:datagsm_idp_session}
@@ -119,6 +120,7 @@ sdk:
       - "/v1/oauth/authorize/consent"
       - "/v1/oauth/token"
       - "/v1/oauth/jwks"
+      - "/.well-known/openid-configuration"
   swagger:
     enabled: true
     title: "DataGSM Authorization Server API"

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthAuthorizeFlowServiceTest.kt
@@ -12,7 +12,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.springframework.context.ApplicationEventPublisher
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.security.crypto.password.PasswordEncoder
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
@@ -143,8 +142,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         } returns issuedRedirectUrl
                         every { mockIdpSessionRedisRepository.save(capture(sessionSlot)) } answers { firstArg() }
                         every { mockIdpSessionHandoffRedisRepository.save(capture(handoffSlot)) } answers { firstArg() }
-                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(any(), any()) } returns Optional.empty()
-                        every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } answers { firstArg() }
+                        every { mockOauthConsentJpaRepository.findIdByAccountIdAndClientId(any(), any()) } returns 7L
                     }
 
                     it("세션 핸드오프 URL로 302 리다이렉트되어야 한다") {
@@ -211,28 +209,29 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         handoffSlot.captured.ttl shouldBe idpSessionHandoffExpirationSeconds
                     }
 
-                    it("동의 기록이 유니크 제약에 걸려도 재조회로 복구되어야 한다") {
-                        val existing = OauthConsentJpaEntity.create(1L, testClientId, setOf("other:scope"))
-                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(any(), any()) } returnsMany
-                            listOf(Optional.empty(), Optional.of(existing))
-                        every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } throws
-                            DataIntegrityViolationException("duplicate") andThen existing
-
+                    // 조회 후 insert는 동시 로그인 시 둘 다 "없음"을 보고 insert해 제약 위반이 난다.
+                    // 이 시점엔 code와 세션이 이미 Redis에 있어 롤백되지 않으므로,
+                    // 애플리케이션 재시도가 아니라 원자적 upsert로 처리한다.
+                    it("동의 기록은 조회 후 분기가 아닌 원자적 upsert로 저장되어야 한다") {
                         val response = completeOauthAuthorizeFlowService.execute(reqDto)
 
-                        // 동시 로그인으로 제약 위반이 나도 사용자에게 500이 나가지 않아야 한다.
                         response.statusCode shouldBe HttpStatus.FOUND
-                        existing.grantedScopes shouldBe mutableSetOf("other:scope", "self:read")
+                        verify(exactly = 1) { mockOauthConsentJpaRepository.upsertConsent(1L, testClientId) }
+                        verify(exactly = 0) {
+                            mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>())
+                        }
                     }
 
                     it("요청한 scope가 동의 기록으로 저장되어야 한다") {
-                        val consentSlot = slot<OauthConsentJpaEntity>()
-                        every { mockOauthConsentJpaRepository.saveAndFlush(capture(consentSlot)) } answers { firstArg() }
+                        val scopeSlot = mutableListOf<String>()
+                        every {
+                            mockOauthConsentJpaRepository.addScopeIfAbsent(7L, capture(scopeSlot))
+                        } returns Unit
 
                         completeOauthAuthorizeFlowService.execute(reqDto)
 
-                        consentSlot.captured.clientId shouldBe testClientId
-                        consentSlot.captured.grantedScopes shouldBe mutableSetOf("self:read")
+                        verify(exactly = 1) { mockOauthConsentJpaRepository.upsertConsent(1L, testClientId) }
+                        scopeSlot.toSet() shouldBe setOf("self:read")
                     }
 
                     it("Redis에서 인증 상태가 삭제되어야 한다") {
@@ -540,8 +539,7 @@ class CompleteOauthAuthorizeFlowServiceTest :
                         every {
                             mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
                         } returns "$testRedirectUri?code=test-code&state=random-state"
-                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(any(), any()) } returns Optional.empty()
-                        every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } answers { firstArg() }
+                        every { mockOauthConsentJpaRepository.findIdByAccountIdAndClientId(any(), any()) } returns 7L
                         every { mockIdpSessionRedisRepository.save(any<IdpSessionRedisEntity>()) } answers { firstArg() }
                         every {
                             mockIdpSessionHandoffRedisRepository.save(any<IdpSessionHandoffRedisEntity>())

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthConsentServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthConsentServiceTest.kt
@@ -8,9 +8,7 @@ import io.kotest.matchers.string.shouldStartWith
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
 import team.themoment.datagsm.common.domain.account.entity.constant.AccountObjectType
@@ -104,9 +102,7 @@ class CompleteOauthConsentServiceTest :
                     every { mockIdpSessionRedisRepository.findById(testSessionId) } returns
                         Optional.of(IdpSessionRedisEntity(testSessionId, testEmail, 28800))
                     every { mockAccountJpaRepository.findByEmail(testEmail) } returns Optional.of(activeAccount())
-                    every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returns
-                        Optional.empty()
-                    every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } answers { firstArg() }
+                    every { mockOauthConsentJpaRepository.findIdByAccountIdAndClientId(1L, testClientId) } returns 7L
                     every {
                         mockIssueAuthorizationCodeService.execute(any(), any(), any(), any(), any(), any(), any())
                     } returns issuedRedirectUrl
@@ -125,17 +121,18 @@ class CompleteOauthConsentServiceTest :
                     }
 
                     it("승인한 scope가 동의 기록으로 저장되어야 한다") {
-                        val consentSlot = slot<OauthConsentJpaEntity>()
-                        every { mockOauthConsentJpaRepository.saveAndFlush(capture(consentSlot)) } answers { firstArg() }
+                        val scopeSlot = mutableListOf<String>()
+                        every {
+                            mockOauthConsentJpaRepository.addScopeIfAbsent(7L, capture(scopeSlot))
+                        } returns Unit
 
                         completeOauthConsentService.execute(
                             OauthConsentReqDto(testToken, approved = true),
                             testSessionId,
                         )
 
-                        consentSlot.captured.accountId shouldBe 1L
-                        consentSlot.captured.clientId shouldBe testClientId
-                        consentSlot.captured.grantedScopes shouldBe testScopes
+                        verify(exactly = 1) { mockOauthConsentJpaRepository.upsertConsent(1L, testClientId) }
+                        scopeSlot.toSet() shouldBe testScopes
                     }
 
                     it("재사용되지 않도록 state 토큰을 소비해야 한다") {
@@ -290,22 +287,44 @@ class CompleteOauthConsentServiceTest :
                     }
                 }
 
-                context("동의 기록 저장이 유니크 제약에 걸렸을 때") {
-                    it("재조회 후 병합해 코드 발급이 실패하지 않아야 한다") {
-                        val existing = OauthConsentJpaEntity.create(1L, testClientId, setOf("datagsm:account_read"))
-                        every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returnsMany
-                            listOf(Optional.empty(), Optional.of(existing))
-                        every { mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>()) } throws
-                            DataIntegrityViolationException("duplicate") andThen existing
+                // 조회 후 insert 방식은 동시 요청 시 둘 다 "없음"을 보고 insert해 제약 위반이 난다.
+                // 원자적 upsert에 맡겨, 애플리케이션에서 제약 위반을 잡아 재시도하지 않는다.
+                context("동의 기록을 저장할 때") {
+                    it("조회 후 분기하지 않고 원자적 upsert를 써야 한다") {
+                        completeOauthConsentService.execute(
+                            OauthConsentReqDto(testToken, approved = true),
+                            testSessionId,
+                        )
 
-                        val response =
+                        verify(exactly = 1) { mockOauthConsentJpaRepository.upsertConsent(1L, testClientId) }
+                        verify(exactly = 0) {
+                            mockOauthConsentJpaRepository.saveAndFlush(any<OauthConsentJpaEntity>())
+                        }
+                    }
+
+                    it("이미 동의한 scope를 다시 넣어도 중복이 쌓이지 않아야 한다") {
+                        completeOauthConsentService.execute(
+                            OauthConsentReqDto(testToken, approved = true),
+                            testSessionId,
+                        )
+
+                        // addScopeIfAbsent가 NOT EXISTS로 거르므로 scope당 한 번만 호출된다.
+                        testScopes.forEach { scope ->
+                            verify(exactly = 1) { mockOauthConsentJpaRepository.addScopeIfAbsent(7L, scope) }
+                        }
+                    }
+
+                    it("행 id를 읽지 못하면 scope를 매달지 않고 실패해야 한다") {
+                        every { mockOauthConsentJpaRepository.findIdByAccountIdAndClientId(1L, testClientId) } returns null
+
+                        shouldThrow<ExpectedException> {
                             completeOauthConsentService.execute(
                                 OauthConsentReqDto(testToken, approved = true),
                                 testSessionId,
                             )
+                        }
 
-                        response.statusCode shouldBe HttpStatus.FOUND
-                        existing.grantedScopes shouldBe testScopes
+                        verify(exactly = 0) { mockOauthConsentJpaRepository.addScopeIfAbsent(any(), any()) }
                     }
                 }
             }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOidcDiscoveryServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryOidcDiscoveryServiceTest.kt
@@ -1,0 +1,92 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.QueryOidcDiscoveryServiceImpl
+import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
+
+class QueryOidcDiscoveryServiceTest :
+    DescribeSpec({
+
+        val mockOauthEnvironment = mockk<OauthEnvironment>()
+        val mockJwtEnvironment = mockk<OauthJwtProvisionEnvironment>()
+
+        val queryOidcDiscoveryService =
+            QueryOidcDiscoveryServiceImpl(mockOauthEnvironment, mockJwtEnvironment)
+
+        afterEach {
+            clearAllMocks()
+        }
+
+        describe("QueryOidcDiscoveryService 클래스의") {
+            describe("execute 메서드는") {
+
+                beforeEach {
+                    every { mockOauthEnvironment.issuerUrl } returns "https://oauth.authorization.datagsm.kr"
+                    every { mockOauthEnvironment.userinfoUrl } returns "https://oauth.userinfo.datagsm.kr/userinfo"
+                    every { mockJwtEnvironment.datagsmApplicationId } returns "datagsm"
+                }
+
+                context("Discovery 문서를 요청했을 때") {
+                    it("issuer 기준으로 엔드포인트가 조립되어야 한다") {
+                        val result = queryOidcDiscoveryService.execute()
+
+                        result.issuer shouldBe "https://oauth.authorization.datagsm.kr"
+                        result.authorizationEndpoint shouldBe "https://oauth.authorization.datagsm.kr/v1/oauth/authorize"
+                        result.tokenEndpoint shouldBe "https://oauth.authorization.datagsm.kr/v1/oauth/token"
+                        result.jwksUri shouldBe "https://oauth.authorization.datagsm.kr/v1/oauth/jwks"
+                        result.endSessionEndpoint shouldBe "https://oauth.authorization.datagsm.kr/v1/oauth/logout"
+                    }
+
+                    it("UserInfo는 별도 호스트 설정값을 그대로 써야 한다") {
+                        val result = queryOidcDiscoveryService.execute()
+
+                        result.userinfoEndpoint shouldBe "https://oauth.userinfo.datagsm.kr/userinfo"
+                    }
+
+                    // 목록을 손으로 적으면 구현이 바뀌어도 문서만 남아 SP가 지원하지 않는 값을 쓰게 된다.
+                    it("지원 grant_type이 실제 구현과 일치해야 한다") {
+                        val result = queryOidcDiscoveryService.execute()
+
+                        result.grantTypesSupported shouldBe
+                            listOf("authorization_code", "refresh_token", "client_credentials")
+                    }
+
+                    it("지원 PKCE 방식이 실제 구현과 일치해야 한다") {
+                        val result = queryOidcDiscoveryService.execute()
+
+                        result.codeChallengeMethodsSupported.toSet() shouldBe setOf("plain", "S256")
+                    }
+
+                    it("scope 목록에 openid와 애플리케이션 scope가 포함되어야 한다") {
+                        val result = queryOidcDiscoveryService.execute()
+
+                        result.scopesSupported.contains("openid") shouldBe true
+                        result.scopesSupported.contains("datagsm:account_read") shouldBe true
+                        result.scopesSupported.contains("datagsm:student_read") shouldBe true
+                    }
+
+                    it("id_token 서명 알고리즘은 실제 서명과 같은 RS256이어야 한다") {
+                        val result = queryOidcDiscoveryService.execute()
+
+                        result.idTokenSigningAlgValuesSupported shouldBe listOf("RS256")
+                    }
+                }
+
+                context("issuer_url 끝에 슬래시가 있을 때") {
+                    it("엔드포인트에 슬래시가 중복되지 않아야 한다") {
+                        every { mockOauthEnvironment.issuerUrl } returns "https://oauth.authorization.datagsm.kr/"
+
+                        val result = queryOidcDiscoveryService.execute()
+
+                        result.issuer shouldBe "https://oauth.authorization.datagsm.kr"
+                        result.tokenEndpoint shouldBe "https://oauth.authorization.datagsm.kr/v1/oauth/token"
+                    }
+                }
+            }
+        }
+    })

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldNotBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.springframework.security.crypto.password.PasswordEncoder
 import team.themoment.datagsm.common.domain.account.entity.AccountJpaEntity
@@ -284,6 +285,97 @@ class Oauth2TokenServiceImplTest :
                             }
                         exception.error shouldBe "invalid_grant"
                         exception.errorDescription shouldBe "PKCE 검증에 실패했습니다."
+                    }
+                }
+
+                context("openid scope로 토큰을 요청할 때") {
+                    val openidReqDto =
+                        Oauth2TokenReqDto(
+                            grantType = "authorization_code",
+                            code = "openid-code",
+                            clientId = "test-client",
+                            clientSecret = "test-secret",
+                            redirectUri = "https://example.com/callback",
+                        )
+
+                    val openidCode =
+                        OauthCodeRedisEntity(
+                            email = "test@gsm.hs.kr",
+                            clientId = "test-client",
+                            redirectUri = "https://example.com/callback",
+                            codeChallenge = null,
+                            codeChallengeMethod = null,
+                            scopes = setOf("openid", "self:read"),
+                            nonce = "n-0S6_WzA2Mj",
+                            code = "openid-code",
+                            ttl = 300,
+                        )
+
+                    val openidClient =
+                        ClientJpaEntity().apply {
+                            id = "test-client"
+                            secret = "hashed-secret"
+                            redirectUrls = setOf("https://example.com/callback")
+                            scopes.add("self:read")
+                        }
+
+                    val openidAccount =
+                        AccountJpaEntity().apply {
+                            id = 42L
+                            email = "test@gsm.hs.kr"
+                            role = AccountRole.USER
+                        }
+
+                    beforeEach {
+                        every { mockOauthCodeRedisRepository.findById("openid-code") } returns Optional.of(openidCode)
+                        every { mockClientJpaRepository.findById("test-client") } returns Optional.of(openidClient)
+                        every { mockPasswordEncoder.matches("test-secret", "hashed-secret") } returns true
+                        every { mockAccountJpaRepository.findByEmail("test@gsm.hs.kr") } returns Optional.of(openidAccount)
+                        every { mockJwtProvider.generateOauthAccessToken(any(), any(), any(), any()) } returns "access-token"
+                        every { mockJwtProvider.generateOauthRefreshToken(any(), any()) } returns "refresh-token"
+                        every { mockJwtProvider.generateIdToken(any(), any(), any(), any()) } returns "id-token"
+                        every { mockJwtEnvironment.accessTokenExpiration } returns 3600000L
+                        every { mockJwtEnvironment.refreshTokenExpiration } returns 2592000000L
+                        every { mockOauthRefreshTokenRedisRepository.deleteByEmailAndClientId(any(), any()) } returns Unit
+                        every { mockOauthRefreshTokenRedisRepository.save(any()) } answers { firstArg() }
+                        every { mockOauthCodeRedisRepository.delete(any()) } returns Unit
+                        every { mockOAuthScopeJpaRepository.findAllByApplicationIdIn(setOf("self")) } returns listOf(mockScopeEntity)
+                    }
+
+                    it("id_token이 함께 발급된다") {
+                        val result = service.execute(openidReqDto)
+
+                        result.idToken shouldBe "id-token"
+                    }
+
+                    // sub는 email이 아닌 account.id여야 한다. email은 변경될 수 있어
+                    // 바뀌는 순간 SP가 같은 사람을 다른 사용자로 인식한다.
+                    it("sub에 account.id가, nonce에 요청값이 전달되어야 한다") {
+                        val accountIdSlot = slot<Long>()
+                        val nonceSlot = slot<String>()
+                        every {
+                            mockJwtProvider.generateIdToken(capture(accountIdSlot), any(), any(), capture(nonceSlot))
+                        } returns "id-token"
+
+                        service.execute(openidReqDto)
+
+                        accountIdSlot.captured shouldBe 42L
+                        nonceSlot.captured shouldBe "n-0S6_WzA2Mj"
+                    }
+
+                    // openid는 tb_oauth_scope에 없는 프로토콜 지시자다.
+                    // DB 조회 대상에 섞이면 "권한 데이터가 잘못되었습니다" 500이 난다.
+                    it("openid를 권한 scope로 조회하지 않아야 한다") {
+                        val result = service.execute(openidReqDto)
+
+                        result.accessToken shouldBe "access-token"
+                        verify(exactly = 0) { mockOAuthScopeJpaRepository.findAllByApplicationIdIn(setOf("openid")) }
+                    }
+
+                    it("응답 scope에 openid가 그대로 포함되어야 한다") {
+                        val result = service.execute(openidReqDto)
+
+                        result.scope.split(" ").contains("openid") shouldBe true
                     }
                 }
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/Oauth2TokenServiceImplTest.kt
@@ -333,7 +333,7 @@ class Oauth2TokenServiceImplTest :
                         every { mockAccountJpaRepository.findByEmail("test@gsm.hs.kr") } returns Optional.of(openidAccount)
                         every { mockJwtProvider.generateOauthAccessToken(any(), any(), any(), any()) } returns "access-token"
                         every { mockJwtProvider.generateOauthRefreshToken(any(), any()) } returns "refresh-token"
-                        every { mockJwtProvider.generateIdToken(any(), any(), any(), any()) } returns "id-token"
+                        every { mockJwtProvider.generateIdToken(any(), any(), any()) } returns "id-token"
                         every { mockJwtEnvironment.accessTokenExpiration } returns 3600000L
                         every { mockJwtEnvironment.refreshTokenExpiration } returns 2592000000L
                         every { mockOauthRefreshTokenRedisRepository.deleteByEmailAndClientId(any(), any()) } returns Unit
@@ -348,18 +348,17 @@ class Oauth2TokenServiceImplTest :
                         result.idToken shouldBe "id-token"
                     }
 
-                    // sub는 email이 아닌 account.id여야 한다. email은 변경될 수 있어
-                    // 바뀌는 순간 SP가 같은 사람을 다른 사용자로 인식한다.
-                    it("sub에 account.id가, nonce에 요청값이 전달되어야 한다") {
-                        val accountIdSlot = slot<Long>()
+                    // sub는 access token, /userinfo와 같은 email을 쓴다.
+                    it("sub에 email이, nonce에 요청값이 전달되어야 한다") {
+                        val emailSlot = slot<String>()
                         val nonceSlot = slot<String>()
                         every {
-                            mockJwtProvider.generateIdToken(capture(accountIdSlot), any(), any(), capture(nonceSlot))
+                            mockJwtProvider.generateIdToken(capture(emailSlot), any(), capture(nonceSlot))
                         } returns "id-token"
 
                         service.execute(openidReqDto)
 
-                        accountIdSlot.captured shouldBe 42L
+                        emailSlot.captured shouldBe "test@gsm.hs.kr"
                         nonceSlot.captured shouldBe "n-0S6_WzA2Mj"
                     }
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/global/security/jwt/JwtProviderIdTokenTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/global/security/jwt/JwtProviderIdTokenTest.kt
@@ -57,7 +57,7 @@ class JwtProviderIdTokenTest :
 
                 context("nonce가 주어졌을 때") {
                     it("replay 방지를 위해 nonce 클레임을 포함해야 한다") {
-                        val token = jwtProvider.generateIdToken(42L, "user@gsm.hs.kr", "client-1", "n-0S6_WzA2Mj")
+                        val token = jwtProvider.generateIdToken("user@gsm.hs.kr", "client-1", "n-0S6_WzA2Mj")
 
                         parse(token)["nonce"] shouldBe "n-0S6_WzA2Mj"
                     }
@@ -65,23 +65,23 @@ class JwtProviderIdTokenTest :
 
                 context("nonce가 없을 때") {
                     it("nonce 클레임을 넣지 않아야 한다") {
-                        val token = jwtProvider.generateIdToken(42L, "user@gsm.hs.kr", "client-1", null)
+                        val token = jwtProvider.generateIdToken("user@gsm.hs.kr", "client-1", null)
 
                         parse(token).containsKey("nonce") shouldBe false
                     }
                 }
 
                 context("표준 클레임을 확인할 때") {
-                    // sub는 email이 아닌 account.id다. email은 변경될 수 있어
-                    // 바뀌는 순간 SP가 같은 사람을 다른 사용자로 인식한다.
-                    it("sub는 account.id여야 한다") {
-                        val token = jwtProvider.generateIdToken(42L, "user@gsm.hs.kr", "client-1", null)
+                    // 이 시스템의 계정 email은 학교 계정에 묶여 변경되지 않으므로
+                    // OIDC가 sub에 요구하는 영구 식별자 조건을 만족한다.
+                    it("sub는 email이어야 한다") {
+                        val token = jwtProvider.generateIdToken("user@gsm.hs.kr", "client-1", null)
 
-                        parse(token).subject shouldBe "42"
+                        parse(token).subject shouldBe "user@gsm.hs.kr"
                     }
 
                     it("iss와 aud가 규격대로 채워져야 한다") {
-                        val token = jwtProvider.generateIdToken(42L, "user@gsm.hs.kr", "client-1", null)
+                        val token = jwtProvider.generateIdToken("user@gsm.hs.kr", "client-1", null)
 
                         val claims = parse(token)
                         claims.issuer shouldBe "https://oauth.authorization.datagsm.kr"
@@ -89,13 +89,13 @@ class JwtProviderIdTokenTest :
                     }
 
                     it("email 클레임이 포함되어야 한다") {
-                        val token = jwtProvider.generateIdToken(42L, "user@gsm.hs.kr", "client-1", null)
+                        val token = jwtProvider.generateIdToken("user@gsm.hs.kr", "client-1", null)
 
                         parse(token)["email"] shouldBe "user@gsm.hs.kr"
                     }
 
                     it("exp와 iat가 설정되어야 한다") {
-                        val token = jwtProvider.generateIdToken(42L, "user@gsm.hs.kr", "client-1", null)
+                        val token = jwtProvider.generateIdToken("user@gsm.hs.kr", "client-1", null)
 
                         val claims = parse(token)
                         (claims.expiration != null) shouldBe true
@@ -104,8 +104,9 @@ class JwtProviderIdTokenTest :
                 }
 
                 context("access token과 비교할 때") {
-                    // access token의 sub는 기존 /userinfo 소비자와의 호환을 위해 email을 유지한다.
-                    it("access token의 sub는 email로 남아 있어야 한다") {
+                    // id_token, access token, /userinfo가 모두 email을 식별자로 쓴다.
+                    // 셋 중 하나만 달라지면 SP가 같은 사용자를 다르게 인식한다.
+                    it("access token의 sub와 같은 값이어야 한다") {
                         val accessToken =
                             jwtProvider.generateOauthAccessToken(
                                 "user@gsm.hs.kr",
@@ -114,7 +115,10 @@ class JwtProviderIdTokenTest :
                                 emptySet(),
                             )
 
+                        val idToken = jwtProvider.generateIdToken("user@gsm.hs.kr", "client-1", null)
+
                         parse(accessToken).subject shouldBe "user@gsm.hs.kr"
+                        parse(idToken).subject shouldBe parse(accessToken).subject
                     }
                 }
             }

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/global/security/jwt/JwtProviderIdTokenTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/global/security/jwt/JwtProviderIdTokenTest.kt
@@ -1,0 +1,122 @@
+package team.themoment.datagsm.oauth.authorization.global.security.jwt
+
+import io.jsonwebtoken.Jwts
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.global.data.OauthJwtProvisionEnvironment
+import java.security.KeyPairGenerator
+import java.util.Base64
+
+/**
+ * id_token은 SP가 서명과 클레임만 보고 사용자를 식별하는 값이라,
+ * 실제로 서명된 토큰을 파싱해 클레임이 들어갔는지까지 확인한다.
+ * JwtProvider를 목으로 두면 nonce 누락 같은 결함이 그대로 통과한다.
+ */
+class JwtProviderIdTokenTest :
+    DescribeSpec({
+
+        val keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+        val encoder = Base64.getMimeEncoder()
+
+        val privateKeyPem =
+            "-----BEGIN PRIVATE KEY-----\n" +
+                encoder.encodeToString(keyPair.private.encoded) +
+                "\n-----END PRIVATE KEY-----"
+        val publicKeyPem =
+            "-----BEGIN PUBLIC KEY-----\n" +
+                encoder.encodeToString(keyPair.public.encoded) +
+                "\n-----END PUBLIC KEY-----"
+
+        val jwtEnvironment =
+            mockk<OauthJwtProvisionEnvironment> {
+                every { privateKey } returns privateKeyPem
+                every { publicKey } returns publicKeyPem
+                every { keyId } returns "test-key-id"
+                every { accessTokenExpiration } returns 3600000L
+            }
+        val oauthEnvironment =
+            mockk<OauthEnvironment> {
+                every { issuerUrl } returns "https://oauth.authorization.datagsm.kr"
+            }
+
+        val jwtProvider = JwtProvider(jwtEnvironment, oauthEnvironment)
+
+        fun parse(token: String) =
+            Jwts
+                .parser()
+                .verifyWith(keyPair.public)
+                .build()
+                .parseSignedClaims(token)
+                .payload
+
+        describe("JwtProvider 클래스의") {
+            describe("generateIdToken 메서드는") {
+
+                context("nonce가 주어졌을 때") {
+                    it("replay 방지를 위해 nonce 클레임을 포함해야 한다") {
+                        val token = jwtProvider.generateIdToken(42L, "user@gsm.hs.kr", "client-1", "n-0S6_WzA2Mj")
+
+                        parse(token)["nonce"] shouldBe "n-0S6_WzA2Mj"
+                    }
+                }
+
+                context("nonce가 없을 때") {
+                    it("nonce 클레임을 넣지 않아야 한다") {
+                        val token = jwtProvider.generateIdToken(42L, "user@gsm.hs.kr", "client-1", null)
+
+                        parse(token).containsKey("nonce") shouldBe false
+                    }
+                }
+
+                context("표준 클레임을 확인할 때") {
+                    // sub는 email이 아닌 account.id다. email은 변경될 수 있어
+                    // 바뀌는 순간 SP가 같은 사람을 다른 사용자로 인식한다.
+                    it("sub는 account.id여야 한다") {
+                        val token = jwtProvider.generateIdToken(42L, "user@gsm.hs.kr", "client-1", null)
+
+                        parse(token).subject shouldBe "42"
+                    }
+
+                    it("iss와 aud가 규격대로 채워져야 한다") {
+                        val token = jwtProvider.generateIdToken(42L, "user@gsm.hs.kr", "client-1", null)
+
+                        val claims = parse(token)
+                        claims.issuer shouldBe "https://oauth.authorization.datagsm.kr"
+                        claims.audience shouldBe setOf("client-1")
+                    }
+
+                    it("email 클레임이 포함되어야 한다") {
+                        val token = jwtProvider.generateIdToken(42L, "user@gsm.hs.kr", "client-1", null)
+
+                        parse(token)["email"] shouldBe "user@gsm.hs.kr"
+                    }
+
+                    it("exp와 iat가 설정되어야 한다") {
+                        val token = jwtProvider.generateIdToken(42L, "user@gsm.hs.kr", "client-1", null)
+
+                        val claims = parse(token)
+                        (claims.expiration != null) shouldBe true
+                        (claims.issuedAt != null) shouldBe true
+                    }
+                }
+
+                context("access token과 비교할 때") {
+                    // access token의 sub는 기존 /userinfo 소비자와의 호환을 위해 email을 유지한다.
+                    it("access token의 sub는 email로 남아 있어야 한다") {
+                        val accessToken =
+                            jwtProvider.generateOauthAccessToken(
+                                "user@gsm.hs.kr",
+                                team.themoment.datagsm.common.domain.account.entity.constant.AccountRole.USER,
+                                "client-1",
+                                emptySet(),
+                            )
+
+                        parse(accessToken).subject shouldBe "user@gsm.hs.kr"
+                    }
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## 개요

SSO 로드맵 **우선순위 3(`id_token` + `openid` scope)과 우선순위 4(OIDC Discovery)** 를 함께 다룹니다. 로드맵이 "묶어서 하나의 OIDC 준수 PR로"를 권장한 항목입니다.

> 스택 PR입니다. base는 #437입니다.

## 본문

### 왜 필요한가

현재 발급하는 JWT는 access token(인가용)뿐이라, SP가 "이 사용자가 누구인지" 알려면 `/userinfo`를 추가 호출해야 합니다. 동작에는 문제없지만 SP가 표준 OIDC 클라이언트 라이브러리(Spring Security `oauth2Login()`, next-auth 등)를 쓰려면 `id_token`이 필요하고, 없으면 각 팀이 수동 연동 코드를 작성해야 합니다.

### 논의했던 `sub` 값 — email로 결정

로드맵에서 팀 논의가 필요하다고 표시된 항목입니다. **`id_token.sub`에는 email을 넣습니다.**

처음에는 OIDC의 "영구적이고 고유한 식별자" 요구를 근거로 `account.id`를 넣었지만, **이 시스템의 계정 email은 학교 계정에 묶여 변경되지 않으므로 그 조건을 이미 만족합니다.** 바뀌지 않는 값을 두고 별도 식별자를 쓸 이유가 없었습니다.

일관성 쪽 근거가 더 큽니다. access token의 `sub`도, `/userinfo`(`datagsm-oauth-userinfo`의 `JwtProvider`가 `claims.subject`를 email로 읽습니다)도 email을 식별자로 씁니다. **id_token만 `account.id`를 쓰면 세 곳의 `sub`가 어긋나** SP 연동에서 "어느 토큰의 sub인지"를 매번 따져야 합니다.

`id_token`과 access token의 `sub`가 실제로 같은 값인지 확인하는 테스트를 넣어 두 값이 갈라지지 않도록 고정했습니다.

### 변경 내용

**1. `openid` scope**

`openid`는 권한이 아니라 "id_token을 함께 달라"는 **프로토콜 지시자**입니다. `applicationId:scopeName` 형식이 아니고 `tb_oauth_scope`에도 없어서, client 등록 scope 검사와 DB 조회 양쪽에서 제외했습니다. 섞인 채로 조회하면 "권한 데이터가 잘못되었습니다" 500이 납니다.

**2. `nonce` 지원**

authorize에서 받아 code에 실어 `id_token` 클레임까지 전달합니다 (OIDC replay 방지 필수 항목).

**3. `GET /.well-known/openid-configuration`**

지원 목록을 손으로 적지 않고 `GrantType`, `PkceChallengeMethod` enum에서 끌어옵니다. 그러지 않으면 구현이 바뀌었는데 문서만 남아 SP가 지원하지 않는 값을 쓰게 됩니다.

`sdk.response.not-wrapping-urls`에 경로를 추가해 `CommonApiResponse` 래핑 없이 raw JSON이 나가도록 했습니다.

### 검증

- 신규 테스트 18건 포함 **171건 통과**, `ktlintCheck build` 통과
- 뮤테이션 테스트:
  - `openid`를 DB scope 조회에서 제외하지 않음 → 4건 실패
  - `id_token` 미발급 → 2건 실패
  - `sub`에 email이 아닌 다른 값 사용 → 2건 실패
  - `nonce` 클레임 누락 → 1건 실패

> `nonce` 누락 뮤테이션이 처음엔 **살아남았습니다.** 토큰 서비스 테스트가 `JwtProvider`를 목으로 두어 "전달했는지"만 보고 "JWT에 실제로 들어갔는지"는 보지 못했기 때문입니다. RSA 키를 생성해 **실제로 서명된 토큰을 파싱해 검증**하는 `JwtProviderIdTokenTest`를 추가했습니다.

### 새 환경변수

```bash
OAUTH_USERINFO_URL=https://oauth.userinfo.datagsm.kr/userinfo
```

Discovery 문서의 `userinfo_endpoint`에 쓰입니다. UserInfo는 별도 모듈(`datagsm-oauth-userinfo`)의 다른 호스트라 `issuer_url`에서 유도할 수 없습니다.
