### PR TITLE
[oauth] 활성 IdP 세션 조회 및 개별 종료

### DIFF
--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/response/IdpSessionListResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/response/IdpSessionListResDto.kt
@@ -1,0 +1,8 @@
+package team.themoment.datagsm.common.domain.oauth.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class IdpSessionListResDto(
+    @field:Schema(description = "활성 세션 목록. 최근 로그인 순으로 정렬됩니다.")
+    val sessions: List<IdpSessionResDto>,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/response/IdpSessionResDto.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/dto/response/IdpSessionResDto.kt
@@ -1,0 +1,14 @@
+package team.themoment.datagsm.common.domain.oauth.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class IdpSessionResDto(
+    @field:Schema(description = "세션 식별자. 개별 종료 요청에 사용합니다.")
+    val sessionId: String,
+    @field:Schema(description = "로그인한 기기의 User-Agent. 기록되지 않은 세션은 null입니다.")
+    val userAgent: String?,
+    @field:Schema(description = "로그인 시각(epoch milliseconds). 기록되지 않은 세션은 null입니다.")
+    val createdAt: Long?,
+    @field:Schema(description = "현재 요청에 사용된 세션인지 여부")
+    val current: Boolean,
+)

--- a/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionRedisEntity.kt
+++ b/datagsm-common/src/main/kotlin/team/themoment/datagsm/common/domain/oauth/entity/IdpSessionRedisEntity.kt
@@ -12,6 +12,10 @@ data class IdpSessionRedisEntity(
     // 비밀번호 변경 시 해당 계정의 모든 세션을 끊어야 하므로 역방향 조회가 필요하다.
     @Indexed
     val email: String,
+    // 사용자가 "어떤 기기에서 로그인 중인지" 구분할 근거.
+    // 기존 세션에는 없는 값이라 null을 허용한다.
+    val userAgent: String? = null,
+    val createdAt: Long? = null,
     @TimeToLive
     val ttl: Long,
 )

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/controller/OauthController.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CookieValue
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
@@ -21,6 +22,7 @@ import team.themoment.datagsm.common.domain.oauth.dto.request.Oauth2TokenReqDto
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeReqDto
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthAuthorizeSubmitReqDto
 import team.themoment.datagsm.common.domain.oauth.dto.request.OauthConsentReqDto
+import team.themoment.datagsm.common.domain.oauth.dto.response.IdpSessionListResDto
 import team.themoment.datagsm.common.domain.oauth.dto.response.JwkSetResDto
 import team.themoment.datagsm.common.domain.oauth.dto.response.Oauth2TokenResDto
 import team.themoment.datagsm.common.domain.oauth.dto.response.OauthSessionResDto
@@ -29,8 +31,10 @@ import team.themoment.datagsm.common.domain.student.dto.response.StudentDataEdit
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteIdpSessionHandoffService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthAuthorizeFlowService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.CompleteOauthConsentService
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.DeleteIdpSessionService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.LogoutIdpSessionService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.Oauth2TokenService
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryIdpSessionService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryJwkSetService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryOauthSessionService
 import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryStudentDataEditRequestService
@@ -46,6 +50,8 @@ class OauthController(
     val completeOauthConsentService: CompleteOauthConsentService,
     val completeIdpSessionHandoffService: CompleteIdpSessionHandoffService,
     val logoutIdpSessionService: LogoutIdpSessionService,
+    val queryIdpSessionService: QueryIdpSessionService,
+    val deleteIdpSessionService: DeleteIdpSessionService,
     val queryOauthSessionService: QueryOauthSessionService,
     val queryJwkSetService: QueryJwkSetService,
     val queryStudentDataEditRequestService: QueryStudentDataEditRequestService,
@@ -83,7 +89,8 @@ class OauthController(
         @RequestParam(required = false) verifier: String?,
         @RequestHeader(name = "Sec-Fetch-Site", required = false) secFetchSite: String?,
         @RequestHeader(name = "Sec-Fetch-Mode", required = false) secFetchMode: String?,
-    ): ResponseEntity<Void> = completeIdpSessionHandoffService.execute(ticket, verifier, secFetchSite, secFetchMode)
+        @RequestHeader(name = "User-Agent", required = false) userAgent: String?,
+    ): ResponseEntity<Void> = completeIdpSessionHandoffService.execute(ticket, verifier, secFetchSite, secFetchMode, userAgent)
 
     @PostMapping("/authorize")
     @Operation(
@@ -149,6 +156,38 @@ class OauthController(
     fun logout(
         @CookieValue(name = "\${spring.security.oauth.idp-session-cookie-name}", required = false) sessionId: String?,
     ): ResponseEntity<Void> = logoutIdpSessionService.execute(sessionId)
+
+    @GetMapping("/idp-sessions")
+    @Operation(
+        summary = "활성 IdP 세션 목록 조회",
+        description = "현재 세션 쿠키가 가리키는 계정의 활성 세션 목록을 반환합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "조회 성공"),
+            ApiResponse(responseCode = "401", description = "IdP 세션이 없거나 유효하지 않음", content = [Content()]),
+        ],
+    )
+    fun queryIdpSessions(
+        @CookieValue(name = "\${spring.security.oauth.idp-session-cookie-name}", required = false) sessionId: String?,
+    ): IdpSessionListResDto = queryIdpSessionService.execute(sessionId)
+
+    @DeleteMapping("/idp-sessions/{targetSessionId}")
+    @Operation(
+        summary = "개별 IdP 세션 종료",
+        description = "지정한 세션을 종료합니다. 본인 계정의 세션만 종료할 수 있습니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "종료 완료"),
+            ApiResponse(responseCode = "401", description = "IdP 세션이 없거나 유효하지 않음", content = [Content()]),
+            ApiResponse(responseCode = "404", description = "세션을 찾을 수 없음", content = [Content()]),
+        ],
+    )
+    fun deleteIdpSession(
+        @PathVariable targetSessionId: String,
+        @CookieValue(name = "\${spring.security.oauth.idp-session-cookie-name}", required = false) sessionId: String?,
+    ): ResponseEntity<Void> = deleteIdpSessionService.execute(targetSessionId, sessionId)
 
     @GetMapping("/sessions/{token}")
     @Operation(

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteIdpSessionHandoffService.kt
@@ -8,5 +8,6 @@ interface CompleteIdpSessionHandoffService {
         verifier: String?,
         secFetchSite: String?,
         secFetchMode: String?,
+        userAgent: String? = null,
     ): ResponseEntity<Void>
 }

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/DeleteIdpSessionService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/DeleteIdpSessionService.kt
@@ -1,0 +1,10 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import org.springframework.http.ResponseEntity
+
+interface DeleteIdpSessionService {
+    fun execute(
+        targetSessionId: String,
+        sessionId: String?,
+    ): ResponseEntity<Void>
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryIdpSessionService.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/QueryIdpSessionService.kt
@@ -1,0 +1,7 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import team.themoment.datagsm.common.domain.oauth.dto.response.IdpSessionListResDto
+
+interface QueryIdpSessionService {
+    fun execute(sessionId: String?): IdpSessionListResDto
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteIdpSessionHandoffServiceImpl.kt
@@ -28,6 +28,9 @@ class CompleteIdpSessionHandoffServiceImpl(
         private const val SEC_FETCH_MODE_NAVIGATE = "navigate"
         private val ALLOWED_SEC_FETCH_SITES = setOf("same-origin", "same-site", "none")
         private const val INVALID_TICKET_MESSAGE = "인증 티켓이 유효하지 않거나 만료되었습니다. 다시 시도해주세요."
+
+        // User-Agent는 클라이언트가 임의로 채우는 값이라 길이를 제한한다.
+        private const val MAX_USER_AGENT_LENGTH = 255
     }
 
     @Transactional(readOnly = true)
@@ -36,6 +39,7 @@ class CompleteIdpSessionHandoffServiceImpl(
         verifier: String?,
         secFetchSite: String?,
         secFetchMode: String?,
+        userAgent: String?,
     ): ResponseEntity<Void> {
         verifyTopLevelNavigation(secFetchSite, secFetchMode)
 
@@ -59,6 +63,8 @@ class CompleteIdpSessionHandoffServiceImpl(
 
         idpSessionHandoffRedisRepository.deleteById(ticket)
 
+        recordUserAgent(handoff.sessionId, userAgent)
+
         return ResponseEntity
             .status(HttpStatus.FOUND)
             .header(
@@ -66,6 +72,19 @@ class CompleteIdpSessionHandoffServiceImpl(
                 IdpSessionCookieFactory.issued(oauthEnvironment, handoff.sessionId).toString(),
             ).location(URI.create(handoff.redirectUrl))
             .build()
+    }
+
+    // 세션을 만든 POST는 BFF의 서버-투-서버 호출이라 User-Agent가 BFF의 것이다.
+    // 이 GET은 브라우저가 직접 보내므로, 사용자가 기기를 구분할 수 있는 값은 여기서만 얻을 수 있다.
+    // 세션이 이미 만료됐다면 되살리지 않고 넘어간다.
+    private fun recordUserAgent(
+        sessionId: String,
+        userAgent: String?,
+    ) {
+        if (userAgent.isNullOrBlank()) return
+
+        val session = idpSessionRedisRepository.findByIdOrNull(sessionId) ?: return
+        idpSessionRedisRepository.save(session.copy(userAgent = userAgent.take(MAX_USER_AGENT_LENGTH)))
     }
 
     // 핸드오프 URL은 로그·Referer·브라우저 히스토리에 남기 때문에, 나중에 그 URL을 입수한

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/CompleteOauthAuthorizeFlowServiceImpl.kt
@@ -144,6 +144,9 @@ class CompleteOauthAuthorizeFlowServiceImpl(
             IdpSessionRedisEntity(
                 sessionId = sessionId,
                 email = email,
+                // userAgent는 여기서 채우지 않는다. 이 요청은 BFF의 서버-투-서버 호출이라
+                // User-Agent가 BFF의 것이다. 브라우저가 직접 오는 핸드오프 시점에 기록한다.
+                createdAt = System.currentTimeMillis(),
                 ttl = oauthEnvironment.idpSessionExpirationSeconds,
             ),
         )

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/DeleteIdpSessionServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/DeleteIdpSessionServiceImpl.kt
@@ -1,0 +1,51 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.common.global.security.util.IdpSessionCookieFactory
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.DeleteIdpSessionService
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class DeleteIdpSessionServiceImpl(
+    private val idpSessionRedisRepository: IdpSessionRedisRepository,
+    private val oauthEnvironment: OauthEnvironment,
+) : DeleteIdpSessionService {
+    override fun execute(
+        targetSessionId: String,
+        sessionId: String?,
+    ): ResponseEntity<Void> {
+        val currentSession =
+            sessionId
+                ?.takeIf { it.isNotBlank() }
+                ?.let { idpSessionRedisRepository.findByIdOrNull(it) }
+                ?: throw ExpectedException("로그인이 필요합니다.", HttpStatus.UNAUTHORIZED)
+
+        val target =
+            idpSessionRedisRepository.findByIdOrNull(targetSessionId)
+                ?: throw ExpectedException("세션을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+
+        // 세션 ID를 알아낸 것만으로 남의 세션을 끊을 수 있으면 안 된다.
+        // 존재하지 않는 세션과 같은 404로 응답해, 다른 계정의 세션이 있는지도 알려주지 않는다.
+        if (target.email != currentSession.email) {
+            throw ExpectedException("세션을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+        }
+
+        idpSessionRedisRepository.deleteById(targetSessionId)
+
+        // 자기 세션을 끊었다면 쿠키도 함께 비워야 브라우저에 죽은 세션이 남지 않는다.
+        val builder = ResponseEntity.status(HttpStatus.NO_CONTENT)
+        if (targetSessionId == currentSession.sessionId) {
+            builder.header(
+                HttpHeaders.SET_COOKIE,
+                IdpSessionCookieFactory.expired(oauthEnvironment).toString(),
+            )
+        }
+        return builder.build()
+    }
+}

--- a/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryIdpSessionServiceImpl.kt
+++ b/datagsm-oauth-authorization/src/main/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/impl/QueryIdpSessionServiceImpl.kt
@@ -1,0 +1,40 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import team.themoment.datagsm.common.domain.oauth.dto.response.IdpSessionListResDto
+import team.themoment.datagsm.common.domain.oauth.dto.response.IdpSessionResDto
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.QueryIdpSessionService
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+class QueryIdpSessionServiceImpl(
+    private val idpSessionRedisRepository: IdpSessionRedisRepository,
+) : QueryIdpSessionService {
+    // 세션 쿠키 자체를 자격 증명으로 쓴다. 조회 대상은 그 쿠키가 가리키는 계정으로
+    // 한정되므로, 다른 계정의 세션을 볼 수 있는 경로가 생기지 않는다.
+    override fun execute(sessionId: String?): IdpSessionListResDto {
+        val currentSession =
+            sessionId
+                ?.takeIf { it.isNotBlank() }
+                ?.let { idpSessionRedisRepository.findByIdOrNull(it) }
+                ?: throw ExpectedException("로그인이 필요합니다.", HttpStatus.UNAUTHORIZED)
+
+        val sessions =
+            idpSessionRedisRepository
+                .findAllByEmail(currentSession.email)
+                .sortedByDescending { it.createdAt ?: 0L }
+                .map {
+                    IdpSessionResDto(
+                        sessionId = it.sessionId,
+                        userAgent = it.userAgent,
+                        createdAt = it.createdAt,
+                        current = it.sessionId == currentSession.sessionId,
+                    )
+                }
+
+        return IdpSessionListResDto(sessions = sessions)
+    }
+}

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/password/service/impl/ModifyPasswordServiceImplTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/account/password/service/impl/ModifyPasswordServiceImplTest.kt
@@ -200,8 +200,8 @@ class ModifyPasswordServiceImplTest :
             every { oauthRefreshTokenRedisRepository.deleteAll(any<Iterable<OauthRefreshTokenRedisEntity>>()) } returns Unit
             every { idpSessionRedisRepository.findAllByEmail(email) } returns
                 listOf(
-                    IdpSessionRedisEntity("session-1", email, 28800),
-                    IdpSessionRedisEntity("session-2", email, 28800),
+                    IdpSessionRedisEntity(sessionId = "session-1", email = email, ttl = 28800),
+                    IdpSessionRedisEntity(sessionId = "session-2", email = email, ttl = 28800),
                 )
             every { idpSessionRedisRepository.deleteAll(any<Iterable<IdpSessionRedisEntity>>()) } returns Unit
 

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthConsentServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/CompleteOauthConsentServiceTest.kt
@@ -102,7 +102,7 @@ class CompleteOauthConsentServiceTest :
                     every { mockOauthAuthorizeStateRedisRepository.findById(testToken) } returns
                         Optional.of(stateEntity())
                     every { mockIdpSessionRedisRepository.findById(testSessionId) } returns
-                        Optional.of(IdpSessionRedisEntity(testSessionId, testEmail, 28800))
+                        Optional.of(IdpSessionRedisEntity(sessionId = testSessionId, email = testEmail, ttl = 28800))
                     every { mockAccountJpaRepository.findByEmail(testEmail) } returns Optional.of(activeAccount())
                     every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returns
                         Optional.empty()

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/IdpSessionManagementServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/IdpSessionManagementServiceTest.kt
@@ -1,0 +1,197 @@
+package team.themoment.datagsm.oauth.authorization.domain.oauth.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import team.themoment.datagsm.common.domain.oauth.entity.IdpSessionRedisEntity
+import team.themoment.datagsm.common.domain.oauth.repository.IdpSessionRedisRepository
+import team.themoment.datagsm.common.global.data.OauthEnvironment
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.DeleteIdpSessionServiceImpl
+import team.themoment.datagsm.oauth.authorization.domain.oauth.service.impl.QueryIdpSessionServiceImpl
+import team.themoment.sdk.exception.ExpectedException
+import java.util.Optional
+
+class IdpSessionManagementServiceTest :
+    DescribeSpec({
+
+        val mockIdpSessionRedisRepository = mockk<IdpSessionRedisRepository>(relaxed = true)
+        val mockOauthEnvironment = mockk<OauthEnvironment>()
+
+        val queryIdpSessionService = QueryIdpSessionServiceImpl(mockIdpSessionRedisRepository)
+        val deleteIdpSessionService =
+            DeleteIdpSessionServiceImpl(mockIdpSessionRedisRepository, mockOauthEnvironment)
+
+        afterEach {
+            clearAllMocks()
+        }
+
+        val myEmail = "user@gsm.hs.kr"
+        val otherEmail = "other@gsm.hs.kr"
+        val currentSessionId = "session-current"
+        val otherDeviceSessionId = "session-other-device"
+        val foreignSessionId = "session-foreign"
+
+        fun session(
+            id: String,
+            email: String,
+            userAgent: String? = null,
+            createdAt: Long? = null,
+        ) = IdpSessionRedisEntity(
+            sessionId = id,
+            email = email,
+            userAgent = userAgent,
+            createdAt = createdAt,
+            ttl = 28800,
+        )
+
+        describe("QueryIdpSessionService 클래스의") {
+            describe("execute 메서드는") {
+
+                beforeEach {
+                    every { mockIdpSessionRedisRepository.findById(currentSessionId) } returns
+                        Optional.of(session(currentSessionId, myEmail, "Chrome/120", 2000L))
+                    every { mockIdpSessionRedisRepository.findAllByEmail(myEmail) } returns
+                        listOf(
+                            session(currentSessionId, myEmail, "Chrome/120", 2000L),
+                            session(otherDeviceSessionId, myEmail, "Safari/17", 3000L),
+                        )
+                }
+
+                context("유효한 세션 쿠키가 주어졌을 때") {
+                    it("해당 계정의 세션 목록을 반환해야 한다") {
+                        val result = queryIdpSessionService.execute(currentSessionId)
+
+                        result.sessions.map { it.sessionId }.toSet() shouldBe
+                            setOf(currentSessionId, otherDeviceSessionId)
+                    }
+
+                    it("최근 로그인 순으로 정렬되어야 한다") {
+                        val result = queryIdpSessionService.execute(currentSessionId)
+
+                        result.sessions.map { it.sessionId } shouldBe
+                            listOf(otherDeviceSessionId, currentSessionId)
+                    }
+
+                    it("현재 사용 중인 세션을 표시해야 한다") {
+                        val result = queryIdpSessionService.execute(currentSessionId)
+
+                        result.sessions.single { it.current }.sessionId shouldBe currentSessionId
+                    }
+
+                    it("기기를 구분할 수 있도록 User-Agent를 함께 내려줘야 한다") {
+                        val result = queryIdpSessionService.execute(currentSessionId)
+
+                        result.sessions.single { it.sessionId == otherDeviceSessionId }.userAgent shouldBe "Safari/17"
+                    }
+                }
+
+                context("세션 쿠키가 없을 때") {
+                    it("401이 반환되어야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> { queryIdpSessionService.execute(null) }
+
+                        exception.statusCode shouldBe HttpStatus.UNAUTHORIZED
+                    }
+                }
+
+                context("세션이 만료되었을 때") {
+                    it("401이 반환되어야 한다") {
+                        every { mockIdpSessionRedisRepository.findById(currentSessionId) } returns Optional.empty()
+
+                        shouldThrow<ExpectedException> { queryIdpSessionService.execute(currentSessionId) }
+                    }
+                }
+            }
+        }
+
+        describe("DeleteIdpSessionService 클래스의") {
+            describe("execute 메서드는") {
+
+                beforeEach {
+                    every { mockOauthEnvironment.idpSessionCookieName } returns "datagsm_idp_session"
+                    every { mockOauthEnvironment.idpSessionCookieSecure } returns true
+                    every { mockIdpSessionRedisRepository.findById(currentSessionId) } returns
+                        Optional.of(session(currentSessionId, myEmail))
+                    every { mockIdpSessionRedisRepository.findById(otherDeviceSessionId) } returns
+                        Optional.of(session(otherDeviceSessionId, myEmail))
+                    every { mockIdpSessionRedisRepository.findById(foreignSessionId) } returns
+                        Optional.of(session(foreignSessionId, otherEmail))
+                }
+
+                context("본인의 다른 기기 세션을 종료할 때") {
+                    it("해당 세션이 삭제되어야 한다") {
+                        val response =
+                            deleteIdpSessionService.execute(otherDeviceSessionId, currentSessionId)
+
+                        response.statusCode shouldBe HttpStatus.NO_CONTENT
+                        verify(exactly = 1) { mockIdpSessionRedisRepository.deleteById(otherDeviceSessionId) }
+                    }
+
+                    it("현재 쿠키는 건드리지 않아야 한다") {
+                        val response =
+                            deleteIdpSessionService.execute(otherDeviceSessionId, currentSessionId)
+
+                        response.headers.getFirst(HttpHeaders.SET_COOKIE) shouldBe null
+                    }
+                }
+
+                context("현재 사용 중인 세션을 종료할 때") {
+                    it("죽은 세션이 남지 않도록 쿠키도 만료시켜야 한다") {
+                        val response =
+                            deleteIdpSessionService.execute(currentSessionId, currentSessionId)
+
+                        (response.headers.getFirst(HttpHeaders.SET_COOKIE) ?: "") shouldContain "Max-Age=0"
+                    }
+                }
+
+                // 세션 ID를 알아낸 것만으로 남의 세션을 끊을 수 있으면 안 된다.
+                context("다른 계정의 세션을 종료하려 할 때") {
+                    it("삭제하지 않고 404가 반환되어야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                deleteIdpSessionService.execute(foreignSessionId, currentSessionId)
+                            }
+
+                        exception.statusCode shouldBe HttpStatus.NOT_FOUND
+                        verify(exactly = 0) { mockIdpSessionRedisRepository.deleteById(foreignSessionId) }
+                    }
+
+                    // 존재하지 않는 세션과 응답이 달라지면 세션 존재 여부를 탐지할 수 있게 된다.
+                    it("존재하지 않는 세션과 같은 상태 코드여야 한다") {
+                        every { mockIdpSessionRedisRepository.findById("unknown") } returns Optional.empty()
+
+                        val foreign =
+                            shouldThrow<ExpectedException> {
+                                deleteIdpSessionService.execute(foreignSessionId, currentSessionId)
+                            }
+                        val unknown =
+                            shouldThrow<ExpectedException> {
+                                deleteIdpSessionService.execute("unknown", currentSessionId)
+                            }
+
+                        foreign.statusCode shouldBe unknown.statusCode
+                        foreign.message shouldBe unknown.message
+                    }
+                }
+
+                context("세션 쿠키가 없을 때") {
+                    it("401이 반환되고 삭제가 일어나지 않아야 한다") {
+                        val exception =
+                            shouldThrow<ExpectedException> {
+                                deleteIdpSessionService.execute(otherDeviceSessionId, null)
+                            }
+
+                        exception.statusCode shouldBe HttpStatus.UNAUTHORIZED
+                        verify(exactly = 0) { mockIdpSessionRedisRepository.deleteById(any()) }
+                    }
+                }
+            }
+        }
+    })

--- a/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
+++ b/datagsm-oauth-authorization/src/test/kotlin/team/themoment/datagsm/oauth/authorization/domain/oauth/service/StartOauthAuthorizeFlowServiceTest.kt
@@ -438,7 +438,7 @@ class StartOauthAuthorizeFlowServiceTest :
                         } answers { firstArg() }
                         every { mockClientJpaRepository.findById(testClientId) } returns Optional.of(mockClient)
                         every { mockIdpSessionRedisRepository.findById(testSessionId) } returns
-                            Optional.of(IdpSessionRedisEntity(testSessionId, testEmail, 28800))
+                            Optional.of(IdpSessionRedisEntity(sessionId = testSessionId, email = testEmail, ttl = 28800))
                         every { mockAccountJpaRepository.findByEmail(testEmail) } returns Optional.of(activeAccount())
                         every { mockOauthConsentJpaRepository.findByAccountIdAndClientId(1L, testClientId) } returns
                             Optional.of(OauthConsentJpaEntity.create(1L, testClientId, setOf("datagsm:account_read")))


### PR DESCRIPTION
## 개요

SSO 로드맵 **우선순위 5 — 세션 관리 기능** 중 조회와 개별 종료를 구현합니다. (전체 세션 종료는 #437에서 비밀번호 변경 시 자동 실행으로 이미 처리했습니다.)

> 스택 PR입니다. base는 #438입니다.

## 본문

### 변경 내용

**`GET /v1/oauth/idp-sessions`** — 현재 쿠키가 가리키는 계정의 활성 세션 목록
**`DELETE /v1/oauth/idp-sessions/{targetSessionId}`** — 개별 세션 종료

### 인증 모델

이 엔드포인트들은 **세션 쿠키 자체를 자격 증명으로** 씁니다. bearer token이 아니라 브라우저가 쿠키와 함께 직접 호출하는 흐름이기 때문입니다. 조회·삭제 대상을 그 쿠키의 계정으로 한정하므로, 다른 계정의 세션에 접근할 경로가 생기지 않습니다.

**다른 계정의 세션을 종료하려는 요청은 존재하지 않는 세션과 동일한 404**로 응답합니다. 403과 404를 구분하면 세션 ID를 넣어보는 것만으로 "그 세션이 실재하는지"를 알아낼 수 있기 때문입니다. 이 동작은 테스트로 못박았습니다.

### 기기 구분 정보

목록이 쓸모 있으려면 "어느 기기인지"가 보여야 해서 `userAgent`와 `createdAt`을 세션에 기록합니다.

`userAgent`는 **핸드오프(GET) 시점에** 채웁니다. 세션을 만드는 `POST /v1/oauth/authorize`는 BFF의 서버-투-서버 호출이라 그 시점의 `User-Agent`는 **BFF의 것**입니다. 브라우저가 직접 오는 핸드오프에서만 사용자의 실제 값을 얻을 수 있습니다.

기존에 발급된 세션에는 두 값이 없으므로 nullable로 두었습니다.

### 검증

- 신규 테스트 12건 포함 **183건 통과**, `ktlintCheck build` 통과
- 뮤테이션 테스트:
  - 소유권 검사 제거(남의 세션 종료 가능) → 2건 실패
  - 자기 세션 종료 시 쿠키 미만료 → 1건 실패
  - 조회 시 계정 한정 해제 → 4건 실패

### 프론트엔드 필요 작업

- 세션 관리 화면 — 목록 표시 + 개별 종료 버튼
- `current: true`인 항목은 "현재 기기"로 표시하고, 종료 시 로그아웃됨을 안내하면 좋습니다.

### 남은 과제 (로드맵)

- 로그아웃 전파(back-channel logout) — SP가 여러 개로 늘어난 뒤 판단
- 세션 절대 만료 / 동시 세션 수 제한
- IdP 세션 생성·사용·만료 메트릭 (SSO 적중률 측정)
- `OauthUserPrincipal` / `OauthAuthenticationToken` 중복을 `datagsm-common`으로 승격 검토